### PR TITLE
Updates to generalized version

### DIFF
--- a/newscripts/age_normalized.tsv
+++ b/newscripts/age_normalized.tsv
@@ -1,7152 +1,7152 @@
-h_age	h_organism_id	h_organism_name	index	normalized_h_age
-6-8 weeks old	10000067	Mus musculus C57BL/6	0	6-8 weeks old
-NULL	9606	Homo sapiens (human)	1	null
-6-8 weeks old	10000000	Mus musculus BALB/c	2	6-8 weeks old
-8 weeks	10000047	Mus musculus C57BL/10	3	8 weeks
-49 years old	10000119	Homo sapiens Caucasian	4	49 years old
-51 years old	10000119	Homo sapiens Caucasian	5	51 years old
-NULL	10000067	Mus musculus C57BL/6	6	null
-NULL	9598	Pan troglodytes (chimpanzee)	7	null
-8-16 weeks	10000000	Mus musculus BALB/c	8	8-16 weeks
-6-8 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	9	6-8 weeks old
-6-10 weeks old	10000000	Mus musculus BALB/c	10	6-10 weeks old
-4-16 years old	9606	Homo sapiens (human)	11	4-16 years old
-32-62 years	9606	Homo sapiens (human)	12	32-62 years
-32-38 years	9606	Homo sapiens (human)	13	32-38 years
-2-54 years	9606	Homo sapiens (human)	14	2-54 years
-3-8 years	9606	Homo sapiens (human)	15	3-8 years
-6-10 wk	10000047	Mus musculus C57BL/10	16	6-10 week
-24 years	9606	Homo sapiens (human)	17	24 years
-6-12 weeks-old	10000219	Mus musculus C57BL/6 X CBA	18	6-12 weeks-old
-29-38	9606	Homo sapiens (human)	19	29-38
-NULL	10090	Mus musculus (mouse)	20	null
-12-65 years old	9606	Homo sapiens (human)	21	12-65 years old
-6-8 weeks	10000067	Mus musculus C57BL/6	22	6-8 weeks
-6-12 weeks	10000067	Mus musculus C57BL/6	23	6-12 weeks
-8-10 weeks	10000000	Mus musculus BALB/c	24	8-10 weeks
-8-10 weeks	10000067	Mus musculus C57BL/6	25	8-10 weeks
-45 years	9606	Homo sapiens (human)	26	45 years
-10-15 weeks	10000276	Mus musculus B10.S	27	10-15 weeks
-6-10 weeks	10001019	Mus musculus B10.D2	28	6-10 weeks
-6-10 weeks	10000647	Mus musculus Quackenbush	29	6-10 weeks
-NULL	10000607	Mus musculus HLA-DR3 Tg	30	null
-8 weeks	10000000	Mus musculus BALB/c	31	8 weeks
-6-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	32	6-8 weeks
-6-8 weeks	10000271	Mus musculus B10.M	33	6-8 weeks
-Adults (pregnant)	9606	Homo sapiens (human)	34	adults (pregnant)
-6-8 weeks	10000253	Mus musculus A/J	35	6-8 weeks
-Adults	9606	Homo sapiens (human)	36	adults
-26-72 years-old	9606	Homo sapiens (human)	37	26-72 years-old
-4-6 weeks old	10000000	Mus musculus BALB/c	38	4-6 weeks old
-20-55 years	9606	Homo sapiens (human)	39	20-55 years
-55-69 years	9606	Homo sapiens (human)	40	55-69 years
-2-4 months old	10000000	Mus musculus BALB/c	41	2-4 months old
-2-4 months old	10000067	Mus musculus C57BL/6	42	2-4 months old
-NULL	10000601	Mus musculus HLA-DR1 Tg	43	null
-NULL	10000598	Mus musculus HLA-DQ8 Tg	44	null
-33-52 years-old	9606	Homo sapiens (human)	45	33-52 years-old
-26-45 years	9606	Homo sapiens (human)	46	26-45 years
-7-74 years old	9606	Homo sapiens (human)	47	7-74 years old
-6-8 weeks	10000038	Mus musculus C3H/He	48	6-8 weeks
-21-45 years old	9606	Homo sapiens (human)	49	21-45 years old
-8-24 weeks old	10000067	Mus musculus C57BL/6	50	8-24 weeks old
-NULL	10000047	Mus musculus C57BL/10	51	null
-NULL	10000094	Mus musculus C57BL/6 IAbeta null	52	null
-NULL	10000188	Sus scrofa NIH miniature pig	53	null
-average age 29.8 years	9606	Homo sapiens (human)	54	average age 29.8 years
-18-91 years	9606	Homo sapiens (human)	55	18-91 years
-NULL	10000645	Mus musculus PrP null	56	null
-6-10 weeks	10000263	Mus musculus B10.BR	57	6-10 weeks
-6-10 weeks	10000000	Mus musculus BALB/c	58	6-10 weeks
-29-58 years	9606	Homo sapiens (human)	59	29-58 years
-NULL	10000000	Mus musculus BALB/c	60	null
-NULL	10000649	Mus musculus SJL	61	null
-26-38 years	9606	Homo sapiens (human)	62	26-38 years
-30-52 years-old	9606	Homo sapiens (human)	63	30-52 years-old
-32- 53.5 years	9606	Homo sapiens (human)	64	32- 53.5 years
-NULL	9534	Chlorocebus aethiops (African green monkey)	65	null
-NULL	10000575	Mus musculus HBV(adr) transgenic BALB/c	66	null
-32-74 years old	9606	Homo sapiens (human)	67	32-74 years old
-6-10 weeks-old	10000038	Mus musculus C3H/He	68	6-10 weeks-old
-NULL	10000582	Mus musculus HLA-A2 Tg	69	null
-NULL	10000670	Cavia porcellus Ssc:AL	70	null
-8-week-old	10000067	Mus musculus C57BL/6	71	8-week-old
-6 weeks	10000038	Mus musculus C3H/He	72	6 weeks
-44 years	9606	Homo sapiens (human)	73	44 years
-8-12 weeks	10000263	Mus musculus B10.BR	74	8-12 weeks
-31-39	9606	Homo sapiens (human)	75	31-39
-7-8 weeks	10000649	Mus musculus SJL	76	7-8 weeks
-Adults (40 year-old average)	9606	Homo sapiens (human)	77	adults (40 year-old average)
-6 weeks	10000000	Mus musculus BALB/c	78	6 weeks
-NULL	10000276	Mus musculus B10.S	79	null
-6-10 wk	10000271	Mus musculus B10.M	80	6-10 week
-Children and Adults	9606	Homo sapiens (human)	81	children and adults
-6-8 weeks old	10000030	Mus musculus C3H.JK	82	6-8 weeks old
-NULL	10000119	Homo sapiens Caucasian	83	null
-6-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	84	6-8 weeks
-6-8 weeks	10000228	Mus musculus CBA	85	6-8 weeks
-NULL	10001537	Mus musculus PL	86	null
-6-10 weeks-old	10000000	Mus musculus BALB/c	87	6-10 weeks-old
-NULL	10000275	Mus musculus B10.RIII	88	null
-NULL	10000640	Mus musculus NZW	89	null
-Adults and children	9606	Homo sapiens (human)	90	adults and children
-20 years old	9606	Homo sapiens (human)	91	20 years old
-29-41 years	9606	Homo sapiens (human)	92	29-41 years
-1-48 months-old	9606	Homo sapiens (human)	93	1-48 months-old
-8-12 weeks-old	10000067	Mus musculus C57BL/6	94	8-12 weeks-old
-6-8 weeks	10000000	Mus musculus BALB/c	95	6-8 weeks
-Adult	9606	Homo sapiens (human)	96	adult
-NULL	9913	Bos taurus (bovine)	97	null
-15 weeks	10000600	Mus musculus HLA-DR Transgenic	98	15 weeks
-4-6 weeks	10000000	Mus musculus BALB/c	99	4-6 weeks
-6-10 weeks	10000067	Mus musculus C57BL/6	100	6-10 weeks
-6 to 8 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	101	6 to 8 weeks
-59 years	9606	Homo sapiens (human)	102	59 years
-8-12 weeks	10000236	Mus musculus CBA/J	103	8-12 weeks
-8-12 weeks	10000649	Mus musculus SJL	104	8-12 weeks
-8-12 weeks	10000000	Mus musculus BALB/c	105	8-12 weeks
-25-58 years old	9606	Homo sapiens (human)	106	25-58 years old
-NULL	10000233	Mus musculus CBA/Ca	107	null
-6 weeks-old	10000233	Mus musculus CBA/Ca	108	6 weeks-old
-6-8 weeks old	10000047	Mus musculus C57BL/10	109	6-8 weeks old
-14-65 years old	9606	Homo sapiens (human)	110	14-65 years old
-7-8 weeks	10000000	Mus musculus BALB/c	111	7-8 weeks
-31-58 years	9606	Homo sapiens (human)	112	31-58 years
-6-10 wk	10000273	Mus musculus B10.P	113	6-10 week
-6-9 weeks	10000067	Mus musculus C57BL/6	114	6-9 weeks
-36-70 years-old	9606	Homo sapiens (human)	115	36-70 years-old
-18-45 years	9606	Homo sapiens (human)	116	18-45 years
-6-10 weeks-old	10000063	Mus musculus B10.A	117	6-10 weeks-old
-8-11 wk	10000000	Mus musculus BALB/c	118	8-11 week
-24-75 years old	9606	Homo sapiens (human)	119	24-75 years old
-6-10 wk	10000066	Mus musculus C57BL/1Flu NP(328-498) Tg	120	6-10 week
-6-8 weeks old	10000263	Mus musculus B10.BR	121	6-8 weeks old
-2-8 months	10000067	Mus musculus C57BL/6	122	2-8 months
-6 to 8 weeks	10000067	Mus musculus C57BL/6	123	6 to 8 weeks
-5 weeks	10000000	Mus musculus BALB/c	124	5 weeks
-Adult	10000196	Ovis aries Finnish Landrace	125	adult
-9-86 years	9606	Homo sapiens (human)	126	9-86 years
-19-74 years-old	9606	Homo sapiens (human)	127	19-74 years-old
-18-30 years old	9606	Homo sapiens (human)	128	18-30 years old
-NULL	10000190	Bos taurus Friesian	129	null
-5-6 weeks	10000067	Mus musculus C57BL/6	130	5-6 weeks
-12-16 weeks	10000021	Mus musculus BALB/c-H2dm2	131	12-16 weeks
-12-16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	132	12-16 weeks
-5-7 weeks	10000000	Mus musculus BALB/c	133	5-7 weeks
-73	9606	Homo sapiens (human)	134	73
-6-8 wk	10000067	Mus musculus C57BL/6	135	6-8 week
-NULL	10000642	Mus musculus Outbred	136	null
-7-10 weeks-old	10000576	Mus musculus HLA-A*02:01 Tg	137	7-10 weeks-old
-1-9 years-old	9606	Homo sapiens (human)	138	1-9 years-old
-18-75 years	9606	Homo sapiens (human)	139	18-75 years
-4-16 weeks	10000061	Mus musculus FVB	140	4-16 weeks
-11 or 18 weeks	10000025	Mus musculus Biozzi AB/H	141	11 or 18 weeks
-15-73 years-old	9606	Homo sapiens (human)	142	15-73 years-old
-8-16 wk	10000007	Mus musculus 6.5 TCR Tg	143	8-16 week
-6-8 weeks	10000660	Rattus norvegicus Fischer	144	6-8 weeks
-NULL	10000668	Cavia porcellus Duncan-Hartley	145	null
-NULL	10001980	Mus musculus Ob.1A12 TCR Tg	146	null
-7-79	9606	Homo sapiens (human)	147	7-79
-20-29 years	9606	Homo sapiens (human)	148	20-29 years
-Adult	10000119	Homo sapiens Caucasian	149	adult
-NULL	10000228	Mus musculus CBA	150	null
-6-8 weeks	10000653	Mus musculus Swiss	151	6-8 weeks
-5, 11 or 18 weeks	10000632	Mus musculus NOD	152	5, 11 or 18 weeks
-35 to 40 days	10000607	Mus musculus HLA-DR3 Tg	153	35 to 40 days
-8-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	154	8-12 weeks
-6-10 weeks-old	10000067	Mus musculus C57BL/6	155	6-10 weeks-old
-4-24 months	10000188	Sus scrofa NIH miniature pig	156	4-24 months
-NULL	10000271	Mus musculus B10.M	157	null
-NULL	10000263	Mus musculus B10.BR	158	null
-8-12 weeks	10090	Mus musculus (mouse)	159	8-12 weeks
-6-8 weeks	10000263	Mus musculus B10.BR	160	6-8 weeks
-6-8 weeks	10000051	Mus musculus C57BL/10 X DBA/2	161	6-8 weeks
-18 years	9606	Homo sapiens (human)	162	18 years
-61 years	9606	Homo sapiens (human)	163	61 years
-NULL	9504	Aotus (night monkey)	164	null
-18 to 65 years	9606	Homo sapiens (human)	165	18 to 65 years
-8-12 weeks	10000067	Mus musculus C57BL/6	166	8-12 weeks
-18-59 years	9606	Homo sapiens (human)	167	18-59 years
-6-10 weeks	10000610	Mus musculus HLA-DR4 Tg	168	6-10 weeks
-8-14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	169	8-14 weeks
-4-6 weeks-old	10000000	Mus musculus BALB/c	170	4-6 weeks-old
-> 18 years	9606	Homo sapiens (human)	171	> 18 years
-30-60 years	9606	Homo sapiens (human)	172	30-60 years
-6-12 weeks	10000028	Mus musculus C3H	173	6-12 weeks
-6 months	10001405	Mus musculus NZB X NZW	174	6 months
-6-8 wk old	10000576	Mus musculus HLA-A*02:01 Tg	175	6-8 week old
-8-10 weeks	10000253	Mus musculus A/J	176	8-10 weeks
-mean 54 years (range 19-68)	9606	Homo sapiens (human)	177	mean 54 years (range 19-68)
-6-8 weeks	10090	Mus musculus (mouse)	178	6-8 weeks
-37 years old	9606	Homo sapiens (human)	179	37 years old
-6-8 weeks	10000032	Mus musculus C3H.Q	180	6-8 weeks
-NULL	10000289	Mus musculus BALB.B	181	null
-NULL	10000193	Bos taurus Holstein	182	null
-5-14 years	9606	Homo sapiens (human)	183	5-14 years
-Children	9606	Homo sapiens (human)	184	children
-6-8 weeks old	10000038	Mus musculus C3H/He	185	6-8 weeks old
-NULL	10000220	Mus musculus C57BL/6 X DBA/2	186	null
-NULL	10000625	Mus musculus MRL	187	null
-6-8 weeks old	10000032	Mus musculus C3H.Q	188	6-8 weeks old
-NULL	10141	Cavia porcellus (guinea pig)	189	null
-10 months	9913	Bos taurus (bovine)	190	10 months
-4-16 weeks	10000067	Mus musculus C57BL/6	191	4-16 weeks
-6-8 weeks-old	10000047	Mus musculus C57BL/10	192	6-8 weeks-old
-4 weeks	9823	Sus scrofa (pig)	193	4 weeks
-8-12 weeks	10000253	Mus musculus A/J	194	8-12 weeks
-NULL	10000216	Mus musculus C57BL/6 X BALB/c	195	null
-NULL	10000576	Mus musculus HLA-A*02:01 Tg	196	null
-8-12 weeks-old	10000106	Mus musculus HY-A1 TCR beta chain Tg	197	8-12 weeks-old
-5-6 weeks	10090	Mus musculus (mouse)	198	5-6 weeks
-6-8 weeks	10000649	Mus musculus SJL	199	6-8 weeks
-42-64 years	9606	Homo sapiens (human)	200	42-64 years
-46-53 years	9606	Homo sapiens (human)	201	46-53 years
-6-12 weeks	10000000	Mus musculus BALB/c	202	6-12 weeks
-average age 29.8	9606	Homo sapiens (human)	203	average age 29.8
-6-8 weeks old	10000601	Mus musculus HLA-DR1 Tg	204	6-8 weeks old
-6-8 weeks	10000027	Mus musculus C.AL-Igho/SmnJ	205	6-8 weeks
-1.5 - 10 years	9606	Homo sapiens (human)	206	1.5 - 10 years
-8-12 weeks old	10000000	Mus musculus BALB/c	207	8-12 weeks old
-11 or 18 weeks	10000637	Mus musculus NODasp	208	11 or 18 weeks
-21-34 years	9606	Homo sapiens (human)	209	21-34 years
-8 weeks	10000038	Mus musculus C3H/He	210	8 weeks
-33 years	10000119	Homo sapiens Caucasian	211	33 years
-NULL	78449	Macaca cyclopis (Taiwan macaque)	212	null
-8-10 weeks old	10000000	Mus musculus BALB/c	213	8-10 weeks old
-8-10 weeks old	10000233	Mus musculus CBA/Ca	214	8-10 weeks old
-4-6 weeks	10000067	Mus musculus C57BL/6	215	4-6 weeks
-NULL	10002230	Mus musculus 1807 TCR Tg	216	null
-8-12 weeks	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	217	8-12 weeks
-NULL	10000038	Mus musculus C3H/He	218	null
-6-12 weeks	10090	Mus musculus (mouse)	219	6-12 weeks
-10-12 weeks	10000067	Mus musculus C57BL/6	220	10-12 weeks
-2-18 mo	10000067	Mus musculus C57BL/6	221	2-18 month
-NULL	10000206	Oryctolagus cuniculus New Zealand White	222	null
-8-11 weeks	10000000	Mus musculus BALB/c	223	8-11 weeks
-37-61 years old	9606	Homo sapiens (human)	224	37-61 years old
-Mean: 29 years	9606	Homo sapiens (human)	225	mean: 29 years
-4-6 weeks	10000948	Mus musculus C3H/Ou	226	4-6 weeks
-NULL	10000287	Mus musculus P14 TCR Tg	227	null
-4-6 wk	10000582	Mus musculus HLA-A2 Tg	228	4-6 week
-8 weeks	10000636	Mus musculus NOD/Lt Ealphak Tg	229	8 weeks
-8-10 weeks-old	10000000	Mus musculus BALB/c	230	8-10 weeks-old
-6-10 weeks-old	10000047	Mus musculus C57BL/10	231	6-10 weeks-old
-8 weeks	10000289	Mus musculus BALB.B	232	8 weeks
-6 weeks old	10000000	Mus musculus BALB/c	233	6 weeks old
-28-55 years	9606	Homo sapiens (human)	234	28-55 years
-22-52 years	9606	Homo sapiens (human)	235	22-52 years
-NULL	10000194	Bos taurus Holstein-Friesian	236	null
-6-12 months	10000185	Canis familiaris beagle	237	6-12 months
-32	9606	Homo sapiens (human)	238	32
-32-42	9606	Homo sapiens (human)	239	32-42
-NULL	10000255	Mus musculus AKR	240	null
-6-8 weeks	10000620	Mus musculus IL-10 null	241	6-8 weeks
-4-5 weeks	10000067	Mus musculus C57BL/6	242	4-5 weeks
-5 weeks	10090	Mus musculus (mouse)	243	5 weeks
-2 months	10000216	Mus musculus C57BL/6 X BALB/c	244	2 months
-8-12 wks	10000067	Mus musculus C57BL/6	245	8-12 weeks
-3 months-old	10000233	Mus musculus CBA/Ca	246	3 months-old
-8 weeks	10000276	Mus musculus B10.S	247	8 weeks
-29-38 years	9606	Homo sapiens (human)	248	29-38 years
-8-10 weeks	10090	Mus musculus (mouse)	249	8-10 weeks
-8-10 weeks	10000632	Mus musculus NOD	250	8-10 weeks
-NULL	9995	Marmota monax (groundhog)	251	null
-7-10 weeks-old	10000067	Mus musculus C57BL/6	252	7-10 weeks-old
-6-8 weeks	10000047	Mus musculus C57BL/10	253	6-8 weeks
-NULL	10000055	Mus musculus DBA/2	254	null
-8-yr-old	9598	Pan troglodytes (chimpanzee)	255	8-year-old
-8-weeks-old	10000000	Mus musculus BALB/c	256	8-weeks-old
-38-59 years	9606	Homo sapiens (human)	257	38-59 years
-6-12 weeks	10000229	Mus musculus HLA-B*27:05 Tg	258	6-12 weeks
-28-42 years	9606	Homo sapiens (human)	259	28-42 years
-NULL	10000661	Rattus norvegicus Fischer 344	260	null
-6 months	10000190	Bos taurus Friesian	261	6 months
-8-12 weeks old	10000067	Mus musculus C57BL/6	262	8-12 weeks old
-8-12 wk	10000000	Mus musculus BALB/c	263	8-12 week
-23-55 years old	9606	Homo sapiens (human)	264	23-55 years old
-28-63 years	9606	Homo sapiens (human)	265	28-63 years
-NULL	10000070	Mus musculus C57BL/6 bg	266	null
-NULL	10000092	Mus musculus gBT-I TCR Tg	267	null
-2 months	10000236	Mus musculus CBA/J	268	2 months
-6-8 weeks old	10000276	Mus musculus B10.S	269	6-8 weeks old
-6-8 weeks	10000662	Rattus norvegicus Lewis	270	6-8 weeks
-8-14 weeks old	10000598	Mus musculus HLA-DQ8 Tg	271	8-14 weeks old
-8-12 weeks old	10000185	Canis familiaris beagle	272	8-12 weeks old
-NULL	10000610	Mus musculus HLA-DR4 Tg	273	null
-37-57	9606	Homo sapiens (human)	274	37-57
-NULL	10000277	Mus musculus B10.S(7R)	275	null
-NULL	10000051	Mus musculus C57BL/10 X DBA/2	276	null
-3-4 weeks	10116	Rattus norvegicus (brown rat)	277	3-4 weeks
-10-50 years	9606	Homo sapiens (human)	278	10-50 years
-52-68	9606	Homo sapiens (human)	279	52-68
-5-8 weeks	10000254	Mus musculus A/Sn	280	5-8 weeks
-6-12 weeks	10000038	Mus musculus C3H/He	281	6-12 weeks
-5-30 years-old	9606	Homo sapiens (human)	282	5-30 years-old
-8-14 wk	10000067	Mus musculus C57BL/6	283	8-14 week
-21-66 years old	9606	Homo sapiens (human)	284	21-66 years old
-12  weeks	10000000	Mus musculus BALB/c	285	12  weeks
-21-50 years old	10000119	Homo sapiens Caucasian	286	21-50 years old
-8 weeks	10000632	Mus musculus NOD	287	8 weeks
-NULL	10000059	Mus musculus Flu HAmemb Tg	288	null
-5-8 weeks	10000067	Mus musculus C57BL/6	289	5-8 weeks
-8 weeks	10000635	Mus musculus NOD/Lt	290	8 weeks
-NULL	9796	Equus caballus (domestic horse)	291	null
-10.5 years avg.	9606	Homo sapiens (human)	292	10.5 years avg.
-NULL	10000597	Mus musculus HLA-DQ6 Tg	293	null
-6-8 wks	10001782	Mus musculus HLA-B*07:02 Tg	294	6-8 weeks
-4-8 weeks	10090	Mus musculus (mouse)	295	4-8 weeks
-2 months	10000000	Mus musculus BALB/c	296	2 months
-2 months	10000067	Mus musculus C57BL/6	297	2 months
-18–64 years)	9606	Homo sapiens (human)	298	1864 years)
-6-8 wk	10000000	Mus musculus BALB/c	299	6-8 week
-6-8 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	300	6-8 weeks old
-1-2 months-old	9606	Homo sapiens (human)	301	1-2 months-old
-6-16 wk	10000095	Mus musculus C57BL/6 IFNgamma null	302	6-16 week
-NULL	10000581	Mus musculus HLA-A11 Tg	303	null
-3.5-17 months	9796	Equus caballus (domestic horse)	304	3.5-17 months
-6-7 weeks	10000000	Mus musculus BALB/c	305	6-7 weeks
-1-1.5 years	9913	Bos taurus (bovine)	306	1-1.5 years
-At least 8 weeks old	10000000	Mus musculus BALB/c	307	at least 8 weeks old
-8-24 weeks old	10000063	Mus musculus B10.A	308	8-24 weeks old
-7-9 weeks	10000649	Mus musculus SJL	309	7-9 weeks
-7-9 weeks	10000000	Mus musculus BALB/c	310	7-9 weeks
-12 weeks	10000067	Mus musculus C57BL/6	311	12 weeks
-4-5 wk	10000067	Mus musculus C57BL/6	312	4-5 week
-8 weeks or older	10000067	Mus musculus C57BL/6	313	8 weeks or older
-17-81 years old	9606	Homo sapiens (human)	314	17-81 years old
-10-12 weeks	10000000	Mus musculus BALB/c	315	10-12 weeks
-8-10 wk	10000000	Mus musculus BALB/c	316	8-10 week
-3 months-old	10000000	Mus musculus BALB/c	317	3 months-old
-5-6 months	10000193	Bos taurus Holstein	318	5-6 months
-6-10 wk	10000067	Mus musculus C57BL/6	319	6-10 week
-2 months or older	10000000	Mus musculus BALB/c	320	2 months or older
-28-65 years	9606	Homo sapiens (human)	321	28-65 years
-6 to 8-week old	10090	Mus musculus (mouse)	322	6 to 8-week old
-8 weeks old	10000000	Mus musculus BALB/c	323	8 weeks old
-5-6 weeks	10000000	Mus musculus BALB/c	324	5-6 weeks
-8-10 weeks old	10000067	Mus musculus C57BL/6	325	8-10 weeks old
-21 - 85 yo	9606	Homo sapiens (human)	326	21 - 85 year
-6-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	327	6-12 weeks
-17-57	9606	Homo sapiens (human)	328	17-57
-22-55 years	9606	Homo sapiens (human)	329	22-55 years
-35.4 yrs average	9606	Homo sapiens (human)	330	35.4 years average
-5-8 weeks	10000000	Mus musculus BALB/c	331	5-8 weeks
->6 wk	10000233	Mus musculus CBA/Ca	332	>6 week
-18-72	9606	Homo sapiens (human)	333	18-72
-6 months-1.1 year	9606	Homo sapiens (human)	334	6 months-1.1 year
-NULL	9685	Felis catus (cat)	335	null
-6 weeks	10000067	Mus musculus C57BL/6	336	6 weeks
-4 months- 4 years	9606	Homo sapiens (human)	337	4 months- 4 years
-10-16 weeks old	10000607	Mus musculus HLA-DR3 Tg	338	10-16 weeks old
-36-51 years old	9606	Homo sapiens (human)	339	36-51 years old
-15-50 years old	10000119	Homo sapiens Caucasian	340	15-50 years old
-16-48 years old	9606	Homo sapiens (human)	341	16-48 years old
-6-8 weeks	10000582	Mus musculus HLA-A2 Tg	342	6-8 weeks
-21-55 years old	9606	Homo sapiens (human)	343	21-55 years old
-8 to 10 weeks	10000607	Mus musculus HLA-DR3 Tg	344	8 to 10 weeks
-5, 8, 11 or 18 weeks	10000632	Mus musculus NOD	345	5, 8, 11 or 18 weeks
-4-6 wk	10090	Mus musculus (mouse)	346	4-6 week
-30-65 years	9606	Homo sapiens (human)	347	30-65 years
-NULL	10000065	Mus musculus C57BL/10SnJ	348	null
-3-5 weeks	10000000	Mus musculus BALB/c	349	3-5 weeks
-15 weeks	10000610	Mus musculus HLA-DR4 Tg	350	15 weeks
-NULL	43147	Aotus lemurinus (lemurine night monkey)	351	null
-6-8 wks	10000067	Mus musculus C57BL/6	352	6-8 weeks
-newborn	10000047	Mus musculus C57BL/10	353	newborn
-6 weeks-old	10090	Mus musculus (mouse)	354	6 weeks-old
-25-50 years-old	9606	Homo sapiens (human)	355	25-50 years-old
-6-8 week	10000000	Mus musculus BALB/c	356	6-8 week
-17-86 years old	10000119	Homo sapiens Caucasian	357	17-86 years old
-12 weeks	10000000	Mus musculus BALB/c	358	12 weeks
-48 years old	10000119	Homo sapiens Caucasian	359	48 years old
-18-60 years old	9606	Homo sapiens (human)	360	18-60 years old
-8 to 10 weeks	10000067	Mus musculus C57BL/6	361	8 to 10 weeks
-35	9606	Homo sapiens (human)	362	35
-46 years	9606	Homo sapiens (human)	363	46 years
-28 years	9606	Homo sapiens (human)	364	28 years
-6 to 10 weeks	10000047	Mus musculus C57BL/10	365	6 to 10 weeks
-18-61	9606	Homo sapiens (human)	366	18-61
-7-12 weeks	10000253	Mus musculus A/J	367	7-12 weeks
-6 to 10 weeks	10000263	Mus musculus B10.BR	368	6 to 10 weeks
-4-10 weeks	10000038	Mus musculus C3H/He	369	4-10 weeks
-4-10 weeks	10000000	Mus musculus BALB/c	370	4-10 weeks
-18-54 years	9606	Homo sapiens (human)	371	18-54 years
-13-133 months	9606	Homo sapiens (human)	372	13-133 months
-6-8 weeks old	10000649	Mus musculus SJL	373	6-8 weeks old
-8 weeks-old	10000067	Mus musculus C57BL/6	374	8 weeks-old
-8-12 weeks old	10000028	Mus musculus C3H	375	8-12 weeks old
-75 years	9606	Homo sapiens (human)	376	75 years
-32-51 years	9606	Homo sapiens (human)	377	32-51 years
-4 week	10000000	Mus musculus BALB/c	378	4 week
-7-10 weeks	10090	Mus musculus (mouse)	379	7-10 weeks
-mean age 30 years	9606	Homo sapiens (human)	380	mean age 30 years
-27 to 78 years	9606	Homo sapiens (human)	381	27 to 78 years
-8-12 weeks	10000290	Mus musculus BALB.K	382	8-12 weeks
-6-12 weeks old	10000067	Mus musculus C57BL/6	383	6-12 weeks old
-6-12 weeks	10000597	Mus musculus HLA-DQ6 Tg	384	6-12 weeks
-NULL	10000073	Mus musculus 1AD2 TCR Tg	385	null
-4-8 weeks-old	10000000	Mus musculus BALB/c	386	4-8 weeks-old
-6 to 10 weeks	10000256	Mus musculus B10 X B10.BR	387	6 to 10 weeks
-8-12 wk	10000067	Mus musculus C57BL/6	388	8-12 week
-NULL	9544	Macaca mulatta (rhesus macaque)	389	null
-18-50 years	9606	Homo sapiens (human)	390	18-50 years
-22-61 years-old	9606	Homo sapiens (human)	391	22-61 years-old
-17-88	9606	Homo sapiens (human)	392	17-88
-21-44 years	9606	Homo sapiens (human)	393	21-44 years
-NULL	408722	Grammomys gazellae	394	null
-18-30 years	9606	Homo sapiens (human)	395	18-30 years
-NULL	10000041	Mus musculus C3H/SnJ	396	null
-12 to 55 year-old	9606	Homo sapiens (human)	397	12 to 55 year-old
-6-12 weeks-old	10090	Mus musculus (mouse)	398	6-12 weeks-old
-10-79 years	9606	Homo sapiens (human)	399	10-79 years
-NULL	10000615	Mus musculus HLA-DRB1*01:01 Tg	400	null
-4-5 weeks	10000000	Mus musculus BALB/c	401	4-5 weeks
-16-87 years	9606	Homo sapiens (human)	402	16-87 years
-20–67 years	9606	Homo sapiens (human)	403	2067 years
-6-8 weeks old	10000582	Mus musculus HLA-A2 Tg	404	6-8 weeks old
-8 weeks-old	10000253	Mus musculus A/J	405	8 weeks-old
-3-4 months	10000263	Mus musculus B10.BR	406	3-4 months
-6-12 weeks	10000628	Mus musculus B5 TCR Tg	407	6-12 weeks
-6-8 weeks-old	10090	Mus musculus (mouse)	408	6-8 weeks-old
-6-8 weeks	10000054	Mus musculus DBA/1	409	6-8 weeks
-2-68 years old	9606	Homo sapiens (human)	410	2-68 years old
-7-10 weeks	10000067	Mus musculus C57BL/6	411	7-10 weeks
-10 years and older	9606	Homo sapiens (human)	412	10 years and older
-NULL	10000221	Mus musculus C57BL/6-Cd28tm1Mak	413	null
-30	9606	Homo sapiens (human)	414	30
-16-45 years	9606	Homo sapiens (human)	415	16-45 years
-8 to 12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	416	8 to 12 weeks
-19-59 years	9606	Homo sapiens (human)	417	19-59 years
-5-6 weeks old	10000649	Mus musculus SJL	418	5-6 weeks old
-38-64 years	9606	Homo sapiens (human)	419	38-64 years
-6-8 weeks	10000276	Mus musculus B10.S	420	6-8 weeks
-mean age 46.5 years	9606	Homo sapiens (human)	421	mean age 46.5 years
-6-8 weeks-old	10000000	Mus musculus BALB/c	422	6-8 weeks-old
-23-69 years-old	9606	Homo sapiens (human)	423	23-69 years-old
-6-8 weeks	10000218	Mus musculus C57BL/6 X C3H	424	6-8 weeks
-NULL	10000017	Mus musculus BALB/c X DBA/2	425	null
-1 month-old-81 years-old	9606	Homo sapiens (human)	426	1 month-old-81 years-old
-6-12 weeks	10000598	Mus musculus HLA-DQ8 Tg	427	6-12 weeks
-6-8 weeks	10000028	Mus musculus C3H	428	6-8 weeks
-NULL	10000259	Mus musculus B10.A(3R)	429	null
-8-14 wk	10000576	Mus musculus HLA-A*02:01 Tg	430	8-14 week
-NULL	10000015	Mus musculus BALB/c X C3H	431	null
-4-10 weeks-old	10090	Mus musculus (mouse)	432	4-10 weeks-old
-42-70 years-old	9606	Homo sapiens (human)	433	42-70 years-old
-6-10 wk	10000051	Mus musculus C57BL/10 X DBA/2	434	6-10 week
-12-16 weeks	10000067	Mus musculus C57BL/6	435	12-16 weeks
-8-10wk	10000000	Mus musculus BALB/c	436	8-10wk
-12 weeks	10001407	Mus musculus SNF1	437	12 weeks
-8–12 weeks	10000000	Mus musculus BALB/c	438	812 weeks
-8-65 years	9606	Homo sapiens (human)	439	8-65 years
-8-16 weeks	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	440	8-16 weeks
-6-12 wk	10000067	Mus musculus C57BL/6	441	6-12 week
-NULL	10000063	Mus musculus B10.A	442	null
-8-15 weeks	10000067	Mus musculus C57BL/6	443	8-15 weeks
-NULL	10000264	Mus musculus B10.BR DM null	444	null
-6-8 weeks-old	10000582	Mus musculus HLA-A2 Tg	445	6-8 weeks-old
-6-16 wk	10000067	Mus musculus C57BL/6	446	6-16 week
-NULL	10000003	Mus musculus BALB/c DM null	447	null
-52 years-old	9606	Homo sapiens (human)	448	52 years-old
-8-16 weeks	10000067	Mus musculus C57BL/6	449	8-16 weeks
-16 years	9606	Homo sapiens (human)	450	16 years
-8-16 weeks	10000107	Mus musculus C57BL/6 X A/WySnJ	451	8-16 weeks
-8-12 weeks	10000043	Mus musculus C3HeB/FeJ	452	8-12 weeks
-4-6 weeks	10000649	Mus musculus SJL	453	4-6 weeks
-2-4 months old	10090	Mus musculus (mouse)	454	2-4 months old
-8-10 wks	10000067	Mus musculus C57BL/6	455	8-10 weeks
-8-10 wks	10000000	Mus musculus BALB/c	456	8-10 weeks
-10 weeks	10116	Rattus norvegicus (brown rat)	457	10 weeks
-5-65 years	9606	Homo sapiens (human)	458	5-65 years
-25-61 years	9606	Homo sapiens (human)	459	25-61 years
-1 year	10000956	Bos taurus Charolais	460	1 year
-12-57 years	9606	Homo sapiens (human)	461	12-57 years
-31-60 years	9606	Homo sapiens (human)	462	31-60 years
-9 months	10000189	Bos taurus Brahman-Angus	463	9 months
-3-10 years old	9615	Canis lupus familiaris (dogs)	464	3-10 years old
-NULL	8839	Anas platyrhynchos (duck)	465	null
-7 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	466	7 to 8 weeks
-Newborn	9606	Homo sapiens (human)	467	newborn
-2-80 years	9606	Homo sapiens (human)	468	2-80 years
-2 years	10000191	Bos taurus Hereford	469	2 years
-43-46	9606	Homo sapiens (human)	470	43-46
-8-10 wk	10000067	Mus musculus C57BL/6	471	8-10 week
-4-5 weeks	10000096	Mus musculus C57BL/6 IL-10 null	472	4-5 weeks
-1-4 months	10000067	Mus musculus C57BL/6	473	1-4 months
-8-12 wk	10000236	Mus musculus CBA/J	474	8-12 week
-NULL	10000253	Mus musculus A/J	475	null
-18-55 years	9606	Homo sapiens (human)	476	18-55 years
-25-53 years	9606	Homo sapiens (human)	477	25-53 years
-2-3 months	10000228	Mus musculus CBA	478	2-3 months
-NULL	10000662	Rattus norvegicus Lewis	479	null
-5-8 weeks	10090	Mus musculus (mouse)	480	5-8 weeks
-7-10 weeks	10000038	Mus musculus C3H/He	481	7-10 weeks
-8-12 weeks	10000245	Mus musculus (C57BL/6 X BALB/c) Tg(HBV 1.3 genome)chi32	482	8-12 weeks
-12-16 weeks old	10000067	Mus musculus C57BL/6	483	12-16 weeks old
-19-38 years old	9606	Homo sapiens (human)	484	19-38 years old
-5-6 weeks	10000662	Rattus norvegicus Lewis	485	5-6 weeks
-40-62 years	9606	Homo sapiens (human)	486	40-62 years
-2-12 months	10000067	Mus musculus C57BL/6	487	2-12 months
-11-32 years	9606	Homo sapiens (human)	488	11-32 years
-27-60	10000119	Homo sapiens Caucasian	489	27-60
-8-14 weeks	10000038	Mus musculus C3H/He	490	8-14 weeks
-8-24 weeks old	10000228	Mus musculus CBA	491	8-24 weeks old
-NULL	10000057	Mus musculus F5 TCR Tg	492	null
-35-50 years	9606	Homo sapiens (human)	493	35-50 years
-22-62 years	9606	Homo sapiens (human)	494	22-62 years
-8-10 weeks-old	10000047	Mus musculus C57BL/10	495	8-10 weeks-old
-8 to 12 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	496	8 to 12 weeks
-26-66 years	9606	Homo sapiens (human)	497	26-66 years
-NULL	10000274	Mus musculus B10.PL	498	null
-53-64 years	9606	Homo sapiens (human)	499	53-64 years
-6-12 weeks	10000276	Mus musculus B10.S	500	6-12 weeks
-6-8 wks	10000000	Mus musculus BALB/c	501	6-8 weeks
-6-8 weeks old	10000028	Mus musculus C3H	502	6-8 weeks old
-22-88 years	9606	Homo sapiens (human)	503	22-88 years
-37-41 years	9606	Homo sapiens (human)	504	37-41 years
-Children (mean age 7.2 years)	9606	Homo sapiens (human)	505	children (mean age 7.2 years)
-30-86	9606	Homo sapiens (human)	506	30-86
-30 years	9606	Homo sapiens (human)	507	30 years
-8-12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	508	8-12 weeks
-40-65 years	9606	Homo sapiens (human)	509	40-65 years
-NULL	10000660	Rattus norvegicus Fischer	510	null
-NULL	10000594	Mus musculus HLA-B27 Tg	511	null
-14 years-old	9606	Homo sapiens (human)	512	14 years-old
-18 to 50 years	9606	Homo sapiens (human)	513	18 to 50 years
-3-4 months	10000193	Bos taurus Holstein	514	3-4 months
-3-4 months	9913	Bos taurus (bovine)	515	3-4 months
-6-10 weeks-old	10090	Mus musculus (mouse)	516	6-10 weeks-old
-5 to 19 weeks	10000000	Mus musculus BALB/c	517	5 to 19 weeks
-38 years-old	9606	Homo sapiens (human)	518	38 years-old
-4-16 weeks	10000000	Mus musculus BALB/c	519	4-16 weeks
-8-12 weeks	10000038	Mus musculus C3H/He	520	8-12 weeks
-NULL	10000260	Mus musculus B10.A(4R)	521	null
-17 years	9606	Homo sapiens (human)	522	17 years
-18-76 years	9606	Homo sapiens (human)	523	18-76 years
-5- to 8- weeks -old	10000000	Mus musculus BALB/c	524	5- to 8- weeks -old
-average age 35.1	9606	Homo sapiens (human)	525	average age 35.1
-NULL	10000632	Mus musculus NOD	526	null
-29-51 years	9606	Homo sapiens (human)	527	29-51 years
-18-56 years	9606	Homo sapiens (human)	528	18-56 years
-20-67 years	9606	Homo sapiens (human)	529	20-67 years
-23-42 years	9606	Homo sapiens (human)	530	23-42 years
-NULL	10000227	Mus musculus OT-1 TCR Tg	531	null
-Mean age = 30.7 years	9606	Homo sapiens (human)	532	mean age = 30.7 years
-38-56 years	9606	Homo sapiens (human)	533	38-56 years
-NULL	10000246	Mus musculus (C57BL/6 X DBA/2) Tg(HBV 1.3 genome)chi32	534	null
-20-37 years	9606	Homo sapiens (human)	535	20-37 years
-35-55 years	9606	Homo sapiens (human)	536	35-55 years
-NULL	10000210	Mus musculus (BALB/c X C57BL/10) Db null Kb null	537	null
-7-10 weeks-old	10000000	Mus musculus BALB/c	538	7-10 weeks-old
-6-9 months-old	10000194	Bos taurus Holstein-Friesian	539	6-9 months-old
-NULL	10000021	Mus musculus BALB/c-H2dm2	540	null
-12-16 weeks	10000000	Mus musculus BALB/c	541	12-16 weeks
-5 months-3 years	9606	Homo sapiens (human)	542	5 months-3 years
-15-74 years	9606	Homo sapiens (human)	543	15-74 years
-22-65 years	9606	Homo sapiens (human)	544	22-65 years
-8-10 weeks old	10001539	Mus musculus TCR transgenic	545	8-10 weeks old
-34-44 years	9606	Homo sapiens (human)	546	34-44 years
-6-8 weeks	10000975	Mus musculus FVB Db Tg	547	6-8 weeks
-NULL	10000258	Mus musculus B10.A(2R)	548	null
-young adult	9598	Pan troglodytes (chimpanzee)	549	young adult
-6-10 week old	10000582	Mus musculus HLA-A2 Tg	550	6-10 week old
-12 weeks	10000610	Mus musculus HLA-DR4 Tg	551	12 weeks
-8-12 weeks	10000276	Mus musculus B10.S	552	8-12 weeks
-6-9 months	10000190	Bos taurus Friesian	553	6-9 months
-6-10 week old	10000595	Mus musculus HLA-B7 Tg	554	6-10 week old
-NULL	10001381	Mus musculus HLA-DRB1*15:01 Tg	555	null
-NULL	10001539	Mus musculus TCR transgenic	556	null
-8-12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	557	8-12 weeks
-NULL	10000236	Mus musculus CBA/J	558	null
-28-60 yrs	9606	Homo sapiens (human)	559	28-60 years
-6-10 weeks	10000219	Mus musculus C57BL/6 X CBA	560	6-10 weeks
-14-48 years	9606	Homo sapiens (human)	561	14-48 years
-5-7 weeks	10000067	Mus musculus C57BL/6	562	5-7 weeks
-34-45 years	9606	Homo sapiens (human)	563	34-45 years
-4-6 weeks	10000038	Mus musculus C3H/He	564	4-6 weeks
-NULL	9490	Saguinus oedipus (cotton-top tamarin)	565	null
-6-10 weeks-old	10000016	Mus musculus BALB/c X C57BL/10	566	6-10 weeks-old
-2-4 months	10000067	Mus musculus C57BL/6	567	2-4 months
-12 months-old	10000192	Bos taurus Hereford-Angus	568	12 months-old
-40 years-old	9606	Homo sapiens (human)	569	40 years-old
-10-28 weeks	10000038	Mus musculus C3H/He	570	10-28 weeks
-8-10 wks.	10000000	Mus musculus BALB/c	571	8-10 weeks.
-8-10 wks.	10000067	Mus musculus C57BL/6	572	8-10 weeks.
-7-9 weeks	10000067	Mus musculus C57BL/6	573	7-9 weeks
-5-6 weeks	10000263	Mus musculus B10.BR	574	5-6 weeks
-50	9606	Homo sapiens (human)	575	50
-2-35 years	9606	Homo sapiens (human)	576	2-35 years
-7-37 years	9606	Homo sapiens (human)	577	7-37 years
-5-8 weeks	10000662	Rattus norvegicus Lewis	578	5-8 weeks
-41 years	9606	Homo sapiens (human)	579	41 years
-52 years	9606	Homo sapiens (human)	580	52 years
-4-6 weeks	10090	Mus musculus (mouse)	581	4-6 weeks
-28-79 years	9606	Homo sapiens (human)	582	28-79 years
-8-10 weeks	10000228	Mus musculus CBA	583	8-10 weeks
-41-55	9606	Homo sapiens (human)	584	41-55
-8-20 weeks-old	10000256	Mus musculus B10 X B10.BR	585	8-20 weeks-old
-NULL	10000011	Mus musculus ABLE Tg TCR	586	null
-25-50 years	9606	Homo sapiens (human)	587	25-50 years
-8-14 weeks	10000000	Mus musculus BALB/c	588	8-14 weeks
-8-14 weeks	10000067	Mus musculus C57BL/6	589	8-14 weeks
-6-10 wk	10000263	Mus musculus B10.BR	590	6-10 week
-8-10 weeks-old	10000275	Mus musculus B10.RIII	591	8-10 weeks-old
-6-10 weeks	10000054	Mus musculus DBA/1	592	6-10 weeks
-4-5 weeks old	10000000	Mus musculus BALB/c	593	4-5 weeks old
-29 years	9606	Homo sapiens (human)	594	29 years
-7-8 weeks-old	10000028	Mus musculus C3H	595	7-8 weeks-old
-4-8 weeks	10000028	Mus musculus C3H	596	4-8 weeks
-20-65	9606	Homo sapiens (human)	597	20-65
-29-55 years	9606	Homo sapiens (human)	598	29-55 years
-6-8 weeks old	10090	Mus musculus (mouse)	599	6-8 weeks old
-Not available	10000067	Mus musculus C57BL/6	600	not available
-6-10 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	601	6-10 weeks
-NULL	10000269	Mus musculus B10.G	602	null
-16-84 years	9606	Homo sapiens (human)	603	16-84 years
-50-64 years	9606	Homo sapiens (human)	604	50-64 years
-28 years-old	9606	Homo sapiens (human)	605	28 years-old
-29-37 years	9606	Homo sapiens (human)	606	29-37 years
-18-48 years	9606	Homo sapiens (human)	607	18-48 years
-4-8 weeks old	10090	Mus musculus (mouse)	608	4-8 weeks old
-27 years	9606	Homo sapiens (human)	609	27 years
-6 months to 2 years	9606	Homo sapiens (human)	610	6 months to 2 years
-4 weeks	10000236	Mus musculus CBA/J	611	4 weeks
-8 weeks	10000257	Mus musculus B10 X B10.S	612	8 weeks
-5-8 weeks-old	10000067	Mus musculus C57BL/6	613	5-8 weeks-old
-NULL	10001377	Mus musculus HLA-DQB1*06:01 Tg	614	null
-NULL	10000054	Mus musculus DBA/1	615	null
-32 years old	9606	Homo sapiens (human)	616	32 years old
-18-33 months	9544	Macaca mulatta (rhesus macaque)	617	18-33 months
-6-10 weeks old	10000582	Mus musculus HLA-A2 Tg	618	6-10 weeks old
-8-years-old	9598	Pan troglodytes (chimpanzee)	619	8-years-old
-14 years	9606	Homo sapiens (human)	620	14 years
-10 to 17 days-old	10000627	Mus musculus MRL/MpJ	621	10 to 17 days-old
-NULL	10000212	Mus musculus (C57BL/6 X 129/SV) p53 null	622	null
-8-10 weeks	10000649	Mus musculus SJL	623	8-10 weeks
-8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	624	8 weeks
-6-10 weeks	10000047	Mus musculus C57BL/10	625	6-10 weeks
-6-16 wk	10000000	Mus musculus BALB/c	626	6-16 week
-1 month	10000193	Bos taurus Holstein	627	1 month
-23-52 years	9606	Homo sapiens (human)	628	23-52 years
-Sucking	10000067	Mus musculus C57BL/6	629	sucking
-average 48 years	9606	Homo sapiens (human)	630	average 48 years
-4-6 weeks old	10000067	Mus musculus C57BL/6	631	4-6 weeks old
-6 years	9521	Saimiri sciureus (South American squirrel monkey)	632	6 years
-27-67 years	9606	Homo sapiens (human)	633	27-67 years
-8-10 weeks	10000582	Mus musculus HLA-A2 Tg	634	8-10 weeks
-6-8 weeks old	10000630	Mus musculus NHI Swiss	635	6-8 weeks old
-NULL	10000653	Mus musculus Swiss	636	null
-8 to 10 weeks	10000605	Mus musculus HLA-DR2 Tg	637	8 to 10 weeks
-12-15 months	9606	Homo sapiens (human)	638	12-15 months
-10 days	10000289	Mus musculus BALB.B	639	10 days
-32 years	9606	Homo sapiens (human)	640	32 years
-6 to 10 wk	10000000	Mus musculus BALB/c	641	6 to 10 week
-NULL	10000265	Mus musculus AND TCR Tg	642	null
-NULL	10000230	Mus musculus CBA X AKR	643	null
-8-12 weeks-old	10000042	Mus musculus C3HeB X DBA/2	644	8-12 weeks-old
-8-12 weeks-old	10000043	Mus musculus C3HeB/FeJ	645	8-12 weeks-old
-6 to 8 weeks	10000632	Mus musculus NOD	646	6 to 8 weeks
-4 weeks	10000000	Mus musculus BALB/c	647	4 weeks
-NULL	10000019	Mus musculus BALB/cByJ	648	null
-4-6 months	10000000	Mus musculus BALB/c	649	4-6 months
-3-4 months-old	10000233	Mus musculus CBA/Ca	650	3-4 months-old
-6 weeks or older	10000233	Mus musculus CBA/Ca	651	6 weeks or older
-NULL	10000656	Mus musculus VM X DBA/2	652	null
-1 year	9913	Bos taurus (bovine)	653	1 year
-10 weeks	10000954	Gallus gallus Prague CB	654	10 weeks
-20-50 years	9606	Homo sapiens (human)	655	20-50 years
-NULL	10000060	Mus musculus Flu HAtrunc Tg	656	null
-36 years	9606	Homo sapiens (human)	657	36 years
-NULL	10000028	Mus musculus C3H	658	null
-12-18 years	9606	Homo sapiens (human)	659	12-18 years
-6-10 weeks	10000276	Mus musculus B10.S	660	6-10 weeks
-6-18 weeks	10000038	Mus musculus C3H/He	661	6-18 weeks
-NULL	10000189	Bos taurus Brahman-Angus	662	null
-21-39 years	9606	Homo sapiens (human)	663	21-39 years
-8 to 10 weeks	10000610	Mus musculus HLA-DR4 Tg	664	8 to 10 weeks
-6-10 wk	10002138	Mus musculus B10	665	6-10 week
-8-10 wk	10000216	Mus musculus C57BL/6 X BALB/c	666	8-10 week
-8 to 12 weeks	10000000	Mus musculus BALB/c	667	8 to 12 weeks
-NULL	10000955	Bos taurus Jersey	668	null
-4 weeks	10000067	Mus musculus C57BL/6	669	4 weeks
-6-12 weeks old	10000000	Mus musculus BALB/c	670	6-12 weeks old
-28-58 years old	9606	Homo sapiens (human)	671	28-58 years old
-4-8 weeks	10000067	Mus musculus C57BL/6	672	4-8 weeks
-NULL	10000626	Mus musculus MRL X B10.BR	673	null
-40-73 years old	9606	Homo sapiens (human)	674	40-73 years old
-5-6 weeks	10000649	Mus musculus SJL	675	5-6 weeks
-47 years	9606	Homo sapiens (human)	676	47 years
-6-10 weeks	10000038	Mus musculus C3H/He	677	6-10 weeks
-6-10 weeks	10000649	Mus musculus SJL	678	6-10 weeks
-6 weeks or older	10000000	Mus musculus BALB/c	679	6 weeks or older
-62-74 years	9606	Homo sapiens (human)	680	62-74 years
-4-12 weeks-old	10000000	Mus musculus BALB/c	681	4-12 weeks-old
-8-12 weeks old	10000260	Mus musculus B10.A(4R)	682	8-12 weeks old
-6 weeks	10000228	Mus musculus CBA	683	6 weeks
-NULL	37293	Aotus nancymaae (Ma's night monkey)	684	null
-6-7 wk	10000236	Mus musculus CBA/J	685	6-7 week
-37 yrs average	9606	Homo sapiens (human)	686	37 years average
-4-5 weeks	10000286	Mus musculus B6.PL Thy1a/Cy	687	4-5 weeks
-6-8 wk.	10000028	Mus musculus C3H	688	6-8 week.
-3-6 weeks	10000000	Mus musculus BALB/c	689	3-6 weeks
-5 to 19 weeks	10000067	Mus musculus C57BL/6	690	5 to 19 weeks
-6-weeks	10000067	Mus musculus C57BL/6	691	6-weeks
-22-108 months	9606	Homo sapiens (human)	692	22-108 months
-6-10 wk	10000000	Mus musculus BALB/c	693	6-10 week
-NULL	10000072	Mus musculus C57BL/6 Db null Kb null	694	null
-NULL	10000671	Mus musculus (BALB/c x B10.G)F1-B10.G bone marrow chimera	695	null
-23-54 years-old	9606	Homo sapiens (human)	696	23-54 years-old
-20-23 years	9606	Homo sapiens (human)	697	20-23 years
-8 to 10 weeks	10000000	Mus musculus BALB/c	698	8 to 10 weeks
-21	9606	Homo sapiens (human)	699	21
-8-10 weeks-old	10000067	Mus musculus C57BL/6	700	8-10 weeks-old
-child	9606	Homo sapiens (human)	701	child
-NULL	10000071	Mus musculus C57BL/6 Db null	702	null
-NULL	10000651	Mus musculus SMARTA TCR Tg	703	null
-6-10 weeks	10000653	Mus musculus Swiss	704	6-10 weeks
-46-74 years old	9606	Homo sapiens (human)	705	46-74 years old
-16 years-old	9606	Homo sapiens (human)	706	16 years-old
-10 days	10000067	Mus musculus C57BL/6	707	10 days
-6-8 week	10000067	Mus musculus C57BL/6	708	6-8 week
-4-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	709	4-8 weeks
-14-24 weeks	10000067	Mus musculus C57BL/6	710	14-24 weeks
-6-18 weeks-old	10000038	Mus musculus C3H/He	711	6-18 weeks-old
-10-17 days	10000627	Mus musculus MRL/MpJ	712	10-17 days
-NULL	10000672	Mus musculus B10.BR-SCID  bone marrow chimera	713	null
-22 to 80 years	9606	Homo sapiens (human)	714	22 to 80 years
-NULL	10000261	Mus musculus B10.A(5R)	715	null
-8-10 wk	10090	Mus musculus (mouse)	716	8-10 week
-7-10 weeks-old	10000047	Mus musculus C57BL/10	717	7-10 weeks-old
-20-65 years	9606	Homo sapiens (human)	718	20-65 years
-5 to 8 weeks	10000067	Mus musculus C57BL/6	719	5 to 8 weeks
-37 yrs. Average	9606	Homo sapiens (human)	720	37 years. average
-8 weeks	10000582	Mus musculus HLA-A2 Tg	721	8 weeks
-19-29 years	9606	Homo sapiens (human)	722	19-29 years
-8-12 week	10000000	Mus musculus BALB/c	723	8-12 week
-1-13 years	9606	Homo sapiens (human)	724	1-13 years
-36-47 years	9606	Homo sapiens (human)	725	36-47 years
-4 weeks old	10000000	Mus musculus BALB/c	726	4 weeks old
-4 to 6 weeks	10001128	Mus musculus N15 TCR Tg	727	4 to 6 weeks
-NULL	10000097	Mus musculus C57BL/6 Kb null	728	null
-6-8 wk	10000216	Mus musculus C57BL/6 X BALB/c	729	6-8 week
-1 year	10000917	Equus caballus Arabian	730	1 year
-47.6	9606	Homo sapiens (human)	731	47.6
-8-12 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	732	8-12 weeks old
-6-10 weeks-old	10000290	Mus musculus BALB.K	733	6-10 weeks-old
-6-8-week-old	10000067	Mus musculus C57BL/6	734	6-8-week-old
-8 weeks	10000067	Mus musculus C57BL/6	735	8 weeks
-35-65 years	9606	Homo sapiens (human)	736	35-65 years
-NULL	10000618	Mus musculus ICR	737	null
-22 to 64 years	9606	Homo sapiens (human)	738	22 to 64 years
-6-16 weeks	10000000	Mus musculus BALB/c	739	6-16 weeks
-9 to 12 weeks	10000067	Mus musculus C57BL/6	740	9 to 12 weeks
-24-45 years	9606	Homo sapiens (human)	741	24-45 years
-8-10 weeks-old	10000051	Mus musculus C57BL/10 X DBA/2	742	8-10 weeks-old
-mean age 54 years	9606	Homo sapiens (human)	743	mean age 54 years
-50-76	9606	Homo sapiens (human)	744	50-76
-3 months-old	10000228	Mus musculus CBA	745	3 months-old
-9 weeks old	10000067	Mus musculus C57BL/6	746	9 weeks old
-45-66 years	9606	Homo sapiens (human)	747	45-66 years
-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	748	8 weeks
-8-12 wks	10000057	Mus musculus F5 TCR Tg	749	8-12 weeks
-NULL	10000061	Mus musculus FVB	750	null
-NULL	10000229	Mus musculus HLA-B*27:05 Tg	751	null
-7 to 9 weeks	10000067	Mus musculus C57BL/6	752	7 to 9 weeks
-33-67 years	9606	Homo sapiens (human)	753	33-67 years
-12-16 weeks	10090	Mus musculus (mouse)	754	12-16 weeks
-6 to 12 weeks	10000067	Mus musculus C57BL/6	755	6 to 12 weeks
-NULL	10000270	Mus musculus B10.HTT	756	null
-8 to 12-week-old	10000000	Mus musculus BALB/c	757	8 to 12-week-old
-22-32 years	9606	Homo sapiens (human)	758	22-32 years
-NULL	10000288	Mus musculus B6Smn.C3-Faslgld	759	null
-1 year-old	10000191	Bos taurus Hereford	760	1 year-old
-8-34 years	9606	Homo sapiens (human)	761	8-34 years
-4-6 weeks	10000286	Mus musculus B6.PL Thy1a/Cy	762	4-6 weeks
-NULL	10000290	Mus musculus BALB.K	763	null
-25 to 61 years	9606	Homo sapiens (human)	764	25 to 61 years
-3 weeks	10000632	Mus musculus NOD	765	3 weeks
-NULL	10001596	Mus musculus B6.mOVA-Tg	766	null
-43 years old	9606	Homo sapiens (human)	767	43 years old
-31-80	9606	Homo sapiens (human)	768	31-80
-6 wo	10000067	Mus musculus C57BL/6	769	6 week
-31-37	9606	Homo sapiens (human)	770	31-37
-1-52 years	9606	Homo sapiens (human)	771	1-52 years
-Adults and children (ages 4.5-10.5 and 15-44)	9606	Homo sapiens (human)	772	adults and children (ages 4.5-10.5 and 15-44)
-8-12 wk	10000216	Mus musculus C57BL/6 X BALB/c	773	8-12 week
-6-8 weeks	10000601	Mus musculus HLA-DR1 Tg	774	6-8 weeks
-Neonates	9606	Homo sapiens (human)	775	neonates
->9 years	9606	Homo sapiens (human)	776	>9 years
-At least 8 weeks old	10000067	Mus musculus C57BL/6	777	at least 8 weeks old
-8-24 weeks old	10000260	Mus musculus B10.A(4R)	778	8-24 weeks old
-At birth	9995	Marmota monax (groundhog)	779	at birth
-Adult	10000000	Mus musculus BALB/c	780	adult
-21-84 years	9606	Homo sapiens (human)	781	21-84 years
-6-8 weeks-old	10000067	Mus musculus C57BL/6	782	6-8 weeks-old
-12-14 weeks	10000067	Mus musculus C57BL/6	783	12-14 weeks
-8-25 years	9606	Homo sapiens (human)	784	8-25 years
-19-39 years	9606	Homo sapiens (human)	785	19-39 years
-NULL	9541	Macaca fascicularis (crab eating macaque)	786	null
-NULL	10000033	Mus musculus C3H.SW	787	null
-6-10 weeks old	10000632	Mus musculus NOD	788	6-10 weeks old
-65 years	9606	Homo sapiens (human)	789	65 years
-6 to 10 weeks	10000000	Mus musculus BALB/c	790	6 to 10 weeks
-8-24 weeks old	10000258	Mus musculus B10.A(2R)	791	8-24 weeks old
-6-8 weeks	10000227	Mus musculus OT-1 TCR Tg	792	6-8 weeks
-47	9606	Homo sapiens (human)	793	47
-8-10 weeks-old	10090	Mus musculus (mouse)	794	8-10 weeks-old
-NULL	10001217	Mus musculus pmel-1 TCR Tg	795	null
-8-12 week	10000582	Mus musculus HLA-A2 Tg	796	8-12 week
-NULL	9539	Macaca (macaque)	797	null
-66-88	9606	Homo sapiens (human)	798	66-88
-34-35 years	9606	Homo sapiens (human)	799	34-35 years
-34-41 years	9606	Homo sapiens (human)	800	34-41 years
-53 years	9606	Homo sapiens (human)	801	53 years
-4-5 weeks	10090	Mus musculus (mouse)	802	4-5 weeks
-6-16 wk	10000009	Mus musculus BALB/c IFNgamma null	803	6-16 week
-8-24 weeks old	10000047	Mus musculus C57BL/10	804	8-24 weeks old
->10 years	9606	Homo sapiens (human)	805	>10 years
-6-8 weeks	10000037	Mus musculus C3H/FeJ X C57BL/6	806	6-8 weeks
-5-6 weeks-old	10090	Mus musculus (mouse)	807	5-6 weeks-old
-6-10 wks	10090	Mus musculus (mouse)	808	6-10 weeks
-5-10 years-old	9606	Homo sapiens (human)	809	5-10 years-old
-4-15 years	9606	Homo sapiens (human)	810	4-15 years
-19 to 91 years	9606	Homo sapiens (human)	811	19 to 91 years
-NULL	10000669	Cavia porcellus Hartley	812	null
-3-4 weeks	10000000	Mus musculus BALB/c	813	3-4 weeks
-45-55 yrs	9606	Homo sapiens (human)	814	45-55 years
-5-6 weeks	10001634	Mus musculus IFNR null	815	5-6 weeks
-10 weeks	10000635	Mus musculus NOD/Lt	816	10 weeks
-Mean: 30 years	9606	Homo sapiens (human)	817	mean: 30 years
-8-14 weeks	10090	Mus musculus (mouse)	818	8-14 weeks
-6-8 weeks old	10000653	Mus musculus Swiss	819	6-8 weeks old
-4 to 8 weeks	10000019	Mus musculus BALB/cByJ	820	4 to 8 weeks
-29 to 53 years	9606	Homo sapiens (human)	821	29 to 53 years
-8-20 weeks-old	10000263	Mus musculus B10.BR	822	8-20 weeks-old
-23-34 years	9606	Homo sapiens (human)	823	23-34 years
-22 years	9606	Homo sapiens (human)	824	22 years
-2-6 months	10000000	Mus musculus BALB/c	825	2-6 months
-8-12 wk.	10000067	Mus musculus C57BL/6	826	8-12 week.
-8-12 wk.	10000223	Mus musculus C57BL/6J IAbeta null	827	8-12 week.
-8 weeks	10002231	Mus musculus J15 TCR Tg	828	8 weeks
-NULL	10000040	Mus musculus 3A9 TCR Tg	829	null
-22 weeks	10000067	Mus musculus C57BL/6	830	22 weeks
-7 weeks	10001487	Mus musculus Apolipoprotein E null	831	7 weeks
-NULL	9940	Ovis aries (domestic sheep)	832	null
-13-64 years	9606	Homo sapiens (human)	833	13-64 years
-60-95 yrs	9606	Homo sapiens (human)	834	60-95 years
-35 years	9606	Homo sapiens (human)	835	35 years
-16-50 years-old	9606	Homo sapiens (human)	836	16-50 years-old
-6-10 weeks	10000607	Mus musculus HLA-DR3 Tg	837	6-10 weeks
-6-8 weeks	10000658	Rattus norvegicus Brown Norway	838	6-8 weeks
-> 8 wk.	10000211	Mus musculus (C57BL/10 X DBA/2) InsHA Tg	839	> 8 week.
-6-8 weeks old	10000054	Mus musculus DBA/1	840	6-8 weeks old
-3 months	10000000	Mus musculus BALB/c	841	3 months
-NULL	10000267	Mus musculus B10.CE-H13b Aw/(30NX)Sn	842	null
-6 weeks	10000236	Mus musculus CBA/J	843	6 weeks
-average of 30.2 years	9606	Homo sapiens (human)	844	average of 30.2 years
-4-5 weeks-old	10000000	Mus musculus BALB/c	845	4-5 weeks-old
-23 to 55 years	9606	Homo sapiens (human)	846	23 to 55 years
-6-7 weeks	10000662	Rattus norvegicus Lewis	847	6-7 weeks
-8 week-old	10000000	Mus musculus BALB/c	848	8 week-old
-8-12 weeks	10000063	Mus musculus B10.A	849	8-12 weeks
-8-12 wk	10000105	Mus musculus TRAMP Tg	850	8-12 week
-> 8 wk.	10000051	Mus musculus C57BL/10 X DBA/2	851	> 8 week.
-NULL	10000004	Mus musculus BALB/c Factor IX null	852	null
-6-week-old	10000000	Mus musculus BALB/c	853	6-week-old
-50-65 years	9606	Homo sapiens (human)	854	50-65 years
-12 to 16 weeks	10000000	Mus musculus BALB/c	855	12 to 16 weeks
-7 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	856	7 to 10 weeks
-16 weeks	10000635	Mus musculus NOD/Lt	857	16 weeks
-25-40 years	9606	Homo sapiens (human)	858	25-40 years
-12-16 weeks	10000217	Mus musculus C57BL/6 X BALB/c-H2dm2	859	12-16 weeks
-12-16 weeks	10000216	Mus musculus C57BL/6 X BALB/c	860	12-16 weeks
-29 to 36 years	9606	Homo sapiens (human)	861	29 to 36 years
-8 weeks	10000063	Mus musculus B10.A	862	8 weeks
-5 weeks	10000067	Mus musculus C57BL/6	863	5 weeks
-8 wk	10000067	Mus musculus C57BL/6	864	8 week
-NULL	10002763	Mus musculus HLA-A*11:01 Tg	865	null
-8-12 weeks old	10090	Mus musculus (mouse)	866	8-12 weeks old
-6-10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	867	6-10 weeks
-8-12 weeks-old	10000000	Mus musculus BALB/c	868	8-12 weeks-old
-21-46 years	9606	Homo sapiens (human)	869	21-46 years
-8-13 weeks	10000216	Mus musculus C57BL/6 X BALB/c	870	8-13 weeks
-8-10	10000000	Mus musculus BALB/c	871	8-10
-20-45 years	9606	Homo sapiens (human)	872	20-45 years
-18 to 40 years	9606	Homo sapiens (human)	873	18 to 40 years
-8 week	10000000	Mus musculus BALB/c	874	8 week
-6-8 weeks	10000219	Mus musculus C57BL/6 X CBA	875	6-8 weeks
-8-24 weeks	10000007	Mus musculus 6.5 TCR Tg	876	8-24 weeks
-NULL	10001467	Mus musculus TAZ10 TCR Tg	877	null
-58 years	9606	Homo sapiens (human)	878	58 years
-21-87 years	9606	Homo sapiens (human)	879	21-87 years
-18-65  years	9606	Homo sapiens (human)	880	18-65  years
-25-38 years	9606	Homo sapiens (human)	881	25-38 years
-8 week old	10000067	Mus musculus C57BL/6	882	8 week old
-23-32	9606	Homo sapiens (human)	883	23-32
-8 to 10 weeks	10090	Mus musculus (mouse)	884	8 to 10 weeks
-3-5 weeks	10090	Mus musculus (mouse)	885	3-5 weeks
-21-62 years	9606	Homo sapiens (human)	886	21-62 years
-4-8 weeks	10000047	Mus musculus C57BL/10	887	4-8 weeks
-8-9 weeks	10000582	Mus musculus HLA-A2 Tg	888	8-9 weeks
-7-8 weeks	10000067	Mus musculus C57BL/6	889	7-8 weeks
-9 weeks	10000067	Mus musculus C57BL/6	890	9 weeks
-NULL	10001782	Mus musculus HLA-B*07:02 Tg	891	null
-7 to 12 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	892	7 to 12 weeks
-NULL	10000614	Mus musculus HLA-DR51 Tg	893	null
-9 weeks	10000632	Mus musculus NOD	894	9 weeks
-22-59 years	9606	Homo sapiens (human)	895	22-59 years
-8-12 weeks old	10000223	Mus musculus C57BL/6J IAbeta null	896	8-12 weeks old
-6-10 weeks	10000014	Mus musculus BALB/c X B10.BR	897	6-10 weeks
-23-66 years	9606	Homo sapiens (human)	898	23-66 years
-29-67 years	9606	Homo sapiens (human)	899	29-67 years
-8-12 weeks-old	10000216	Mus musculus C57BL/6 X BALB/c	900	8-12 weeks-old
-7-17 years old	9606	Homo sapiens (human)	901	7-17 years old
-8-78 years	9606	Homo sapiens (human)	902	8-78 years
-NULL	10000099	Mus musculus D7 TCR Tg	903	null
-1 month	10000000	Mus musculus BALB/c	904	1 month
-NULL	10116	Rattus norvegicus (brown rat)	905	null
-6-7 weeks	10000649	Mus musculus SJL	906	6-7 weeks
-NULL	10000252	Mus musculus A.SW	907	null
-NULL	292213	Aotus griseimembra	908	null
-NULL	10001983	Mus musculus HLA-DRB1*03:01 Tg	909	null
-NULL	10000257	Mus musculus B10 X B10.S	910	null
-NULL	10000285	Mus musculus B6.FVB-Tg(Itgax-DTR/EGFP)57Lan/J X C57BL/6	911	null
-24-73 years	9606	Homo sapiens (human)	912	24-73 years
-NULL	10000251	Mus musculus A.BY	913	null
-22-36 years	9606	Homo sapiens (human)	914	22-36 years
-6-12 weeks	10000271	Mus musculus B10.M	915	6-12 weeks
-34 years	9606	Homo sapiens (human)	916	34 years
-45-72 years	9606	Homo sapiens (human)	917	45-72 years
-6-10 weeks	10000233	Mus musculus CBA/Ca	918	6-10 weeks
-8-20 weeks-old	10000047	Mus musculus C57BL/10	919	8-20 weeks-old
-~ 33 to 55 years	9606	Homo sapiens (human)	920	~ 33 to 55 years
-42-67 years	9606	Homo sapiens (human)	921	42-67 years
-50 yrs	9606	Homo sapiens (human)	922	50 years
-NULL	10000007	Mus musculus 6.5 TCR Tg	923	null
-6-10 weeks old	10000067	Mus musculus C57BL/6	924	6-10 weeks old
-6-10 weeks	10000220	Mus musculus C57BL/6 X DBA/2	925	6-10 weeks
-32-43 years	9606	Homo sapiens (human)	926	32-43 years
-6-8 weeks	10000290	Mus musculus BALB.K	927	6-8 weeks
-8-15 weeks	10000259	Mus musculus B10.A(3R)	928	8-15 weeks
-54 years old	9606	Homo sapiens (human)	929	54 years old
-NULL	10000031	Mus musculus C3H.NB	930	null
-8-16 weeks	10000263	Mus musculus B10.BR	931	8-16 weeks
-50-73 years	9606	Homo sapiens (human)	932	50-73 years
-7 weeks	10000632	Mus musculus NOD	933	7 weeks
-52-62 years	9606	Homo sapiens (human)	934	52-62 years
-42	9606	Homo sapiens (human)	935	42
-23 years	9606	Homo sapiens (human)	936	23 years
-23 and 61 years	9606	Homo sapiens (human)	937	23 and 61 years
-10-36 years	9606	Homo sapiens (human)	938	10-36 years
-20-56 years	9606	Homo sapiens (human)	939	20-56 years
-31	9606	Homo sapiens (human)	940	31
-31-42	9606	Homo sapiens (human)	941	31-42
-11-62 years-old	9606	Homo sapiens (human)	942	11-62 years-old
-57 to 75 years	9606	Homo sapiens (human)	943	57 to 75 years
-29-70	9606	Homo sapiens (human)	944	29-70
-8-14 weeks	10000216	Mus musculus C57BL/6 X BALB/c	945	8-14 weeks
-NULL	10000058	Mus musculus Flu (PR8) HA Tg	946	null
-6-10 weeks	10001926	Mus musculus FVIII null	947	6-10 weeks
-64 years	9606	Homo sapiens (human)	948	64 years
-59-61 years	9606	Homo sapiens (human)	949	59-61 years
-5-6 weeks old	10000000	Mus musculus BALB/c	950	5-6 weeks old
-32-74	9606	Homo sapiens (human)	951	32-74
-4-5 years	9544	Macaca mulatta (rhesus macaque)	952	4-5 years
-8 weeks-old	10000632	Mus musculus NOD	953	8 weeks-old
-7-12 week	10000253	Mus musculus A/J	954	7-12 week
-6-8	10000067	Mus musculus C57BL/6	955	6-8
-50-69 years	9606	Homo sapiens (human)	956	50-69 years
-20-52 years	9606	Homo sapiens (human)	957	20-52 years
-26	9606	Homo sapiens (human)	958	26
-42 years	9606	Homo sapiens (human)	959	42 years
-9 weeks	10000624	Mus musculus MF1	960	9 weeks
-18-70 years-old	9606	Homo sapiens (human)	961	18-70 years-old
-39 to 67 years	9606	Homo sapiens (human)	962	39 to 67 years
-1.1-11.6 years	9606	Homo sapiens (human)	963	1.1-11.6 years
-6-8 weeks	10000187	Sus scrofa Landrace X Large White	964	6-8 weeks
-17-65 years	9606	Homo sapiens (human)	965	17-65 years
-2-day old	10000000	Mus musculus BALB/c	966	2-day old
-2 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	967	2 months
-11 or 18 weeks	10000632	Mus musculus NOD	968	11 or 18 weeks
-11-50	9606	Homo sapiens (human)	969	11-50
-10-15 years	9598	Pan troglodytes (chimpanzee)	970	10-15 years
-6-12 weeks old	10090	Mus musculus (mouse)	971	6-12 weeks old
-8-12 weeks	10000289	Mus musculus BALB.B	972	8-12 weeks
-NULL	10001071	Mus musculus (A.CA x C57BL/6)F1	973	null
-6-8 weeks	10000273	Mus musculus B10.P	974	6-8 weeks
-7-12 weeks	10090	Mus musculus (mouse)	975	7-12 weeks
-39-73 years	9606	Homo sapiens (human)	976	39-73 years
-13-82 years	9606	Homo sapiens (human)	977	13-82 years
-18-61 years	9606	Homo sapiens (human)	978	18-61 years
-10 to over 90 years	9606	Homo sapiens (human)	979	10 to over 90 years
-8-12 weeks	10000618	Mus musculus ICR	980	8-12 weeks
-6-8 weeks old	10000063	Mus musculus B10.A	981	6-8 weeks old
-6-8 weeks old	10000274	Mus musculus B10.PL	982	6-8 weeks old
-9-72	9606	Homo sapiens (human)	983	9-72
-6-8 weeks	10000236	Mus musculus CBA/J	984	6-8 weeks
-4 to 8 weeks	10090	Mus musculus (mouse)	985	4 to 8 weeks
-6-8 weeks old	10000279	Mus musculus B10.SM	986	6-8 weeks old
-6-8 weeks	10000053	Mus musculus DBA	987	6-8 weeks
-Adult (within 24 hours of parturition)	9606	Homo sapiens (human)	988	adult (within 24 hours of parturition)
-6 to 8-week old	10000000	Mus musculus BALB/c	989	6 to 8-week old
-6-8 weeks old	10000253	Mus musculus A/J	990	6-8 weeks old
-0.5-15 years-old	9606	Homo sapiens (human)	991	0.5-15 years-old
-7-9 weeks	10000047	Mus musculus C57BL/10	992	7-9 weeks
-6-8 weeks old	10000281	Mus musculus B10.WB	993	6-8 weeks old
-21-30 years	9606	Homo sapiens (human)	994	21-30 years
-6-8 weeks	10000101	Mus musculus C57BL/6 Perforin null	995	6-8 weeks
-10-12 weeks old	10000000	Mus musculus BALB/c	996	10-12 weeks old
-5-8 weeks-old	10000000	Mus musculus BALB/c	997	5-8 weeks-old
-4-8 weeks	10000019	Mus musculus BALB/cByJ	998	4-8 weeks
-30-60 years old	9606	Homo sapiens (human)	999	30-60 years old
-18 weeks	10000632	Mus musculus NOD	1000	18 weeks
-< 11 years	9606	Homo sapiens (human)	1001	< 11 years
-8-14 weeks	10001211	Mus musculus (C57BL/6 X A/J)	1002	8-14 weeks
-26 years old	9606	Homo sapiens (human)	1003	26 years old
-43 years	9606	Homo sapiens (human)	1004	43 years
-5-8 weeks old	10000011	Mus musculus ABLE Tg TCR	1005	5-8 weeks old
-6-7 weeks	10000067	Mus musculus C57BL/6	1006	6-7 weeks
-25-88 years	9606	Homo sapiens (human)	1007	25-88 years
-20-72 years	9606	Homo sapiens (human)	1008	20-72 years
-6-8 weeks	10000234	Mus musculus HLA-G Transgenic	1009	6-8 weeks
-NULL	10000605	Mus musculus HLA-DR2 Tg	1010	null
-3 weeks	10000000	Mus musculus BALB/c	1011	3 weeks
-2 months and 5 months	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	1012	2 months and 5 months
-6-7 weeks	10000038	Mus musculus C3H/He	1013	6-7 weeks
-8-10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1014	8-10 weeks
-8-10 weeks old	10000632	Mus musculus NOD	1015	8-10 weeks old
-7 days	10000067	Mus musculus C57BL/6	1016	7 days
-7 day old	10000067	Mus musculus C57BL/6	1017	7 day old
-28 to 33 years	9606	Homo sapiens (human)	1018	28 to 33 years
-42 to 43 years	9606	Homo sapiens (human)	1019	42 to 43 years
-5 months	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	1020	5 months
-6-9 weeks	10000013	Mus musculus BALB/c X A/J	1021	6-9 weeks
-6 weeks	10000028	Mus musculus C3H	1022	6 weeks
-45.8 years	9606	Homo sapiens (human)	1023	45.8 years
-22 to 42 years	9606	Homo sapiens (human)	1024	22 to 42 years
-8-16 weeks	10000618	Mus musculus ICR	1025	8-16 weeks
-20 to 69 years	9606	Homo sapiens (human)	1026	20 to 69 years
-28 to 30 years	9606	Homo sapiens (human)	1027	28 to 30 years
-8-12 weeks	10000228	Mus musculus CBA	1028	8-12 weeks
-NULL	10000113	Homo sapiens Black	1029	null
-2-6 months	10000601	Mus musculus HLA-DR1 Tg	1030	2-6 months
-6-12 weeks	10000594	Mus musculus HLA-B27 Tg	1031	6-12 weeks
-7-12 weeks-old	10000038	Mus musculus C3H/He	1032	7-12 weeks-old
-newborn	10000000	Mus musculus BALB/c	1033	newborn
-5 or 6 weeks	10090	Mus musculus (mouse)	1034	5 or 6 weeks
-6-12 weeks	10000289	Mus musculus BALB.B	1035	6-12 weeks
-20 to 64 years	9606	Homo sapiens (human)	1036	20 to 64 years
-8-24 weeks old	10000263	Mus musculus B10.BR	1037	8-24 weeks old
-6 weeks or older	10090	Mus musculus (mouse)	1038	6 weeks or older
-8-24 weeks old	10000278	Mus musculus B10.S(9R)	1039	8-24 weeks old
-8-24 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	1040	8-24 weeks old
-6-8 weeks-old	10000263	Mus musculus B10.BR	1041	6-8 weeks-old
-9.5 months	10001286	Mus musculus APPswe/PSEN1	1042	9.5 months
-3-6 weeks	10000263	Mus musculus B10.BR	1043	3-6 weeks
-8-24 weeks old	10000053	Mus musculus DBA	1044	8-24 weeks old
-26-58 years old	9606	Homo sapiens (human)	1045	26-58 years old
-6-12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1046	6-12 weeks
-8-24 weeks old	10000000	Mus musculus BALB/c	1047	8-24 weeks old
-NULL	10001998	Mus musculus CD1	1048	null
-2-4 months	10000000	Mus musculus BALB/c	1049	2-4 months
-1-14 years	9606	Homo sapiens (human)	1050	1-14 years
-12 weeks-old	9685	Felis catus (cat)	1051	12 weeks-old
-NULL	10001301	Mus musculus HLA-DR15 Tg	1052	null
-23-44 years	9606	Homo sapiens (human)	1053	23-44 years
-6 weeks	10000043	Mus musculus C3HeB/FeJ	1054	6 weeks
-46.3-66.3 years	9606	Homo sapiens (human)	1055	46.3-66.3 years
-25.5 - 56 years	9606	Homo sapiens (human)	1056	25.5 - 56 years
-12-13 weeks	10000632	Mus musculus NOD	1057	12-13 weeks
-NULL	10001400	Mus musculus HLA-DRB1*15:02 Tg	1058	null
-44	9606	Homo sapiens (human)	1059	44
-6-8 weeks	10000632	Mus musculus NOD	1060	6-8 weeks
-46 years-old	9606	Homo sapiens (human)	1061	46 years-old
-18, 35 years	9606	Homo sapiens (human)	1062	18, 35 years
-6-8	10000000	Mus musculus BALB/c	1063	6-8
-6 to 8 weeks	10000038	Mus musculus C3H/He	1064	6 to 8 weeks
-5 years	10000190	Bos taurus Friesian	1065	5 years
-6-10 weeks	10000051	Mus musculus C57BL/10 X DBA/2	1066	6-10 weeks
-11 weeks	10000637	Mus musculus NODasp	1067	11 weeks
-Adult	10000051	Mus musculus C57BL/10 X DBA/2	1068	adult
-6 to 8 weeks	10001257	Mus musculus NOD.H-2h4	1069	6 to 8 weeks
-6-8	10000916	Mus musculus C3H/He-mg	1070	6-8
-2-3 months	10000000	Mus musculus BALB/c	1071	2-3 months
-54 years	9606	Homo sapiens (human)	1072	54 years
-3 weeks	10000627	Mus musculus MRL/MpJ	1073	3 weeks
-7 yo 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1074	7 year 8 weeks
-NULL	10000622	Mus musculus Kb null	1075	null
-20 years	9606	Homo sapiens (human)	1076	20 years
-6-8 weeks	10000033	Mus musculus C3H.SW	1077	6-8 weeks
-5 or 8 weeks	10000632	Mus musculus NOD	1078	5 or 8 weeks
-7 weeks	10000000	Mus musculus BALB/c	1079	7 weeks
-6 to 8 weeks	10001469	Mus musculus C57BL/6 TSHR null	1080	6 to 8 weeks
-7-12 weeks-old	10090	Mus musculus (mouse)	1081	7-12 weeks-old
-1 week	10000000	Mus musculus BALB/c	1082	1 week
-24-51 years	9606	Homo sapiens (human)	1083	24-51 years
-21-58 years-old	9606	Homo sapiens (human)	1084	21-58 years-old
-6-10 weeks-old	10000263	Mus musculus B10.BR	1085	6-10 weeks-old
-20-69 years	9606	Homo sapiens (human)	1086	20-69 years
-2.5-6 months	10000228	Mus musculus CBA	1087	2.5-6 months
-6 to 12 weeks	10000649	Mus musculus SJL	1088	6 to 12 weeks
-NULL	10001326	Mus musculus Tg4 TCR Tg	1089	null
-8-14 weeks	10000093	Mus musculus C57BL/6 human IgCkappa Tg	1090	8-14 weeks
-35.4 yrs. Average	9606	Homo sapiens (human)	1091	35.4 years. average
-14 to 53 years	9606	Homo sapiens (human)	1092	14 to 53 years
-41 years old	9606	Homo sapiens (human)	1093	41 years old
-NULL	10000012	Mus musculus BALB/c Thy-LCMV NP Tg	1094	null
-6-8 weeks old	10000648	Mus musculus RIIIS	1095	6-8 weeks old
-7 to 14 weeks	10000002	Mus musculus BALB/c beta2m null	1096	7 to 14 weeks
-4-8-week-old	10000000	Mus musculus BALB/c	1097	4-8-week-old
-6-8 wk.	10000000	Mus musculus BALB/c	1098	6-8 week.
-8 weeks-old	10000000	Mus musculus BALB/c	1099	8 weeks-old
-37 years	9606	Homo sapiens (human)	1100	37 years
-6 weeks-old	10000653	Mus musculus Swiss	1101	6 weeks-old
-6-15 weeks	10000632	Mus musculus NOD	1102	6-15 weeks
-6-8 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	1103	6-8 weeks
-NULL	10000655	Mus musculus Swiss Webster	1104	null
-6-10 weeks	10090	Mus musculus (mouse)	1105	6-10 weeks
-9.4 months	10001241	Mus musculus APP	1106	9.4 months
-8-10 weeks	10001244	Mus musculus NOR	1107	8-10 weeks
-8-15 years	9606	Homo sapiens (human)	1108	8-15 years
-NULL	10001256	Mus musculus GAD286 TCR Tg	1109	null
-5 weeks	10000632	Mus musculus NOD	1110	5 weeks
-NULL	10001248	Mus musculus NOD.Cg-Tg	1111	null
-6-42 years	10000119	Homo sapiens Caucasian	1112	6-42 years
-21-53 years	9606	Homo sapiens (human)	1113	21-53 years
-3-52 years	9606	Homo sapiens (human)	1114	3-52 years
-7-8 weeks	10000632	Mus musculus NOD	1115	7-8 weeks
-57 years old	9606	Homo sapiens (human)	1116	57 years old
-25-58 years	9606	Homo sapiens (human)	1117	25-58 years
-13 years	9606	Homo sapiens (human)	1118	13 years
-Young	10000632	Mus musculus NOD	1119	young
-Median age 11.3 years	9606	Homo sapiens (human)	1120	median age 11.3 years
-8-10 weeks	10001211	Mus musculus (C57BL/6 X A/J)	1121	8-10 weeks
-8-10 weeks	10000220	Mus musculus C57BL/6 X DBA/2	1122	8-10 weeks
-8-10 weeks	10000218	Mus musculus C57BL/6 X C3H	1123	8-10 weeks
-10 weeks	10000632	Mus musculus NOD	1124	10 weeks
-12-20 weeks	10000236	Mus musculus CBA/J	1125	12-20 weeks
-8-12 weeks	10000635	Mus musculus NOD/Lt	1126	8-12 weeks
-9 weeks	10001259	Mus musculus NOD.PD	1127	9 weeks
-neonatal	10000632	Mus musculus NOD	1128	neonatal
-2 weeks	10000632	Mus musculus NOD	1129	2 weeks
-12 weeks	10000632	Mus musculus NOD	1130	12 weeks
-NULL	10000635	Mus musculus NOD/Lt	1131	null
-NULL	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	1132	null
-6 weeks old	10000632	Mus musculus NOD	1133	6 weeks old
-2 months to 52 years	9606	Homo sapiens (human)	1134	2 months to 52 years
-16-50 years	9606	Homo sapiens (human)	1135	16-50 years
-6-8 weeks	10001248	Mus musculus NOD.Cg-Tg	1136	6-8 weeks
-8-14 years	9606	Homo sapiens (human)	1137	8-14 years
-Median age 6.3 years	9606	Homo sapiens (human)	1138	median age 6.3 years
-7-15 weeks	10000582	Mus musculus HLA-A2 Tg	1139	7-15 weeks
-NULL	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	1140	null
-8 weeks old	10000632	Mus musculus NOD	1141	8 weeks old
-NULL	10001286	Mus musculus APPswe/PSEN1	1142	null
-NULL	10001244	Mus musculus NOR	1143	null
-7-48 years	9606	Homo sapiens (human)	1144	7-48 years
-8 to 10 weeks	10001266	Mus musculus NOD/Caj	1145	8 to 10 weeks
-6-8 weeks	10000610	Mus musculus HLA-DR4 Tg	1146	6-8 weeks
-4 weeks	10001251	Mus musculus RIP-B7	1147	4 weeks
-11 weeks	10000632	Mus musculus NOD	1148	11 weeks
-46 to 92 years	9606	Homo sapiens (human)	1149	46 to 92 years
-8 weeks	10001313	Mus musculus GAD65 p206 TCR Tg	1150	8 weeks
-14 week old	10000632	Mus musculus NOD	1151	14 week old
-3-4 weeks	10000632	Mus musculus NOD	1152	3-4 weeks
-NULL	10001133	Rattus norvegicus DA	1153	null
-8-12 weeks	10000632	Mus musculus NOD	1154	8-12 weeks
-23-48 years	9606	Homo sapiens (human)	1155	23-48 years
-NULL	10000596	Mus musculus HLA-DQ Transgenic	1156	null
-6 to 12 weeks old	10000067	Mus musculus C57BL/6	1157	6 to 12 weeks old
-7-10 weeks	10000649	Mus musculus SJL	1158	7-10 weeks
-4-6 weeks	10000632	Mus musculus NOD	1159	4-6 weeks
-NULL	10001261	Mus musculus G9Calpha –/ –.NOD	1160	null
-1-16 years	9606	Homo sapiens (human)	1161	1-16 years
-10-16 weeks	10000632	Mus musculus NOD	1162	10-16 weeks
-8 to 12 weeks	10000662	Rattus norvegicus Lewis	1163	8 to 12 weeks
-22-35 years	9606	Homo sapiens (human)	1164	22-35 years
-16-43 years	9606	Homo sapiens (human)	1165	16-43 years
-4 weeks	10000635	Mus musculus NOD/Lt	1166	4 weeks
-4 to 6 weeks old	10001248	Mus musculus NOD.Cg-Tg	1167	4 to 6 weeks old
-4-6 weeks	10001244	Mus musculus NOR	1168	4-6 weeks
-8-12 weeks	10001244	Mus musculus NOR	1169	8-12 weeks
-4 weeks	10000632	Mus musculus NOD	1170	4 weeks
-10-12 weeks	10000635	Mus musculus NOD/Lt	1171	10-12 weeks
-1 month	10000632	Mus musculus NOD	1172	1 month
-6-41 years	9606	Homo sapiens (human)	1173	6-41 years
-8 to 10 weeks	10000070	Mus musculus C57BL/6 bg	1174	8 to 10 weeks
-6-64 years	9606	Homo sapiens (human)	1175	6-64 years
-6-8 weeks	10000635	Mus musculus NOD/Lt	1176	6-8 weeks
-4 to 5 weeks	10000000	Mus musculus BALB/c	1177	4 to 5 weeks
-2–25 years	9606	Homo sapiens (human)	1178	225 years
-7 days	10000632	Mus musculus NOD	1179	7 days
-25	9606	Homo sapiens (human)	1180	25
-49	9606	Homo sapiens (human)	1181	49
-6-12 weeks	10000632	Mus musculus NOD	1182	6-12 weeks
-9-20 weeks	10000632	Mus musculus NOD	1183	9-20 weeks
-20-40 years	9606	Homo sapiens (human)	1184	20-40 years
-6-8 weeks	10002205	Mus musculus TCR-I TCR Tg	1185	6-8 weeks
-5 weeks	10001256	Mus musculus GAD286 TCR Tg	1186	5 weeks
-66-86 years	9606	Homo sapiens (human)	1187	66-86 years
-18-65 years	9606	Homo sapiens (human)	1188	18-65 years
-6-10 weeks	10000632	Mus musculus NOD	1189	6-10 weeks
-17	9606	Homo sapiens (human)	1190	17
-8-12 weeks	10000065	Mus musculus C57BL/10SnJ	1191	8-12 weeks
-4-20 weeks	10000635	Mus musculus NOD/Lt	1192	4-20 weeks
-8-10 weeks	10000635	Mus musculus NOD/Lt	1193	8-10 weeks
-6 weeks	10000635	Mus musculus NOD/Lt	1194	6 weeks
-13-31 years	9606	Homo sapiens (human)	1195	13-31 years
-4-12 weeks	10000635	Mus musculus NOD/Lt	1196	4-12 weeks
-9 or 20 weeks	10000632	Mus musculus NOD	1197	9 or 20 weeks
-12 weeks	10000635	Mus musculus NOD/Lt	1198	12 weeks
-4 weeks	10001254	Mus musculus RIP-B7 X BALB/c	1199	4 weeks
-NULL	10000187	Sus scrofa Landrace X Large White	1200	null
-8-10 weeks	10001237	Mus musculus HLA-B*35:01 Tg	1201	8-10 weeks
-NULL	10000068	Mus musculus 2C TCR Tg	1202	null
-9-25 years	9606	Homo sapiens (human)	1203	9-25 years
-adult	10001275	Rattus norvegicus PVG-RT1u	1204	adult
-NULL	10001260	Mus musculus Tg AI4-NOD.Rag1-/-	1205	null
-63-82 years	9606	Homo sapiens (human)	1206	63-82 years
-16-36 years	10000119	Homo sapiens Caucasian	1207	16-36 years
-7-11 weeks	10000632	Mus musculus NOD	1208	7-11 weeks
-8-11 weeks old	10000065	Mus musculus C57BL/10SnJ	1209	8-11 weeks old
-20 weeks	10000632	Mus musculus NOD	1210	20 weeks
-8-12 weeks	10000598	Mus musculus HLA-DQ8 Tg	1211	8-12 weeks
-12 weeks	10001256	Mus musculus GAD286 TCR Tg	1212	12 weeks
-8-12 weeks	10000266	Mus musculus B10.BR-H2k H2-T18a/SgSnJ	1213	8-12 weeks
-20-27 weeks	10000632	Mus musculus NOD	1214	20-27 weeks
-1-32	9606	Homo sapiens (human)	1215	1-32
-5-10 weeks	10001248	Mus musculus NOD.Cg-Tg	1216	5-10 weeks
-25-80 years	9606	Homo sapiens (human)	1217	25-80 years
-6-18 weeks	10000632	Mus musculus NOD	1218	6-18 weeks
-8-12 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	1219	8-12 weeks
-2-15 years	9606	Homo sapiens (human)	1220	2-15 years
-2-16 years	9606	Homo sapiens (human)	1221	2-16 years
-6-8 weeks	10001271	Mus musculus NOD-PI/NOD8.3	1222	6-8 weeks
-21-52 years	9606	Homo sapiens (human)	1223	21-52 years
-6-16 weeks	10000598	Mus musculus HLA-DQ8 Tg	1224	6-16 weeks
-3-34 years	9606	Homo sapiens (human)	1225	3-34 years
-2-3 months	10001221	Mus musculus C57BL/6 x SJL	1226	2-3 months
-6 weeks	10000632	Mus musculus NOD	1227	6 weeks
-8-10 weeks	10000032	Mus musculus C3H.Q	1228	8-10 weeks
-10-14 weeks	10000649	Mus musculus SJL	1229	10-14 weeks
-8-14 weeks	10000649	Mus musculus SJL	1230	8-14 weeks
-NULL	10000616	Mus musculus HLA-DRB1*04:01 Tg	1231	null
-Mean=28.5 ± 15.0	9606	Homo sapiens (human)	1232	mean=28.5  15.0
-35-45 years	9606	Homo sapiens (human)	1233	35-45 years
-21-59 years	9606	Homo sapiens (human)	1234	21-59 years
-13-56 years	9606	Homo sapiens (human)	1235	13-56 years
->16 weeks	10000632	Mus musculus NOD	1236	>16 weeks
-2-3 months	10001241	Mus musculus APP	1237	2-3 months
-2-3 months	10001282	Mus musculus TGF-beta1	1238	2-3 months
-7-9 weeks	10000054	Mus musculus DBA/1	1239	7-9 weeks
-5-7 weeks	10000054	Mus musculus DBA/1	1240	5-7 weeks
-3-22 years	9606	Homo sapiens (human)	1241	3-22 years
->16 years	9606	Homo sapiens (human)	1242	>16 years
-4 to 16 years	9606	Homo sapiens (human)	1243	4 to 16 years
-14 to 51 years	9606	Homo sapiens (human)	1244	14 to 51 years
-> 6 months	10000632	Mus musculus NOD	1245	> 6 months
-NULL	10002233	Mus musculus 16.2beta TCR Tg	1246	null
-18-43 years	9606	Homo sapiens (human)	1247	18-43 years
-20-26 years	9606	Homo sapiens (human)	1248	20-26 years
-2-3 months	10001281	Mus musculus APP/TGF-beta1	1249	2-3 months
-27-41 years	9606	Homo sapiens (human)	1250	27-41 years
-14 to 24 years	9606	Homo sapiens (human)	1251	14 to 24 years
-24-66 years	9606	Homo sapiens (human)	1252	24-66 years
-6-8 weeks	10000013	Mus musculus BALB/c X A/J	1253	6-8 weeks
-NULL	10001019	Mus musculus B10.D2	1254	null
-10-14 weeks	10000653	Mus musculus Swiss	1255	10-14 weeks
-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1256	12 weeks
-5-38 years	9606	Homo sapiens (human)	1257	5-38 years
-3 months	10000632	Mus musculus NOD	1258	3 months
-2, 3, or 4 months	10000632	Mus musculus NOD	1259	2, 3, or 4 months
-12-13 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1260	12-13 weeks
-10.1 ± 3.6 yr	9606	Homo sapiens (human)	1261	10.1  3.6 year
-9 weeks	10000635	Mus musculus NOD/Lt	1262	9 weeks
-8-10 weeks	10000054	Mus musculus DBA/1	1263	8-10 weeks
-6-15 weeks	10000649	Mus musculus SJL	1264	6-15 weeks
-41-73	9606	Homo sapiens (human)	1265	41-73
-8 to 12 weeks	10001337	Rattus norvegicus LEWIS.1W	1266	8 to 12 weeks
-NULL	10001350	Mus musculus B7-2 null	1267	null
-2-12 months	10000649	Mus musculus SJL	1268	2-12 months
-8-12 weeks	10001333	Rattus norvegicus LEW.1N	1269	8-12 weeks
-34 to 66 years	9606	Homo sapiens (human)	1270	34 to 66 years
-25 to 67 years	9606	Homo sapiens (human)	1271	25 to 67 years
-8-12 weeks	10000662	Rattus norvegicus Lewis	1272	8-12 weeks
-32-58	9606	Homo sapiens (human)	1273	32-58
-28 to 64 years	9606	Homo sapiens (human)	1274	28 to 64 years
-28 to 61 years	9606	Homo sapiens (human)	1275	28 to 61 years
-Newborn	10000649	Mus musculus SJL	1276	newborn
-33-77 years	9606	Homo sapiens (human)	1277	33-77 years
-6 to 7 weeks	10000649	Mus musculus SJL	1278	6 to 7 weeks
-2-3 months	10000662	Rattus norvegicus Lewis	1279	2-3 months
-14-20 weeks	10000662	Rattus norvegicus Lewis	1280	14-20 weeks
-6 to 8 weeks	10000649	Mus musculus SJL	1281	6 to 8 weeks
-6 weeks	10000649	Mus musculus SJL	1282	6 weeks
-5 to 6 weeks	10000649	Mus musculus SJL	1283	5 to 6 weeks
-7-8 weeks	10000038	Mus musculus C3H/He	1284	7-8 weeks
-7-9 weeks old	10000253	Mus musculus A/J	1285	7-9 weeks old
-16-73 years	9606	Homo sapiens (human)	1286	16-73 years
-6 to 10 weeks	10000649	Mus musculus SJL	1287	6 to 10 weeks
-8-10 weeks	10001133	Rattus norvegicus DA	1288	8-10 weeks
-8-10 weeks	10000662	Rattus norvegicus Lewis	1289	8-10 weeks
-mean age 26.5 years	9606	Homo sapiens (human)	1290	mean age 26.5 years
-5 to 8 weeks	10000649	Mus musculus SJL	1291	5 to 8 weeks
-4 to 8 weeks	10000649	Mus musculus SJL	1292	4 to 8 weeks
-4 to 6 weeks	10000649	Mus musculus SJL	1293	4 to 6 weeks
-NULL	10001410	Mus musculus 5B6 TCR Tg	1294	null
-3 to 4 months	10000662	Rattus norvegicus Lewis	1295	3 to 4 months
-21-91 years	9606	Homo sapiens (human)	1296	21-91 years
-18-85 years	9606	Homo sapiens (human)	1297	18-85 years
-NULL	10001221	Mus musculus C57BL/6 x SJL	1298	null
-NULL	10000665	Rattus norvegicus LOU/M	1299	null
-8 to 12 weeks	10000649	Mus musculus SJL	1300	8 to 12 weeks
-33 to 57 years	9606	Homo sapiens (human)	1301	33 to 57 years
-5 to 7 weeks	10000649	Mus musculus SJL	1302	5 to 7 weeks
-NULL	10001376	Mus musculus HLA-DQB1*06:04 Tg	1303	null
-6 weeks	10000669	Cavia porcellus Hartley	1304	6 weeks
-12- 14 weeks	10000632	Mus musculus NOD	1305	12- 14 weeks
-NULL	10001314	Mus musculus HPV 16 E7 Tg	1306	null
-8 to 13 weeks	10000649	Mus musculus SJL	1307	8 to 13 weeks
-18-82 years	9606	Homo sapiens (human)	1308	18-82 years
-2 to 3 months	10000067	Mus musculus C57BL/6	1309	2 to 3 months
-51 years	9606	Homo sapiens (human)	1310	51 years
-8-12 weeks	10001133	Rattus norvegicus DA	1311	8-12 weeks
-64-86 years	9606	Homo sapiens (human)	1312	64-86 years
-8 -12 weeks old	10001041	Rattus norvegicus Wistar	1313	8 -12 weeks old
-6 to 10 weeks	10001537	Mus musculus PL	1314	6 to 10 weeks
-10 to 12 weeks	10090	Mus musculus (mouse)	1315	10 to 12 weeks
-9-11 weeks old	10000000	Mus musculus BALB/c	1316	9-11 weeks old
-22 to 56 years	9606	Homo sapiens (human)	1317	22 to 56 years
-4 to 6 weeks	10000662	Rattus norvegicus Lewis	1318	4 to 6 weeks
-29 to 54 years	9606	Homo sapiens (human)	1319	29 to 54 years
-4-6 weeks	10001446	Rattus norvegicus Wistar Kyoto	1320	4-6 weeks
-6 to 10 weeks	10000610	Mus musculus HLA-DR4 Tg	1321	6 to 10 weeks
-NULL	10000025	Mus musculus Biozzi AB/H	1322	null
-2 months	10001348	Mus musculus A.CA	1323	2 months
-Young adults	9544	Macaca mulatta (rhesus macaque)	1324	young adults
-5 to 8 weeks	10000653	Mus musculus Swiss	1325	5 to 8 weeks
-5 to 8 weeks	10001349	Mus musculus SJL X SWR	1326	5 to 8 weeks
-Young adult	10000662	Rattus norvegicus Lewis	1327	young adult
-NULL	10001356	Mus musculus MBP 84-105 HEL Tg	1328	null
-Adult	10000662	Rattus norvegicus Lewis	1329	adult
-6 to 8 weeks	10000000	Mus musculus BALB/c	1330	6 to 8 weeks
-6 to 8 weeks	10000662	Rattus norvegicus Lewis	1331	6 to 8 weeks
-8 to 10 weeks	10000662	Rattus norvegicus Lewis	1332	8 to 10 weeks
-8 to 12 weeks	10001332	Rattus norvegicus LEW.1AV1	1333	8 to 12 weeks
-18-51 years	9606	Homo sapiens (human)	1334	18-51 years
-13-31 weeks	10001406	Mus musculus MLR/lpr	1335	13-31 weeks
-38.6 years (mean age)	9606	Homo sapiens (human)	1336	38.6 years (mean age)
-6 to 8 weeks old	10000054	Mus musculus DBA/1	1337	6 to 8 weeks old
-5-7 weeks	10000973	Mus musculus 129	1338	5-7 weeks
-8 to 10 weeks	10001384	Mus musculus TCR1640 Tg	1339	8 to 10 weeks
-8 to 12 weeks	10001347	Mus musculus 129/Sv	1340	8 to 12 weeks
-8 weeks	10000662	Rattus norvegicus Lewis	1341	8 weeks
-36-55 years	9606	Homo sapiens (human)	1342	36-55 years
-2-12 months	10000255	Mus musculus AKR	1343	2-12 months
-8 to 12 weeks	10001374	Mus musculus ICOS null	1344	8 to 12 weeks
-2 months or 2-10 months	10000047	Mus musculus C57BL/10	1345	2 months or 2-10 months
-22-77 years	9606	Homo sapiens (human)	1346	22-77 years
-27-58 years	9606	Homo sapiens (human)	1347	27-58 years
-7 months	10001301	Mus musculus HLA-DR15 Tg	1348	7 months
-10-13 weeks	10001367	Mus musculus Pten fl/fl GBC	1349	10-13 weeks
-10-13 weeks	10000067	Mus musculus C57BL/6	1350	10-13 weeks
-NULL	10001365	Mus musculus Clone 19 TCR Tg	1351	null
-6 to 8 weeks	10116	Rattus norvegicus (brown rat)	1352	6 to 8 weeks
-5 months	10000067	Mus musculus C57BL/6	1353	5 months
-8 to 12 weeks	10001327	Mus musculus PL/J X SJL	1354	8 to 12 weeks
-26-42 years	9606	Homo sapiens (human)	1355	26-42 years
-6-10 weeks	10000658	Rattus norvegicus Brown Norway	1356	6-10 weeks
-36-43 years	9606	Homo sapiens (human)	1357	36-43 years
-33-56 years	9606	Homo sapiens (human)	1358	33-56 years
-2.5-4 months	10000919	Gallus gallus White Leghorn	1359	2.5-4 months
-23 to 52 years	9606	Homo sapiens (human)	1360	23 to 52 years
-8-10 weeks	10001221	Mus musculus C57BL/6 x SJL	1361	8-10 weeks
-14-60 years	9606	Homo sapiens (human)	1362	14-60 years
-89.7 years	9606	Homo sapiens (human)	1363	89.7 years
-14-20 weeks	10001332	Rattus norvegicus LEW.1AV1	1364	14-20 weeks
-6-10 weeks	10000662	Rattus norvegicus Lewis	1365	6-10 weeks
-14-20 weeks	10001339	Rattus norvegicus LEWIS.1A	1366	14-20 weeks
-6 weeks	10000662	Rattus norvegicus Lewis	1367	6 weeks
-14-20 weeks	10001337	Rattus norvegicus LEWIS.1W	1368	14-20 weeks
-8 weeks	10000228	Mus musculus CBA	1369	8 weeks
-7-9 weeks old	10000000	Mus musculus BALB/c	1370	7-9 weeks old
-7-9 weeks old	10000038	Mus musculus C3H/He	1371	7-9 weeks old
-7-9 weeks old	10000067	Mus musculus C57BL/6	1372	7-9 weeks old
-7 weeks	10000649	Mus musculus SJL	1373	7 weeks
-average age = 19.2 years	9606	Homo sapiens (human)	1374	average age = 19.2 years
-51	9606	Homo sapiens (human)	1375	51
-8 to 10 weeks old	10000216	Mus musculus C57BL/6 X BALB/c	1376	8 to 10 weeks old
-50-58	9606	Homo sapiens (human)	1377	50-58
-30-45	9606	Homo sapiens (human)	1378	30-45
-20-63 years	9606	Homo sapiens (human)	1379	20-63 years
-40-69 years	9606	Homo sapiens (human)	1380	40-69 years
-4-17 years	9606	Homo sapiens (human)	1381	4-17 years
-7-15 years	9606	Homo sapiens (human)	1382	7-15 years
-28-44	9606	Homo sapiens (human)	1383	28-44
-1-2 months	10000662	Rattus norvegicus Lewis	1384	1-2 months
-24-50 years	9606	Homo sapiens (human)	1385	24-50 years
-28-53 years	9606	Homo sapiens (human)	1386	28-53 years
-24-53 years	9606	Homo sapiens (human)	1387	24-53 years
-2-4 months	10000616	Mus musculus HLA-DRB1*04:01 Tg	1388	2-4 months
-24-44 years	9606	Homo sapiens (human)	1389	24-44 years
-2-4 months	10000632	Mus musculus NOD	1390	2-4 months
-24-42 years	9606	Homo sapiens (human)	1391	24-42 years
-25-57 years	9606	Homo sapiens (human)	1392	25-57 years
-22-44 years	9606	Homo sapiens (human)	1393	22-44 years
-14-59 years	9606	Homo sapiens (human)	1394	14-59 years
-10 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	1395	10 to 12 weeks
-2-4 months	10001245	Mus musculus B10.H2g7	1396	2-4 months
-54	9606	Homo sapiens (human)	1397	54
-30-56 years	9606	Homo sapiens (human)	1398	30-56 years
-41-69 years	9606	Homo sapiens (human)	1399	41-69 years
-3-45 years	9606	Homo sapiens (human)	1400	3-45 years
-13-46 years	9606	Homo sapiens (human)	1401	13-46 years
-6 to 8 week	10090	Mus musculus (mouse)	1402	6 to 8 week
-within 12 hours of birth	10000038	Mus musculus C3H/He	1403	within 12 hours of birth
-13 days	10000038	Mus musculus C3H/He	1404	13 days
-10 to 12 weeks	10000595	Mus musculus HLA-B7 Tg	1405	10 to 12 weeks
-2-6 months	10000067	Mus musculus C57BL/6	1406	2-6 months
-17-36 years	9606	Homo sapiens (human)	1407	17-36 years
-8 to 14 weeks	10000067	Mus musculus C57BL/6	1408	8 to 14 weeks
-8-10 weeks	10000252	Mus musculus A.SW	1409	8-10 weeks
-8-10 weeks	10000038	Mus musculus C3H/He	1410	8-10 weeks
-8-10 weeks	10000643	Mus musculus P/J	1411	8-10 weeks
-8-10 weeks	10000648	Mus musculus RIIIS	1412	8-10 weeks
-older than 8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1413	older than 8 weeks
-36 to 79 years	9606	Homo sapiens (human)	1414	36 to 79 years
-18-60 years-old	9606	Homo sapiens (human)	1415	18-60 years-old
-6 to 14 weeks	10000649	Mus musculus SJL	1416	6 to 14 weeks
-27-54 years	9606	Homo sapiens (human)	1417	27-54 years
-50 days	10000067	Mus musculus C57BL/6	1418	50 days
-27-79 years	9606	Homo sapiens (human)	1419	27-79 years
-25-44 years	9606	Homo sapiens (human)	1420	25-44 years
-Neonatal	10000054	Mus musculus DBA/1	1421	neonatal
-27 weeks	10001253	Mus musculus HLA-DRB1*04:04 Tg	1422	27 weeks
-6 to 8 weeks	10000236	Mus musculus CBA/J	1423	6 to 8 weeks
-26 years	9606	Homo sapiens (human)	1424	26 years
-36	9606	Homo sapiens (human)	1425	36
-NULL	10001287	Mus musculus DBA/1 X B10.Q	1426	null
-33-64 years	9606	Homo sapiens (human)	1427	33-64 years
-13-20 years	9606	Homo sapiens (human)	1428	13-20 years
-43	9606	Homo sapiens (human)	1429	43
-48	9606	Homo sapiens (human)	1430	48
-29	9606	Homo sapiens (human)	1431	29
-3 months	10000576	Mus musculus HLA-A*02:01 Tg	1432	3 months
-3-6 months	10000662	Rattus norvegicus Lewis	1433	3-6 months
-43 years	10000119	Homo sapiens Caucasian	1434	43 years
-2-3 months	10000067	Mus musculus C57BL/6	1435	2-3 months
-6 to 10 weeks	10000067	Mus musculus C57BL/6	1436	6 to 10 weeks
-10-12 weeks	10000649	Mus musculus SJL	1437	10-12 weeks
-27	9606	Homo sapiens (human)	1438	27
-NULL	10001306	Mus musculus KRN TCR Tg	1439	null
-21-83 years old	9606	Homo sapiens (human)	1440	21-83 years old
-4 to 8 weeks old	10000000	Mus musculus BALB/c	1441	4 to 8 weeks old
-38	9606	Homo sapiens (human)	1442	38
-24 to 32 years	9606	Homo sapiens (human)	1443	24 to 32 years
-12-14 weeks	10000598	Mus musculus HLA-DQ8 Tg	1444	12-14 weeks
-12-14 weeks	10000607	Mus musculus HLA-DR3 Tg	1445	12-14 weeks
-2 to 3 months	10000649	Mus musculus SJL	1446	2 to 3 months
-19-32 years	10000119	Homo sapiens Caucasian	1447	19-32 years
-8 months	10001240	Mus musculus APPsw	1448	8 months
-31-88 years	9606	Homo sapiens (human)	1449	31-88 years
-3 weeks	10000635	Mus musculus NOD/Lt	1450	3 weeks
-15-20 weeks	10000632	Mus musculus NOD	1451	15-20 weeks
-5-9 weeks	10000635	Mus musculus NOD/Lt	1452	5-9 weeks
-8 week old	10000632	Mus musculus NOD	1453	8 week old
-10 weeks	10000000	Mus musculus BALB/c	1454	10 weeks
-adult	9685	Felis catus (cat)	1455	adult
-NULL	10000218	Mus musculus C57BL/6 X C3H	1456	null
-10-15 weeks	10001327	Mus musculus PL/J X SJL	1457	10-15 weeks
-4-8 weeks	10000275	Mus musculus B10.RIII	1458	4-8 weeks
-39-46 years old	9606	Homo sapiens (human)	1459	39-46 years old
-45 years old	9606	Homo sapiens (human)	1460	45 years old
-8 to 10 weeks	10001133	Rattus norvegicus DA	1461	8 to 10 weeks
-6-12 weeks	10000228	Mus musculus CBA	1462	6-12 weeks
-4-8 weeks	10000263	Mus musculus B10.BR	1463	4-8 weeks
-39 years old	9606	Homo sapiens (human)	1464	39 years old
-2 months	10000649	Mus musculus SJL	1465	2 months
-4 to 5 weeks	10000067	Mus musculus C57BL/6	1466	4 to 5 weeks
-8-10 weeks	10000095	Mus musculus C57BL/6 IFNgamma null	1467	8-10 weeks
-45-52	9606	Homo sapiens (human)	1468	45-52
-6 to 8 weeks old	10001248	Mus musculus NOD.Cg-Tg	1469	6 to 8 weeks old
-6 -10 weeks old	10000067	Mus musculus C57BL/6	1470	6 -10 weeks old
-5 to 6 weeks	10000662	Rattus norvegicus Lewis	1471	5 to 6 weeks
-10-14 weeks old	10001332	Rattus norvegicus LEW.1AV1	1472	10-14 weeks old
-4-8 weeks	10001135	Mus musculus B10.HTG	1473	4-8 weeks
-8-10 weeks	10000973	Mus musculus 129	1474	8-10 weeks
-37–62 years	9606	Homo sapiens (human)	1475	3762 years
-1-18 years old	9606	Homo sapiens (human)	1476	1-18 years old
-1-55 years old	9606	Homo sapiens (human)	1477	1-55 years old
-12-20	10001537	Mus musculus PL	1478	12-20
-10-14 weeks old	10001333	Rattus norvegicus LEW.1N	1479	10-14 weeks old
-41–64 years	9606	Homo sapiens (human)	1480	4164 years
-30-78 years old	9606	Homo sapiens (human)	1481	30-78 years old
-7-10 weeks	10000054	Mus musculus DBA/1	1482	7-10 weeks
-NULL	10001062	Mus musculus HLA-A*24:02 Tg	1483	null
-5 weeks	10000649	Mus musculus SJL	1484	5 weeks
-48 years old	9606	Homo sapiens (human)	1485	48 years old
-12-14 weeks	10000597	Mus musculus HLA-DQ6 Tg	1486	12-14 weeks
-24-39 years	9606	Homo sapiens (human)	1487	24-39 years
-4 to 6 months	10001287	Mus musculus DBA/1 X B10.Q	1488	4 to 6 months
-12-23 weeks	10000632	Mus musculus NOD	1489	12-23 weeks
-2-6 months	10000598	Mus musculus HLA-DQ8 Tg	1490	2-6 months
-4-8 weeks	10001019	Mus musculus B10.D2	1491	4-8 weeks
-17-66 years old	9606	Homo sapiens (human)	1492	17-66 years old
-NULL	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	1493	null
-NULL	10001245	Mus musculus B10.H2g7	1494	null
-Adult (avg. age = 30.8 years)	9606	Homo sapiens (human)	1495	adult (avg. age = 30.8 years)
-27-66 years	9606	Homo sapiens (human)	1496	27-66 years
-21-56 years	9606	Homo sapiens (human)	1497	21-56 years
-8 to 12 weeks	10001537	Mus musculus PL	1498	8 to 12 weeks
-29-76 years old	9606	Homo sapiens (human)	1499	29-76 years old
-20-55 years old	9606	Homo sapiens (human)	1500	20-55 years old
-28-35 years	9606	Homo sapiens (human)	1501	28-35 years
-<18 hours	10001165	Mus musculus C57BR/cdJ	1502	<18 hours
-8-12 weeks	10000055	Mus musculus DBA/2	1503	8-12 weeks
-5 - 8 weeks	10000025	Mus musculus Biozzi AB/H	1504	5 - 8 weeks
-NULL	10001470	Mus musculus Factor VIII null	1505	null
-49 years	9606	Homo sapiens (human)	1506	49 years
-4-6 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1507	4-6 weeks
-10 - 15 years	9544	Macaca mulatta (rhesus macaque)	1508	10 - 15 years
-4 weeks old	10000632	Mus musculus NOD	1509	4 weeks old
-6-8 weeks	10000274	Mus musculus B10.PL	1510	6-8 weeks
-25-68 years old	9606	Homo sapiens (human)	1511	25-68 years old
-NULL	10001331	Mus musculus SJL X B10.PL	1512	null
-26-60 years	9606	Homo sapiens (human)	1513	26-60 years
-8 to 10 weeks	10000595	Mus musculus HLA-B7 Tg	1514	8 to 10 weeks
-7 to 15 weeks	10090	Mus musculus (mouse)	1515	7 to 15 weeks
-7 to 15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1516	7 to 15 weeks
-NULL	10001291	Mus musculus CBA/Igb	1517	null
-6-35 weeks	10000061	Mus musculus FVB	1518	6-35 weeks
-8-12 weeks	10000601	Mus musculus HLA-DR1 Tg	1519	8-12 weeks
-5-10 weeks	10000000	Mus musculus BALB/c	1520	5-10 weeks
-37-74 years	9606	Homo sapiens (human)	1521	37-74 years
-7-10 weeks	10000258	Mus musculus B10.A(2R)	1522	7-10 weeks
-5-8 weeks old	10000582	Mus musculus HLA-A2 Tg	1523	5-8 weeks old
-24 hours after birth	10000274	Mus musculus B10.PL	1524	24 hours after birth
-38-57 years	9606	Homo sapiens (human)	1525	38-57 years
-27-44 years	9606	Homo sapiens (human)	1526	27-44 years
-6-12 weeks	10000649	Mus musculus SJL	1527	6-12 weeks
-60 years	9606	Homo sapiens (human)	1528	60 years
-3 weeks	10001266	Mus musculus NOD/Caj	1529	3 weeks
-NULL	10001273	Cavia porcellus Strain 13	1530	null
-7-11 weeks	10000274	Mus musculus B10.PL	1531	7-11 weeks
-6 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1532	6 to 8 weeks
-8-10 weeks	10000274	Mus musculus B10.PL	1533	8-10 weeks
-NULL	10002202	Mus musculus BDC12-4.1 beta-chain TCR Tg	1534	null
-NULL	10000032	Mus musculus C3H.Q	1535	null
-8 weeks	10000274	Mus musculus B10.PL	1536	8 weeks
-39-47 years old	9606	Homo sapiens (human)	1537	39-47 years old
-5 to 7 weeks	10000067	Mus musculus C57BL/6	1538	5 to 7 weeks
-19-25	9606	Homo sapiens (human)	1539	19-25
-19-26	9606	Homo sapiens (human)	1540	19-26
-NULL	10001327	Mus musculus PL/J X SJL	1541	null
-37-53 years old	9606	Homo sapiens (human)	1542	37-53 years old
-Children (avg. age = 9.5 years)	9606	Homo sapiens (human)	1543	children (avg. age = 9.5 years)
->27 weeks	10000632	Mus musculus NOD	1544	>27 weeks
-8-10 weeks	10000055	Mus musculus DBA/2	1545	8-10 weeks
-6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1546	6 weeks
-31-57 years	9606	Homo sapiens (human)	1547	31-57 years
-3 to 5 months	10001331	Mus musculus SJL X B10.PL	1548	3 to 5 months
-NULL	10001272	Cavia porcellus Strain 2	1549	null
-14-49 years	9606	Homo sapiens (human)	1550	14-49 years
-NULL	10000013	Mus musculus BALB/c X A/J	1551	null
-8-12 weeks	10000275	Mus musculus B10.RIII	1552	8-12 weeks
-31-76 years	9606	Homo sapiens (human)	1553	31-76 years
-21-31 years	9606	Homo sapiens (human)	1554	21-31 years
-6-10 weeks	10000228	Mus musculus CBA	1555	6-10 weeks
-6-12 weeks	10001537	Mus musculus PL	1556	6-12 weeks
-8-12 weeks	10001332	Rattus norvegicus LEW.1AV1	1557	8-12 weeks
-39	9606	Homo sapiens (human)	1558	39
-6-8 weeks	10001365	Mus musculus Clone 19 TCR Tg	1559	6-8 weeks
-53 to 71 years	9606	Homo sapiens (human)	1560	53 to 71 years
-4-5 weeks	10001133	Rattus norvegicus DA	1561	4-5 weeks
-4 months	10001240	Mus musculus APPsw	1562	4 months
-31 years old	9606	Homo sapiens (human)	1563	31 years old
-8-12 weeks	10001337	Rattus norvegicus LEWIS.1W	1564	8-12 weeks
-21-27 years	9606	Homo sapiens (human)	1565	21-27 years
-NULL	10000975	Mus musculus FVB Db Tg	1566	null
-14-46 years	9606	Homo sapiens (human)	1567	14-46 years
-8-10 weeks	10000610	Mus musculus HLA-DR4 Tg	1568	8-10 weeks
-8-12 weeks	10000610	Mus musculus HLA-DR4 Tg	1569	8-12 weeks
-8 to 12 week	10000576	Mus musculus HLA-A*02:01 Tg	1570	8 to 12 week
-18 to 70 years	9606	Homo sapiens (human)	1571	18 to 70 years
-20-78 years	9606	Homo sapiens (human)	1572	20-78 years
-18-71 years	9606	Homo sapiens (human)	1573	18-71 years
-22-76 years	9606	Homo sapiens (human)	1574	22-76 years
-30-72 years	9606	Homo sapiens (human)	1575	30-72 years
-NULL	10001288	Mus musculus MMC-1 (collagen mutant)	1576	null
-NULL	10000973	Mus musculus 129	1577	null
-4-12 weeks	10000067	Mus musculus C57BL/6	1578	4-12 weeks
-57.1-70.1 years	9606	Homo sapiens (human)	1579	57.1-70.1 years
-6-12 weeks	10000263	Mus musculus B10.BR	1580	6-12 weeks
-8-12 weeks	10000054	Mus musculus DBA/1	1581	8-12 weeks
-8-12 weeks	10001299	Mus musculus HLA-DRB1*04:02 Tg	1582	8-12 weeks
-NULL	9925	Capra hircus (domestic goat)	1583	null
-6 weeks	10002837	Mus musculus HLA-DQA1*05:01/DQB1*02:01 Tg	1584	6 weeks
-14-86 years	9606	Homo sapiens (human)	1585	14-86 years
-30-74 years	9606	Homo sapiens (human)	1586	30-74 years
-18-49 years	9606	Homo sapiens (human)	1587	18-49 years
-31 years	9606	Homo sapiens (human)	1588	31 years
-NULL	10001311	Mus musculus HH8 TCR Tg	1589	null
-30-83 years	9606	Homo sapiens (human)	1590	30-83 years
-19-95 years	9606	Homo sapiens (human)	1591	19-95 years
-neonates	10000663	Rattus norvegicus LOU	1592	neonates
-mean age 31 years	9606	Homo sapiens (human)	1593	mean age 31 years
-8 weeks or older	10000000	Mus musculus BALB/c	1594	8 weeks or older
-26-34 years	9606	Homo sapiens (human)	1595	26-34 years
-8-12 weeks	10001537	Mus musculus PL	1596	8-12 weeks
-26 to 53 years	9606	Homo sapiens (human)	1597	26 to 53 years
-27-62 years	9606	Homo sapiens (human)	1598	27-62 years
-14-44 years	9606	Homo sapiens (human)	1599	14-44 years
-5-12 weeks	10000000	Mus musculus BALB/c	1600	5-12 weeks
-18 to 59 years old	9606	Homo sapiens (human)	1601	18 to 59 years old
-6 to 12 weeks	10000233	Mus musculus CBA/Ca	1602	6 to 12 weeks
-1 year	10001097	Sus scrofa Yorkshire	1603	1 year
-14-26 years	9606	Homo sapiens (human)	1604	14-26 years
-8 to 12 weeks old	10000275	Mus musculus B10.RIII	1605	8 to 12 weeks old
-16-24 years	9606	Homo sapiens (human)	1606	16-24 years
-6-9 weeks	10000662	Rattus norvegicus Lewis	1607	6-9 weeks
-4-6 weeks	10001041	Rattus norvegicus Wistar	1608	4-6 weeks
-NULL	10001321	Rattus norvegicus DR-BB/Wor	1609	null
-NULL	10000231	Mus musculus CBA X BALB/c	1610	null
-8-10 weeks	10001291	Mus musculus CBA/Igb	1611	8-10 weeks
-8-10 weeks	10000064	Mus musculus C57BL/10.Q	1612	8-10 weeks
-20 weeks old	10000632	Mus musculus NOD	1613	20 weeks old
-22-84 years	9606	Homo sapiens (human)	1614	22-84 years
-21-72 years	9606	Homo sapiens (human)	1615	21-72 years
-29-55	9606	Homo sapiens (human)	1616	29-55
-5.5-7.5 months	10001240	Mus musculus APPsw	1617	5.5-7.5 months
-7 weeks	10000662	Rattus norvegicus Lewis	1618	7 weeks
-8-12 weeks	10001287	Mus musculus DBA/1 X B10.Q	1619	8-12 weeks
-19-48	9606	Homo sapiens (human)	1620	19-48
-7-12 weeks	10000032	Mus musculus C3H.Q	1621	7-12 weeks
-34-60 years old	9606	Homo sapiens (human)	1622	34-60 years old
-34-58 years	9606	Homo sapiens (human)	1623	34-58 years
-10-12 weeks	10000054	Mus musculus DBA/1	1624	10-12 weeks
-13 days	10000236	Mus musculus CBA/J	1625	13 days
-7-12 weeks	10000038	Mus musculus C3H/He	1626	7-12 weeks
-7-12 weeks	10000000	Mus musculus BALB/c	1627	7-12 weeks
-6 to 12 weeks	10001314	Mus musculus HPV 16 E7 Tg	1628	6 to 12 weeks
-NULL	10000663	Rattus norvegicus LOU	1629	null
-8-12 weeks	10000274	Mus musculus B10.PL	1630	8-12 weeks
-3 to 21 years	9555	Papio anubis (Doguera baboon)	1631	3 to 21 years
-23-69 years	9606	Homo sapiens (human)	1632	23-69 years
-26-52 years	9606	Homo sapiens (human)	1633	26-52 years
-NULL	9986	Oryctolagus cuniculus (rabbit)	1634	null
-2 months	10141	Cavia porcellus (guinea pig)	1635	2 months
-NULL	10001302	Mus musculus qCII85.33 TCR Tg	1636	null
-8-11 weeks	10000662	Rattus norvegicus Lewis	1637	8-11 weeks
-3 - 4 weeks	10000632	Mus musculus NOD	1638	3 - 4 weeks
-23-53	9606	Homo sapiens (human)	1639	23-53
-24-36	9606	Homo sapiens (human)	1640	24-36
-8-16 weeks	10000032	Mus musculus C3H.Q	1641	8-16 weeks
-3 month	10000649	Mus musculus SJL	1642	3 month
-2-4 months	10000610	Mus musculus HLA-DR4 Tg	1643	2-4 months
-57 years	9606	Homo sapiens (human)	1644	57 years
-16 - 24 weeks old	10000632	Mus musculus NOD	1645	16 - 24 weeks old
-2 to 4 months	10000649	Mus musculus SJL	1646	2 to 4 months
-median age 28 years	9606	Homo sapiens (human)	1647	median age 28 years
-7 weeks	10000032	Mus musculus C3H.Q	1648	7 weeks
-3-20 weeks	10000632	Mus musculus NOD	1649	3-20 weeks
-12-16 weeks	10001244	Mus musculus NOR	1650	12-16 weeks
-16-46 years	9606	Homo sapiens (human)	1651	16-46 years
-15	9606	Homo sapiens (human)	1652	15
-6 months	10000000	Mus musculus BALB/c	1653	6 months
-28-39 years	9606	Homo sapiens (human)	1654	28-39 years
-33-50 years	9606	Homo sapiens (human)	1655	33-50 years
-25-60 years	9606	Homo sapiens (human)	1656	25-60 years
-25-72 years	9606	Homo sapiens (human)	1657	25-72 years
-39-82 years	9606	Homo sapiens (human)	1658	39-82 years
-10-12 weeks	10001277	Mus musculus NOD-Ealpha Tg	1659	10-12 weeks
-4-7 weeks	10000632	Mus musculus NOD	1660	4-7 weeks
-4 - 5 weeks	10000632	Mus musculus NOD	1661	4 - 5 weeks
-5-7 weeks old	10000632	Mus musculus NOD	1662	5-7 weeks old
-36-65 years	9606	Homo sapiens (human)	1663	36-65 years
-4.5 - 6 months	10001241	Mus musculus APP	1664	4.5 - 6 months
-5-7 weeks	10000632	Mus musculus NOD	1665	5-7 weeks
-2-3 months	10001537	Mus musculus PL	1666	2-3 months
-2-3 months	10000649	Mus musculus SJL	1667	2-3 months
-5 weeks	10001241	Mus musculus APP	1668	5 weeks
-43-65	9606	Homo sapiens (human)	1669	43-65
-6-8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	1670	6-8 weeks
-18-36 years	9606	Homo sapiens (human)	1671	18-36 years
-2-4 months	10001041	Rattus norvegicus Wistar	1672	2-4 months
-12-16 months	10001241	Mus musculus APP	1673	12-16 months
-7-12 weeks	10001288	Mus musculus MMC-1 (collagen mutant)	1674	7-12 weeks
-7-9 weeks	10000662	Rattus norvegicus Lewis	1675	7-9 weeks
-8-14 weeks	10001300	Rattus norvegicus WA/KIR/kcl	1676	8-14 weeks
-NULL	10001298	Mus musculus insulin 2 null	1677	null
-6 to 8 weeks	10000610	Mus musculus HLA-DR4 Tg	1678	6 to 8 weeks
-7 weeks	10000067	Mus musculus C57BL/6	1679	7 weeks
-15-20 weeks	10000635	Mus musculus NOD/Lt	1680	15-20 weeks
-7 weeks	10001288	Mus musculus MMC-1 (collagen mutant)	1681	7 weeks
-neonate	10000054	Mus musculus DBA/1	1682	neonate
-Mean age 65 years	9606	Homo sapiens (human)	1683	mean age 65 years
-8 to 12 weeks	10000054	Mus musculus DBA/1	1684	8 to 12 weeks
-8-12 weeks	10001300	Rattus norvegicus WA/KIR/kcl	1685	8-12 weeks
-8 to 12 weeks old	10000054	Mus musculus DBA/1	1686	8 to 12 weeks old
-8-12 weeks.	10001356	Mus musculus MBP 84-105 HEL Tg	1687	8-12 weeks.
-10 to 12 weeks old	10000047	Mus musculus C57BL/10	1688	10 to 12 weeks old
-36-39 years	9606	Homo sapiens (human)	1689	36-39 years
-4-7 weeks old	10001248	Mus musculus NOD.Cg-Tg	1690	4-7 weeks old
-Neonate and adult	9606	Homo sapiens (human)	1691	neonate and adult
-52-89 years	9606	Homo sapiens (human)	1692	52-89 years
-50 years old	9606	Homo sapiens (human)	1693	50 years old
-8-24 weeks	10000067	Mus musculus C57BL/6	1694	8-24 weeks
-8-20 weeks	10000000	Mus musculus BALB/c	1695	8-20 weeks
-<70 years	9606	Homo sapiens (human)	1696	<70 years
-56 years	9606	Homo sapiens (human)	1697	56 years
-8 to 14 weeks	10001537	Mus musculus PL	1698	8 to 14 weeks
-8 to 24 weeks	10000067	Mus musculus C57BL/6	1699	8 to 24 weeks
-6 weeks	10000061	Mus musculus FVB	1700	6 weeks
-16-75 years	9606	Homo sapiens (human)	1701	16-75 years
-embryo	9031	Gallus gallus (chicken)	1702	embryo
-NULL	10001313	Mus musculus GAD65 p206 TCR Tg	1703	null
-8-36 years	9606	Homo sapiens (human)	1704	8-36 years
-8-53 years	9606	Homo sapiens (human)	1705	8-53 years
-20-27 years	9606	Homo sapiens (human)	1706	20-27 years
-3 to 5 months	10000206	Oryctolagus cuniculus New Zealand White	1707	3 to 5 months
-8 to 12 weeks	10000275	Mus musculus B10.RIII	1708	8 to 12 weeks
-18-86 years	9606	Homo sapiens (human)	1709	18-86 years
-21-67 years	9606	Homo sapiens (human)	1710	21-67 years
-4-5 weeks	10000649	Mus musculus SJL	1711	4-5 weeks
-26-59 years old	9606	Homo sapiens (human)	1712	26-59 years old
-8 to 20 weeks	10000274	Mus musculus B10.PL	1713	8 to 20 weeks
-6-12 weeks	10001329	Mus musculus PL/J X B10.PL	1714	6-12 weeks
-5-16 years	9606	Homo sapiens (human)	1715	5-16 years
-7 to 10 weeks	10000025	Mus musculus Biozzi AB/H	1716	7 to 10 weeks
-33 years	9606	Homo sapiens (human)	1717	33 years
-2-6 months	10036	Mesocricetus auratus (Syrian golden hamster)	1718	2-6 months
-6 weeks	10001314	Mus musculus HPV 16 E7 Tg	1719	6 weeks
-7-10 weeks	10000263	Mus musculus B10.BR	1720	7-10 weeks
-7-10 weeks	10001019	Mus musculus B10.D2	1721	7-10 weeks
-60-62 years	9606	Homo sapiens (human)	1722	60-62 years
-68 years	9606	Homo sapiens (human)	1723	68 years
-18-70	9606	Homo sapiens (human)	1724	18-70
-5-6 weeks	10000094	Mus musculus C57BL/6 IAbeta null	1725	5-6 weeks
-8 to 10 weeks	10000582	Mus musculus HLA-A2 Tg	1726	8 to 10 weeks
-10 to 14 weeks	10000000	Mus musculus BALB/c	1727	10 to 14 weeks
-7-78 years	9606	Homo sapiens (human)	1728	7-78 years
-8 to 10 weeks	10001166	Mus musculus HLA-A24 Tg	1729	8 to 10 weeks
-NULL	10000002	Mus musculus BALB/c beta2m null	1730	null
-25-55 years	9606	Homo sapiens (human)	1731	25-55 years
-~ 31 to 55 years	9606	Homo sapiens (human)	1732	~ 31 to 55 years
-15 weeks	10000632	Mus musculus NOD	1733	15 weeks
-8-12 wk	10000038	Mus musculus C3H/He	1734	8-12 week
-NULL	9521	Saimiri sciureus (South American squirrel monkey)	1735	null
-8-12 weeks	10000108	Mus musculus C57BL/6 X B10.D2	1736	8-12 weeks
-8-10 weeks old	10000228	Mus musculus CBA	1737	8-10 weeks old
-6-8 weeks	10000055	Mus musculus DBA/2	1738	6-8 weeks
-NULL	NULL	NULL	1739	null
-18 weeks	10000637	Mus musculus NODasp	1740	18 weeks
-6-10 weeks	10000271	Mus musculus B10.M	1741	6-10 weeks
-5 to 6 weeks	10000067	Mus musculus C57BL/6	1742	5 to 6 weeks
-8 week old	10000000	Mus musculus BALB/c	1743	8 week old
-NULL	10000673	Mus musculus F1sc H-2b scid chimera	1744	null
-46-48 yrs	9606	Homo sapiens (human)	1745	46-48 years
-4-week old	10000649	Mus musculus SJL	1746	4-week old
-4-8 weeks	10000038	Mus musculus C3H/He	1747	4-8 weeks
-18-50 years-old	9606	Homo sapiens (human)	1748	18-50 years-old
-8-12 weeks old	10000641	Mus musculus OF1	1749	8-12 weeks old
-52-59 years	9606	Homo sapiens (human)	1750	52-59 years
-< 12 hours	10000000	Mus musculus BALB/c	1751	< 12 hours
-5 weeks	10001634	Mus musculus IFNR null	1752	5 weeks
-18-40 years	9606	Homo sapiens (human)	1753	18-40 years
-8 Week	10000067	Mus musculus C57BL/6	1754	8 week
-6-8 weeks	10000283	Mus musculus B6.129S2-Cd28tm1Mak	1755	6-8 weeks
-28 to 68 years	9606	Homo sapiens (human)	1756	28 to 68 years
-6 to 8 weeks	10000582	Mus musculus HLA-A2 Tg	1757	6 to 8 weeks
-8 wk.	10000216	Mus musculus C57BL/6 X BALB/c	1758	8 week.
-8-15 weeks	10000038	Mus musculus C3H/He	1759	8-15 weeks
-1 day	10000000	Mus musculus BALB/c	1760	1 day
-39-63 years	9606	Homo sapiens (human)	1761	39-63 years
-11 to 74 months	9606	Homo sapiens (human)	1762	11 to 74 months
-adult	10000047	Mus musculus C57BL/10	1763	adult
-6-8 weeks	10000655	Mus musculus Swiss Webster	1764	6-8 weeks
-18-38 years	9606	Homo sapiens (human)	1765	18-38 years
-57-62 years	9606	Homo sapiens (human)	1766	57-62 years
-3-14 years	9606	Homo sapiens (human)	1767	3-14 years
-63 years	9606	Homo sapiens (human)	1768	63 years
-10 to 12 weeks	10000000	Mus musculus BALB/c	1769	10 to 12 weeks
-38 years	9606	Homo sapiens (human)	1770	38 years
-20-64 years	9606	Homo sapiens (human)	1771	20-64 years
-6-8 wk.	10000067	Mus musculus C57BL/6	1772	6-8 week.
-NULL	9823	Sus scrofa (pig)	1773	null
-Adults (15-44)	9606	Homo sapiens (human)	1774	adults (15-44)
-8 to 12 weeks	10001166	Mus musculus HLA-A24 Tg	1775	8 to 12 weeks
-8-14 wk	10000607	Mus musculus HLA-DR3 Tg	1776	8-14 week
-19-77 years	9606	Homo sapiens (human)	1777	19-77 years
-4-6 weeks	10000019	Mus musculus BALB/cByJ	1778	4-6 weeks
-23-67 years	9606	Homo sapiens (human)	1779	23-67 years
-47-65 years	9606	Homo sapiens (human)	1780	47-65 years
-18-63 years old	9606	Homo sapiens (human)	1781	18-63 years old
-26-63 years	9606	Homo sapiens (human)	1782	26-63 years
-36 years old	9606	Homo sapiens (human)	1783	36 years old
-4-week old	10000271	Mus musculus B10.M	1784	4-week old
-19-53 years	10000119	Homo sapiens Caucasian	1785	19-53 years
-25-31 years	9606	Homo sapiens (human)	1786	25-31 years
-2 months old	10000000	Mus musculus BALB/c	1787	2 months old
-7-8 weeks	10000236	Mus musculus CBA/J	1788	7-8 weeks
-8-10 weeks-old	10000284	Mus musculus B6.129S2-Igh-6tm1Cgn	1789	8-10 weeks-old
-8-24 weeks old	10000028	Mus musculus C3H	1790	8-24 weeks old
-6-7 weeks	10001634	Mus musculus IFNR null	1791	6-7 weeks
-40 years	9606	Homo sapiens (human)	1792	40 years
-Calves	9913	Bos taurus (bovine)	1793	calves
-6-10 weeks	42414	Sigmodon (cotton rat)	1794	6-10 weeks
-3 to 6 months	10000187	Sus scrofa Landrace X Large White	1795	3 to 6 months
-Newborns	9606	Homo sapiens (human)	1796	newborns
-2 months old	10000187	Sus scrofa Landrace X Large White	1797	2 months old
-8-10 weeks	10000258	Mus musculus B10.A(2R)	1798	8-10 weeks
-8-10 weeks	10000028	Mus musculus C3H	1799	8-10 weeks
-12 months old	10000190	Bos taurus Friesian	1800	12 months old
-Adult	9796	Equus caballus (domestic horse)	1801	adult
-Adult	10000917	Equus caballus Arabian	1802	adult
-4 weeks	10000038	Mus musculus C3H/He	1803	4 weeks
-29-82 years	9606	Homo sapiens (human)	1804	29-82 years
-NULL	10000654	Mus musculus Swiss albino	1805	null
-mean age 34.4 years	9606	Homo sapiens (human)	1806	mean age 34.4 years
-3 weeks	10000228	Mus musculus CBA	1807	3 weeks
-4-6 weeks	10000263	Mus musculus B10.BR	1808	4-6 weeks
-4-6 weeks old	10000649	Mus musculus SJL	1809	4-6 weeks old
-6-10 weeks old	10000228	Mus musculus CBA	1810	6-10 weeks old
-2-3 months	10000576	Mus musculus HLA-A*02:01 Tg	1811	2-3 months
-7-8 weeks old	10000649	Mus musculus SJL	1812	7-8 weeks old
-NULL	10001119	Mus musculus BA	1813	null
-19 to 56 years	9606	Homo sapiens (human)	1814	19 to 56 years
-11-19 years	9544	Macaca mulatta (rhesus macaque)	1815	11-19 years
-4-5 months	9940	Ovis aries (domestic sheep)	1816	4-5 months
-6-8 weeks	10000261	Mus musculus B10.A(5R)	1817	6-8 weeks
-NULL	10001024	Mus musculus CE/J	1818	null
-6-8 weeks	10000061	Mus musculus FVB	1819	6-8 weeks
-22-45 years	9606	Homo sapiens (human)	1820	22-45 years
-9-12 months	10000190	Bos taurus Friesian	1821	9-12 months
-6-10 weeks	10001122	Mus musculus µMT	1822	6-10 weeks
-6-8	10000649	Mus musculus SJL	1823	6-8
-6-8	10000062	Mus musculus FVB/J	1824	6-8
-5-16 weeks old	10000067	Mus musculus C57BL/6	1825	5-16 weeks old
-6-8	10000053	Mus musculus DBA	1826	6-8
-18-50 years old	9606	Homo sapiens (human)	1827	18-50 years old
-NULL	10000914	Mus musculus TO	1828	null
-> 6 months	10000190	Bos taurus Friesian	1829	> 6 months
-NULL	10000917	Equus caballus Arabian	1830	null
-9-12 months old	10000190	Bos taurus Friesian	1831	9-12 months old
-6-12 weeks	10001019	Mus musculus B10.D2	1832	6-12 weeks
-6-12 weeks	10000047	Mus musculus C57BL/10	1833	6-12 weeks
-6-12 weeks	10000261	Mus musculus B10.A(5R)	1834	6-12 weeks
-6-12 weeks	10000278	Mus musculus B10.S(9R)	1835	6-12 weeks
-40-60 years	9606	Homo sapiens (human)	1836	40-60 years
-6-8 weeks	10001019	Mus musculus B10.D2	1837	6-8 weeks
-0.8 years	10000194	Bos taurus Holstein-Friesian	1838	0.8 years
-4.1-15.2 years	9606	Homo sapiens (human)	1839	4.1-15.2 years
-2 years	10000917	Equus caballus Arabian	1840	2 years
-4 wk - 3 mo	10000000	Mus musculus BALB/c	1841	4 week - 3 month
-4-8 weeks	10000919	Gallus gallus White Leghorn	1842	4-8 weeks
-1 year	10000194	Bos taurus Holstein-Friesian	1843	1 year
-3-8 years	10000194	Bos taurus Holstein-Friesian	1844	3-8 years
-23-43 years	9606	Homo sapiens (human)	1845	23-43 years
-5 weeks	10000662	Rattus norvegicus Lewis	1846	5 weeks
-6-10 weeks	10000973	Mus musculus 129	1847	6-10 weeks
-41-68 years	9606	Homo sapiens (human)	1848	41-68 years
-5-7 weeks	10000228	Mus musculus CBA	1849	5-7 weeks
-9 weeks	10000028	Mus musculus C3H	1850	9 weeks
-mean age = 30 years	9606	Homo sapiens (human)	1851	mean age = 30 years
-4 weeks-old	10000662	Rattus norvegicus Lewis	1852	4 weeks-old
-60-90 days	10000000	Mus musculus BALB/c	1853	60-90 days
-6-12 weeks	10000260	Mus musculus B10.A(4R)	1854	6-12 weeks
-26-80 years	9606	Homo sapiens (human)	1855	26-80 years
-11 weeks	10000025	Mus musculus Biozzi AB/H	1856	11 weeks
-8-9 weeks	10000000	Mus musculus BALB/c	1857	8-9 weeks
-9 weeks	10000000	Mus musculus BALB/c	1858	9 weeks
-2-5 years	9685	Felis catus (cat)	1859	2-5 years
-6 month-old	10000193	Bos taurus Holstein	1860	6 month-old
-8-14 weeks	10000065	Mus musculus C57BL/10SnJ	1861	8-14 weeks
-8-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1862	8-10 weeks
-6-8 weeks	10000289	Mus musculus BALB.B	1863	6-8 weeks
-4-6 months	10000194	Bos taurus Holstein-Friesian	1864	4-6 months
-3-4 weeks old	10000228	Mus musculus CBA	1865	3-4 weeks old
-8 weeks	10000290	Mus musculus BALB.K	1866	8 weeks
-8 weeks	10001998	Mus musculus CD1	1867	8 weeks
-8 weeks to 6 months	10000253	Mus musculus A/J	1868	8 weeks to 6 months
-8 weeks to 6 months	10000067	Mus musculus C57BL/6	1869	8 weeks to 6 months
-8 weeks to 6 months	10000000	Mus musculus BALB/c	1870	8 weeks to 6 months
-10 weeks	10000067	Mus musculus C57BL/6	1871	10 weeks
-8 weeks	10000236	Mus musculus CBA/J	1872	8 weeks
-8 weeks	10000260	Mus musculus B10.A(4R)	1873	8 weeks
-20-83 years	9606	Homo sapiens (human)	1874	20-83 years
-6 weeks	10001068	Mus musculus C57/BL/6 LCMV NP Tg	1875	6 weeks
-24-47 years	9606	Homo sapiens (human)	1876	24-47 years
-8 to 14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1877	8 to 14 weeks
-8 to 14 weeks	10002763	Mus musculus HLA-A*11:01 Tg	1878	8 to 14 weeks
-8-15 weeks	10000000	Mus musculus BALB/c	1879	8-15 weeks
-8-12 weeks	10000582	Mus musculus HLA-A2 Tg	1880	8-12 weeks
-4-6 wks	10000067	Mus musculus C57BL/6	1881	4-6 weeks
-8 to 14 weeks	10002852	Mus musculus HLA-A1 Tg	1882	8 to 14 weeks
-42.8-66.5 years	9606	Homo sapiens (human)	1883	42.8-66.5 years
-20 to 79 years	9606	Homo sapiens (human)	1884	20 to 79 years
-6-10 weeks	10000028	Mus musculus C3H	1885	6-10 weeks
-NULL	10001072	Mus musculus (A/Sn x CBA)F1	1886	null
-3 weeks	10000625	Mus musculus MRL	1887	3 weeks
-3 weeks	10000263	Mus musculus B10.BR	1888	3 weeks
-8 to 14 weeks	10001782	Mus musculus HLA-B*07:02 Tg	1889	8 to 14 weeks
-8 to 14 weeks	10001062	Mus musculus HLA-A*24:02 Tg	1890	8 to 14 weeks
-8 to 14 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1891	8 to 14 weeks
-6-8weeks	10000000	Mus musculus BALB/c	1892	6-8weeks
-8 to 10 weeks	10000601	Mus musculus HLA-DR1 Tg	1893	8 to 10 weeks
-5-8 weeks	10001090	Mus musculus YA26 TCR Tg	1894	5-8 weeks
-12 weeks	10000228	Mus musculus CBA	1895	12 weeks
-16 weeks	10000582	Mus musculus HLA-A2 Tg	1896	16 weeks
-65-74 years old	9606	Homo sapiens (human)	1897	65-74 years old
-74 years old	9606	Homo sapiens (human)	1898	74 years old
-20-57 years	9606	Homo sapiens (human)	1899	20-57 years
-5-8 weeks	10001363	Mus musculus 2D2 TCR Tg	1900	5-8 weeks
-10-14 weeks	10000632	Mus musculus NOD	1901	10-14 weeks
-3-4 weeks	10000067	Mus musculus C57BL/6	1902	3-4 weeks
-44.9 to 74.1 years	9606	Homo sapiens (human)	1903	44.9 to 74.1 years
-6 weeks	10000054	Mus musculus DBA/1	1904	6 weeks
-NULL	9483	Callithrix jacchus (common marmoset)	1905	null
-32-70 years	9606	Homo sapiens (human)	1906	32-70 years
-37-66 years	9606	Homo sapiens (human)	1907	37-66 years
-8 weeks old	10000067	Mus musculus C57BL/6	1908	8 weeks old
-23-81 years	9606	Homo sapiens (human)	1909	23-81 years
-12-64 years	9606	Homo sapiens (human)	1910	12-64 years
-11-18 years	9606	Homo sapiens (human)	1911	11-18 years
-23 days	10116	Rattus norvegicus (brown rat)	1912	23 days
-NULL	10000978	Mus musculus C57BL/6 X BALB/cByJ	1913	null
-6-8 weeks	10000043	Mus musculus C3HeB/FeJ	1914	6-8 weeks
-7-8 years	10000917	Equus caballus Arabian	1915	7-8 years
-NULL	10000043	Mus musculus C3HeB/FeJ	1916	null
-40 years or older	10000119	Homo sapiens Caucasian	1917	40 years or older
-21-35	9606	Homo sapiens (human)	1918	21-35
-2 months old	10000576	Mus musculus HLA-A*02:01 Tg	1919	2 months old
-NULL	10000195	Capra hircus Saanen	1920	null
-6-9 weeks	10000000	Mus musculus BALB/c	1921	6-9 weeks
-7-8 weeks	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	1922	7-8 weeks
-6 to 8 weeks	10000206	Oryctolagus cuniculus New Zealand White	1923	6 to 8 weeks
-6-8 weeks	10000009	Mus musculus BALB/c IFNgamma null	1924	6-8 weeks
-68-76	9606	Homo sapiens (human)	1925	68-76
-25-37	9606	Homo sapiens (human)	1926	25-37
-42-62 years	9606	Homo sapiens (human)	1927	42-62 years
-6-9 days	10000067	Mus musculus C57BL/6	1928	6-9 days
-NULL	9615	Canis lupus familiaris (dogs)	1929	null
-53-54 years	9606	Homo sapiens (human)	1930	53-54 years
-2 months	10000187	Sus scrofa Landrace X Large White	1931	2 months
-8 to 12-weeks	10000000	Mus musculus BALB/c	1932	8 to 12-weeks
-6-8 weeks	10000661	Rattus norvegicus Fischer 344	1933	6-8 weeks
-14-74	9606	Homo sapiens (human)	1934	14-74
-6-9 days	10000000	Mus musculus BALB/c	1935	6-9 days
-8-10 weeks	10000047	Mus musculus C57BL/10	1936	8-10 weeks
-26-79 years	9606	Homo sapiens (human)	1937	26-79 years
->45 years	9606	Homo sapiens (human)	1938	>45 years
-8-20 weeks	10000067	Mus musculus C57BL/6	1939	8-20 weeks
-24 to 46 years	9606	Homo sapiens (human)	1940	24 to 46 years
-25-73	9606	Homo sapiens (human)	1941	25-73
-24-58 years	9606	Homo sapiens (human)	1942	24-58 years
-6-8 weeks	10000016	Mus musculus BALB/c X C57BL/10	1943	6-8 weeks
-8 weeks	10000253	Mus musculus A/J	1944	8 weeks
-80 days	10000067	Mus musculus C57BL/6	1945	80 days
-52.2 - 69 years	9606	Homo sapiens (human)	1946	52.2 - 69 years
-1-12 years	10000119	Homo sapiens Caucasian	1947	1-12 years
-6 months	10000193	Bos taurus Holstein	1948	6 months
-2 months	9823	Sus scrofa (pig)	1949	2 months
-6-9 weeks	10000038	Mus musculus C3H/He	1950	6-9 weeks
-NULL	10001094	Mus musculus C57BL/6 IL-4 Tg	1951	null
-8-20 weeks	10090	Mus musculus (mouse)	1952	8-20 weeks
-over 18 years old	9606	Homo sapiens (human)	1953	over 18 years old
-14-55 years	9606	Homo sapiens (human)	1954	14-55 years
-20-51	9606	Homo sapiens (human)	1955	20-51
-6-8 weeks	10000258	Mus musculus B10.A(2R)	1956	6-8 weeks
-10-12 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	1957	10-12 weeks
-NULL	10000254	Mus musculus A/Sn	1958	null
-27 to 56 years	9606	Homo sapiens (human)	1959	27 to 56 years
-10-13 days	9823	Sus scrofa (pig)	1960	10-13 days
-6 week	10000067	Mus musculus C57BL/6	1961	6 week
-NULL	10001128	Mus musculus N15 TCR Tg	1962	null
-22-35 years old	9606	Homo sapiens (human)	1963	22-35 years old
-Newborn	10001165	Mus musculus C57BR/cdJ	1964	newborn
-15-18 months	10000191	Bos taurus Hereford	1965	15-18 months
-7.5-8 weeks	10000028	Mus musculus C3H	1966	7.5-8 weeks
-15 weeks	9615	Canis lupus familiaris (dogs)	1967	15 weeks
-8-16 weeks	10000274	Mus musculus B10.PL	1968	8-16 weeks
-19-48 years	9606	Homo sapiens (human)	1969	19-48 years
-55-60 years	9606	Homo sapiens (human)	1970	55-60 years
-8-14 weeks	10001537	Mus musculus PL	1971	8-14 weeks
-NULL	10001336	Mus musculus MS2-3C8 TCR Tg	1972	null
-60	9606	Homo sapiens (human)	1973	60
-81 years	9606	Homo sapiens (human)	1974	81 years
-8 weeks	10001537	Mus musculus PL	1975	8 weeks
-34	9606	Homo sapiens (human)	1976	34
-48 years	9606	Homo sapiens (human)	1977	48 years
-22-54 years	9606	Homo sapiens (human)	1978	22-54 years
-6 weeks	10000063	Mus musculus B10.A	1979	6 weeks
-23-45 years	9606	Homo sapiens (human)	1980	23-45 years
-6 weeks	10001019	Mus musculus B10.D2	1981	6 weeks
-6-8 weeks	10000618	Mus musculus ICR	1982	6-8 weeks
-6 weeks	10000047	Mus musculus C57BL/10	1983	6 weeks
-6 weeks	10000263	Mus musculus B10.BR	1984	6 weeks
-NULL	10001103	Mus musculus SV40 Tg	1985	null
-4 years	9606	Homo sapiens (human)	1986	4 years
-53 yrs	9606	Homo sapiens (human)	1987	53 years
-38-53	9606	Homo sapiens (human)	1988	38-53
-mean age = 27 years	9606	Homo sapiens (human)	1989	mean age = 27 years
-36-37 years	9606	Homo sapiens (human)	1990	36-37 years
-adult	10000067	Mus musculus C57BL/6	1991	adult
-NULL	10001067	Mus musculus B10.D1	1992	null
-NULL	10001066	Mus musculus B10.RIH	1993	null
-3-12 years	9796	Equus caballus (domestic horse)	1994	3-12 years
-7-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1995	7-8 weeks
-8-12 weeks	10001097	Sus scrofa Yorkshire	1996	8-12 weeks
-9-10 weeks	10001103	Mus musculus SV40 Tg	1997	9-10 weeks
-8-9 weeks	10001103	Mus musculus SV40 Tg	1998	8-9 weeks
-3 - 4 week old	10000067	Mus musculus C57BL/6	1999	3 - 4 week old
-3-5 week-old	10000000	Mus musculus BALB/c	2000	3-5 week-old
-28-58 years	9606	Homo sapiens (human)	2001	28-58 years
-1-2 years	9606	Homo sapiens (human)	2002	1-2 years
-6-18 weeks old	10000000	Mus musculus BALB/c	2003	6-18 weeks old
-32-37 years	9606	Homo sapiens (human)	2004	32-37 years
-6-16 weeks	10000067	Mus musculus C57BL/6	2005	6-16 weeks
-8-16 weeks	10001087	Mus musculus C57BL/6 bm14	2006	8-16 weeks
-NULL	10000095	Mus musculus C57BL/6 IFNgamma null	2007	null
-NULL	10001041	Rattus norvegicus Wistar	2008	null
-NULL	10001322	Oryctolagus cuniculus HLA-A2.1 Tg	2009	null
-74 years	9606	Homo sapiens (human)	2010	74 years
-16-53	9606	Homo sapiens (human)	2011	16-53
-NULL	10000101	Mus musculus C57BL/6 Perforin null	2012	null
-NULL	10001104	Mus musculus B6 TNF alpha null	2013	null
-2-8 years	10000185	Canis familiaris beagle	2014	2-8 years
-4 weeks	10000661	Rattus norvegicus Fischer 344	2015	4 weeks
-NULL	10001211	Mus musculus (C57BL/6 X A/J)	2016	null
-19-57	9606	Homo sapiens (human)	2017	19-57
-Calf	9913	Bos taurus (bovine)	2018	calf
-18-64 years	9606	Homo sapiens (human)	2019	18-64 years
-NULL	10000219	Mus musculus C57BL/6 X CBA	2020	null
-Calves and cows	9913	Bos taurus (bovine)	2021	calves and cows
-53 years	10000119	Homo sapiens Caucasian	2022	53 years
-11 weeks	10001657	Mus musculus NZW X BALB/c	2023	11 weeks
-2-6 months	10000265	Mus musculus AND TCR Tg	2024	2-6 months
-23 years old	9606	Homo sapiens (human)	2025	23 years old
-8 to 10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	2026	8 to 10 weeks
-8-12 weeks	10000219	Mus musculus C57BL/6 X CBA	2027	8-12 weeks
-8-10 weeks	10002233	Mus musculus 16.2beta TCR Tg	2028	8-10 weeks
-8-12 weeks	10001208	Mus musculus B6.C-H-2bm1	2029	8-12 weeks
-30-78	9606	Homo sapiens (human)	2030	30-78
-38-50 years	9606	Homo sapiens (human)	2031	38-50 years
-23-45 years old	9606	Homo sapiens (human)	2032	23-45 years old
-30-45 years old	9606	Homo sapiens (human)	2033	30-45 years old
-23-35 years old	9606	Homo sapiens (human)	2034	23-35 years old
-8 yr	9598	Pan troglodytes (chimpanzee)	2035	8 year
-4 weeks-old	10000919	Gallus gallus White Leghorn	2036	4 weeks-old
-6-12 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	2037	6-12 weeks
-6-12 weeks	10001214	Mus musculus B10.A(18R)	2038	6-12 weeks
-NULL	10001219	Mus musculus B10.A x A/J	2039	null
-6-12 weeks	10000258	Mus musculus B10.A(2R)	2040	6-12 weeks
-6-12 weeks	10000259	Mus musculus B10.A(3R)	2041	6-12 weeks
-6-12 weeks	10000253	Mus musculus A/J	2042	6-12 weeks
-2 months	9606	Homo sapiens (human)	2043	2 months
-50 days	10001105	Mus musculus SV11	2044	50 days
-35 to 41 years	9606	Homo sapiens (human)	2045	35 to 41 years
-47 to 53 years	9606	Homo sapiens (human)	2046	47 to 53 years
-2-3 months	10000616	Mus musculus HLA-DRB1*04:01 Tg	2047	2-3 months
-4 to 6 weeks	10000236	Mus musculus CBA/J	2048	4 to 6 weeks
-NULL	10001001	Rattus norvegicus WKAH	2049	null
-12 months	10001240	Mus musculus APPsw	2050	12 months
-8-10 weeks	10002208	Mus musculus DO11.10 TCR Tg	2051	8-10 weeks
-29 years old	9606	Homo sapiens (human)	2052	29 years old
-24 years old	9606	Homo sapiens (human)	2053	24 years old
-24-32 years old	9606	Homo sapiens (human)	2054	24-32 years old
-4-6 weeks	10000228	Mus musculus CBA	2055	4-6 weeks
-10 days	10000000	Mus musculus BALB/c	2056	10 days
-7 to 10 weeks	10001287	Mus musculus DBA/1 X B10.Q	2057	7 to 10 weeks
-8-10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	2058	8-10 weeks
-68 years, and 70 years	9606	Homo sapiens (human)	2059	68 years, and 70 years
-young adult	10001301	Mus musculus HLA-DR15 Tg	2060	young adult
-mean age = 49.2 years	9606	Homo sapiens (human)	2061	mean age = 49.2 years
-42-61 years	9606	Homo sapiens (human)	2062	42-61 years
-NULL	10001218	Mus musculus B10.A x A.BY	2063	null
-11 to 47 years	9606	Homo sapiens (human)	2064	11 to 47 years
-27-29 years	9606	Homo sapiens (human)	2065	27-29 years
-7-8 weeks	10000253	Mus musculus A/J	2066	7-8 weeks
-NULL	10001509	Mus musculus BM3.3 TCR Tg	2067	null
-6-12 weeks	10000256	Mus musculus B10 X B10.BR	2068	6-12 weeks
-6 to 7 weeks	10000054	Mus musculus DBA/1	2069	6 to 7 weeks
-12 weeks	10001405	Mus musculus NZB X NZW	2070	12 weeks
-3 weeks	10000067	Mus musculus C57BL/6	2071	3 weeks
-16 weeks	10001248	Mus musculus NOD.Cg-Tg	2072	16 weeks
-10 to 12 weeks	10000581	Mus musculus HLA-A11 Tg	2073	10 to 12 weeks
-1-7 years	10000194	Bos taurus Holstein-Friesian	2074	1-7 years
-25-52 years	9606	Homo sapiens (human)	2075	25-52 years
-6-12 weeks	10000054	Mus musculus DBA/1	2076	6-12 weeks
-11-42 years	9606	Homo sapiens (human)	2077	11-42 years
-20 months	9606	Homo sapiens (human)	2078	20 months
-31-58.8 years	9606	Homo sapiens (human)	2079	31-58.8 years
-6-11 weeks	10000632	Mus musculus NOD	2080	6-11 weeks
-23-58 years	9606	Homo sapiens (human)	2081	23-58 years
-18-41 years	9606	Homo sapiens (human)	2082	18-41 years
-24-46 years	9606	Homo sapiens (human)	2083	24-46 years
-NULL	10001251	Mus musculus RIP-B7	2084	null
-2 to 4 weeks	9913	Bos taurus (bovine)	2085	2 to 4 weeks
-4-14 weeks	10000632	Mus musculus NOD	2086	4-14 weeks
-13-45	9606	Homo sapiens (human)	2087	13-45
-12-43	9606	Homo sapiens (human)	2088	12-43
-4-9 weeks	10000632	Mus musculus NOD	2089	4-9 weeks
-6 - 8 weeks	10000092	Mus musculus gBT-I TCR Tg	2090	6 - 8 weeks
-46	9606	Homo sapiens (human)	2091	46
-10-52	9606	Homo sapiens (human)	2092	10-52
-53-83 years	9606	Homo sapiens (human)	2093	53-83 years
-12-41	9606	Homo sapiens (human)	2094	12-41
-6 - 8 weeks	10000067	Mus musculus C57BL/6	2095	6 - 8 weeks
-13	9606	Homo sapiens (human)	2096	13
-54-81 years	9606	Homo sapiens (human)	2097	54-81 years
-Median age 5.5 years	9606	Homo sapiens (human)	2098	median age 5.5 years
-30-48 years	9606	Homo sapiens (human)	2099	30-48 years
-27-70 years	9606	Homo sapiens (human)	2100	27-70 years
-NULL	10001610	Mus musculus A1 TCR Tg	2101	null
-6-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2102	6-10 weeks
-8-12 weeks	10001234	Mus musculus C57BL/6 OX40 null	2103	8-12 weeks
-8 to 10 weeks	10000632	Mus musculus NOD	2104	8 to 10 weeks
-32 to 65 years	9606	Homo sapiens (human)	2105	32 to 65 years
-27 to 51	9606	Homo sapiens (human)	2106	27 to 51
-4-5 weeks	10000632	Mus musculus NOD	2107	4-5 weeks
-11 weeks	10001269	Mus musculus NOD HSP60 Tg	2108	11 weeks
-NULL	10001269	Mus musculus NOD HSP60 Tg	2109	null
-8 to 10 weeks old	10000635	Mus musculus NOD/Lt	2110	8 to 10 weeks old
-less than 30 years	9606	Homo sapiens (human)	2111	less than 30 years
-12-24 weeks	10000632	Mus musculus NOD	2112	12-24 weeks
-1 month	10000635	Mus musculus NOD/Lt	2113	1 month
-7 days	10000635	Mus musculus NOD/Lt	2114	7 days
-NULL	10001611	Mus musculus B10.AKM	2115	null
-juvenile	10000632	Mus musculus NOD	2116	juvenile
-1.8-18 years	9606	Homo sapiens (human)	2117	1.8-18 years
-7-40 years	9606	Homo sapiens (human)	2118	7-40 years
-8-29 years	9606	Homo sapiens (human)	2119	8-29 years
-2-62 years	9606	Homo sapiens (human)	2120	2-62 years
-33-75 years	9606	Homo sapiens (human)	2121	33-75 years
-6 to 16 weeks	10000067	Mus musculus C57BL/6	2122	6 to 16 weeks
-67 years old	9606	Homo sapiens (human)	2123	67 years old
-> 24 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2124	> 24 weeks
-8 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2125	8 weeks
-24-65 years	9606	Homo sapiens (human)	2126	24-65 years
-19-65 years	9606	Homo sapiens (human)	2127	19-65 years
-6 weeks	10002836	Mus musculus HLA-DQ2 Tg	2128	6 weeks
-7-17 weeks	10000632	Mus musculus NOD	2129	7-17 weeks
-7 to 15 weeks	10000582	Mus musculus HLA-A2 Tg	2130	7 to 15 weeks
-NULL	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2131	null
-40	9606	Homo sapiens (human)	2132	40
-9-20 weeks	10000067	Mus musculus C57BL/6	2133	9-20 weeks
-7 to 15 weeks	10000061	Mus musculus FVB	2134	7 to 15 weeks
-14-25 years	9606	Homo sapiens (human)	2135	14-25 years
-10 weeks	10001248	Mus musculus NOD.Cg-Tg	2136	10 weeks
-29-49 years	9606	Homo sapiens (human)	2137	29-49 years
-4 week	10000632	Mus musculus NOD	2138	4 week
-4 to 7 weeks old	10001248	Mus musculus NOD.Cg-Tg	2139	4 to 7 weeks old
-17 weeks	10000632	Mus musculus NOD	2140	17 weeks
-12-15 weeks	10000632	Mus musculus NOD	2141	12-15 weeks
-5-12 weeks	10001248	Mus musculus NOD.Cg-Tg	2142	5-12 weeks
->6 weeks	10000632	Mus musculus NOD	2143	>6 weeks
-27- 76 years	9606	Homo sapiens (human)	2144	27- 76 years
-NULL	10002236	Mus musculus 17.6α-8.3β TCR Tg	2145	null
-NULL	8022	Oncorhynchus mykiss (rainbow trout)	2146	null
-5-8 weeks	10001261	Mus musculus G9Calpha –/ –.NOD	2147	5-8 weeks
-4 weeks	10001255	Mus musculus RIP-B7 H2d/d	2148	4 weeks
-7 to 10 weeks	10000067	Mus musculus C57BL/6	2149	7 to 10 weeks
-NULL	10001547	Mus musculus C57BL/6 TCR transgenic	2150	null
-4 weeks	10001248	Mus musculus NOD.Cg-Tg	2151	4 weeks
-65 days	10000667	Rattus norvegicus Sprague-Dawley	2152	65 days
-adult	9940	Ovis aries (domestic sheep)	2153	adult
-17-46 years	9606	Homo sapiens (human)	2154	17-46 years
-17-20 years	9606	Homo sapiens (human)	2155	17-20 years
-16-26 weeks	10000632	Mus musculus NOD	2156	16-26 weeks
-NULL	10001068	Mus musculus C57/BL/6 LCMV NP Tg	2157	null
-12 years 9 months	9606	Homo sapiens (human)	2158	12 years 9 months
-13-15 years	9606	Homo sapiens (human)	2159	13-15 years
-NULL	10001274	Cavia porcellus Strain (2 X 13)	2160	null
-7-8 weeks	10001248	Mus musculus NOD.Cg-Tg	2161	7-8 weeks
-19	9606	Homo sapiens (human)	2162	19
-20-25 years	9606	Homo sapiens (human)	2163	20-25 years
-4.5 weeks	10000632	Mus musculus NOD	2164	4.5 weeks
-NULL	10001240	Mus musculus APPsw	2165	null
-28	9606	Homo sapiens (human)	2166	28
-3 month	10000067	Mus musculus C57BL/6	2167	3 month
-8 to 12 weeks old	10000067	Mus musculus C57BL/6	2168	8 to 12 weeks old
-4-12 weeks	10000632	Mus musculus NOD	2169	4-12 weeks
-12-20 weeks	10000632	Mus musculus NOD	2170	12-20 weeks
-4-8 weeks	10000632	Mus musculus NOD	2171	4-8 weeks
-47-56 years	9606	Homo sapiens (human)	2172	47-56 years
-6-10 weeks	10000952	Mus musculus B6.129P2-B2m tm1Unc/J	2173	6-10 weeks
-60-91 years	9606	Homo sapiens (human)	2174	60-91 years
-24-day-old	10000667	Rattus norvegicus Sprague-Dawley	2175	24-day-old
-8 weeks	10000220	Mus musculus C57BL/6 X DBA/2	2176	8 weeks
-1.5-22 months	10000007	Mus musculus 6.5 TCR Tg	2177	1.5-22 months
-1.5-18 months	10000007	Mus musculus 6.5 TCR Tg	2178	1.5-18 months
-6-8 weeks	10000642	Mus musculus Outbred	2179	6-8 weeks
-24-52 years	9606	Homo sapiens (human)	2180	24-52 years
-3-8 months	10000000	Mus musculus BALB/c	2181	3-8 months
-NULL	10001166	Mus musculus HLA-A24 Tg	2182	null
-NULL	10000595	Mus musculus HLA-B7 Tg	2183	null
-NULL	10001600	Rattus norvegicus WAG	2184	null
-NULL	10000238	Mus musculus CD1d null	2185	null
-3-8 months	10000063	Mus musculus B10.A	2186	3-8 months
-2 years	9913	Bos taurus (bovine)	2187	2 years
-21-45 years	9606	Homo sapiens (human)	2188	21-45 years
-3 to 8 weeks	10000000	Mus musculus BALB/c	2189	3 to 8 weeks
-27-29 days	10001477	Mus musculus InsHA	2190	27-29 days
-33-36 days	10001477	Mus musculus InsHA	2191	33-36 days
-8 weeks	10000055	Mus musculus DBA/2	2192	8 weeks
-4-6 weeks	10000253	Mus musculus A/J	2193	4-6 weeks
-NULL	10001609	Rattus norvegicus PVG-RT1c	2194	null
-8 weeks	10000649	Mus musculus SJL	2195	8 weeks
-NULL	10001508	Mus musculus BALB/cA Bom	2196	null
-5-8 weeks	10001019	Mus musculus B10.D2	2197	5-8 weeks
-2 to 4 months	10000267	Mus musculus B10.CE-H13b Aw/(30NX)Sn	2198	2 to 4 months
-27-57 years	9606	Homo sapiens (human)	2199	27-57 years
-50 ± 15 years	9606	Homo sapiens (human)	2200	50  15 years
-40 ± 12 years	9606	Homo sapiens (human)	2201	40  12 years
-28-48 years	9606	Homo sapiens (human)	2202	28-48 years
-8-20 weeks	10000033	Mus musculus C3H.SW	2203	8-20 weeks
-50 years	9606	Homo sapiens (human)	2204	50 years
-NULL	10002215	Mus musculus Marilyn TCR Tg	2205	null
-21-48 years	9606	Homo sapiens (human)	2206	21-48 years
-NULL	10001665	Mus musculus B6.Tlaa	2207	null
-21-75 years	9606	Homo sapiens (human)	2208	21-75 years
-8-12 weeks	10001339	Rattus norvegicus LEWIS.1A	2209	8-12 weeks
-NULL	10001672	Mus musculus B10.129 H46bH47b	2210	null
-6-8 weeks	10000007	Mus musculus 6.5 TCR Tg	2211	6-8 weeks
-2 to 4 months	10000047	Mus musculus C57BL/10	2212	2 to 4 months
-17 to 74 years	9606	Homo sapiens (human)	2213	17 to 74 years
-8 to 10 weeks	10000658	Rattus norvegicus Brown Norway	2214	8 to 10 weeks
-8 to 10 weeks	10001411	Rattus norvegicus Buffalo	2215	8 to 10 weeks
-8 to 10 weeks	10001413	Rattus norvegicus ACI	2216	8 to 10 weeks
-8 to 10 weeks	10001412	Rattus norvegicus Wistar-Furth	2217	8 to 10 weeks
-NULL	10001656	Mus musculus HNT TCR Tg	2218	null
-6 to 12 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	2219	6 to 12 weeks
-NULL	10001385	Cavia porcellus Albino Himalayan Fullingsdorf	2220	null
-Adult	9544	Macaca mulatta (rhesus macaque)	2221	adult
-24-49 years	9606	Homo sapiens (human)	2222	24-49 years
-6 weeks	10002232	Mus musculus BDC2.5 TCR Tg	2223	6 weeks
-3-22 months	10000007	Mus musculus 6.5 TCR Tg	2224	3-22 months
-4 to 6 weeks	10000063	Mus musculus B10.A	2225	4 to 6 weeks
-4 to 6 weeks	10000000	Mus musculus BALB/c	2226	4 to 6 weeks
-6-10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2227	6-10 weeks
-8 weeks	10001595	Mus musculus B6.2.16 TCR Tg	2228	8 weeks
-NULL	10001727	Mus musculus C3H X B6.K1	2229	null
-6 to 8 weeks	10000227	Mus musculus OT-1 TCR Tg	2230	6 to 8 weeks
-20-65 years-old	9606	Homo sapiens (human)	2231	20-65 years-old
-4 months	10001241	Mus musculus APP	2232	4 months
-> 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2233	> 8 weeks
-40 -58 years	9606	Homo sapiens (human)	2234	40 -58 years
-6-8 weeks	10001221	Mus musculus C57BL/6 x SJL	2235	6-8 weeks
-6-8 weeks	10000668	Cavia porcellus Duncan-Hartley	2236	6-8 weeks
-6-8 weeks, and 4 months	10000067	Mus musculus C57BL/6	2237	6-8 weeks, and 4 months
-Young adult	10000067	Mus musculus C57BL/6	2238	young adult
-12 to 24 weeks	10000632	Mus musculus NOD	2239	12 to 24 weeks
-24-32 years	10000119	Homo sapiens Caucasian	2240	24-32 years
-6 to 35 months	9606	Homo sapiens (human)	2241	6 to 35 months
-NULL	10002208	Mus musculus DO11.10 TCR Tg	2242	null
-21-77 years	9606	Homo sapiens (human)	2243	21-77 years
-NULL	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	2244	null
-NULL	10001363	Mus musculus 2D2 TCR Tg	2245	null
-72 to 90 years	9606	Homo sapiens (human)	2246	72 to 90 years
-20-47 years	9606	Homo sapiens (human)	2247	20-47 years
-31-68 yeays	9606	Homo sapiens (human)	2248	31-68 years
-31 to 68 years	9606	Homo sapiens (human)	2249	31 to 68 years
-8 to 16 weeks	10001275	Rattus norvegicus PVG-RT1u	2250	8 to 16 weeks
-5-7 weeks	10000038	Mus musculus C3H/He	2251	5-7 weeks
-NULL	10001310	Mus musculus BDC12-4.1 TCR Tg	2252	null
-29-60 years	9606	Homo sapiens (human)	2253	29-60 years
-33 to 66 years	9606	Homo sapiens (human)	2254	33 to 66 years
-NULL	10001383	Mus musculus Clone 4 TCR Tg	2255	null
-29-65 years	9606	Homo sapiens (human)	2256	29-65 years
-6-9 weeks	10000228	Mus musculus CBA	2257	6-9 weeks
-17-66 years	9606	Homo sapiens (human)	2258	17-66 years
-8-12 weeks	10116	Rattus norvegicus (brown rat)	2259	8-12 weeks
-4 to 12 weeks	10000000	Mus musculus BALB/c	2260	4 to 12 weeks
-mean age 46 years	9606	Homo sapiens (human)	2261	mean age 46 years
-12 years	9606	Homo sapiens (human)	2262	12 years
-21-41 years	9606	Homo sapiens (human)	2263	21-41 years
-28 to 63 years	9606	Homo sapiens (human)	2264	28 to 63 years
-2.5-25.4 years	9606	Homo sapiens (human)	2265	2.5-25.4 years
-6-10 weeks	10001349	Mus musculus SJL X SWR	2266	6-10 weeks
-6-8 weeks	10000025	Mus musculus Biozzi AB/H	2267	6-8 weeks
-NULL	10001765	Oryctolagus cuniculus EIII/JC	2268	null
-6 to 12 weeks	10000033	Mus musculus C3H.SW	2269	6 to 12 weeks
-5 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	2270	5 weeks
-19-57 years	9606	Homo sapiens (human)	2271	19-57 years
-2 to 6 months	10000000	Mus musculus BALB/c	2272	2 to 6 months
-6-14 weeks	10000000	Mus musculus BALB/c	2273	6-14 weeks
->6 weeks	10001353	Rattus norvegicus DA X LEW	2274	>6 weeks
-8 weeks	10000187	Sus scrofa Landrace X Large White	2275	8 weeks
-NULL	10001364	Mus musculus B6 Calpha null	2276	null
-6-10 weeks	10000601	Mus musculus HLA-DR1 Tg	2277	6-10 weeks
-22-69 years	9606	Homo sapiens (human)	2278	22-69 years
-8 - 10 weeks	10000038	Mus musculus C3H/He	2279	8 - 10 weeks
-3 to 8 weeks	10000063	Mus musculus B10.A	2280	3 to 8 weeks
-7-16 weeks	10000067	Mus musculus C57BL/6	2281	7-16 weeks
-21 to 40 years	9606	Homo sapiens (human)	2282	21 to 40 years
-NULL	10001781	Mus musculus H2-Kb VSV RGYVYQGLTg	2283	null
-15-62 years	9606	Homo sapiens (human)	2284	15-62 years
-<3 years	9544	Macaca mulatta (rhesus macaque)	2285	<3 years
-43-84 years	9606	Homo sapiens (human)	2286	43-84 years
-8 weeks	10000254	Mus musculus A/Sn	2287	8 weeks
-12 weeks	10001133	Rattus norvegicus DA	2288	12 weeks
-12 weeks	10001664	Rattus norvegicus Albino Oxford	2289	12 weeks
-6-8 weeks	10001099	Mus musculus CF-1	2290	6-8 weeks
-16 ± 11 days	9913	Bos taurus (bovine)	2291	16  11 days
-41±13 years	9606	Homo sapiens (human)	2292	4113 years
-54±10 years	9606	Homo sapiens (human)	2293	5410 years
-7-13 weeks	10000067	Mus musculus C57BL/6	2294	7-13 weeks
-23-64	9606	Homo sapiens (human)	2295	23-64
-7-74 years	9606	Homo sapiens (human)	2296	7-74 years
-6 to 7 weeks	10000067	Mus musculus C57BL/6	2297	6 to 7 weeks
-5-7 weeks	10000097	Mus musculus C57BL/6 Kb null	2298	5-7 weeks
-NULL	10001220	Mus musculus OT-II TCR Tg	2299	null
-adult	10001411	Rattus norvegicus Buffalo	2300	adult
-adult	10001413	Rattus norvegicus ACI	2301	adult
-2-12 months	10000263	Mus musculus B10.BR	2302	2-12 months
-19 years	9606	Homo sapiens (human)	2303	19 years
-23-55 years	9606	Homo sapiens (human)	2304	23-55 years
-32-69 years	9606	Homo sapiens (human)	2305	32-69 years
-NULL	10001405	Mus musculus NZB X NZW	2306	null
-2-12 months	10001369	Mus musculus C57L	2307	2-12 months
-2-12 months	10000028	Mus musculus C3H	2308	2-12 months
-6 weeks	10001601	Mus musculus C57BL/6 X 129	2309	6 weeks
-34 to 73 years	9606	Homo sapiens (human)	2310	34 to 73 years
-22 to 82 years	9606	Homo sapiens (human)	2311	22 to 82 years
-35-60 years	9606	Homo sapiens (human)	2312	35-60 years
-6 weeks	10000275	Mus musculus B10.RIII	2313	6 weeks
-6 to 7 weeks	10001410	Mus musculus 5B6 TCR Tg	2314	6 to 7 weeks
-2-4 months	10000601	Mus musculus HLA-DR1 Tg	2315	2-4 months
-NULL	10001299	Mus musculus HLA-DRB1*04:02 Tg	2316	null
-3 months	10000047	Mus musculus C57BL/10	2317	3 months
-6 to 10 weeks	10000229	Mus musculus HLA-B*27:05 Tg	2318	6 to 10 weeks
-1 month	10000188	Sus scrofa NIH miniature pig	2319	1 month
-4-8 months	10001221	Mus musculus C57BL/6 x SJL	2320	4-8 months
-20 - >65 years	9606	Homo sapiens (human)	2321	20 - >65 years
-NULL	10001789	Mus musculus B10.BR X C3H.OL	2322	null
-3 months	10000649	Mus musculus SJL	2323	3 months
-6-8 weeks	10001414	Mus musculus 172.10 TCR Tg	2324	6-8 weeks
-NULL	10001802	Mus musculus NY8.3 TCR Tg	2325	null
-18-60 years	9606	Homo sapiens (human)	2326	18-60 years
-NULL	10001399	Mus musculus HLA-DQB1*06:02 Tg	2327	null
-10 to 16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2328	10 to 16 weeks
-17 to 78 years	9606	Homo sapiens (human)	2329	17 to 78 years
-8-12 weeks	10001275	Rattus norvegicus PVG-RT1u	2330	8-12 weeks
-NULL	10001359	Mus musculus A.TL	2331	null
-4 to 6 weeks	10000067	Mus musculus C57BL/6	2332	4 to 6 weeks
-7-70 years	9606	Homo sapiens (human)	2333	7-70 years
-12-48 weeks	10090	Mus musculus (mouse)	2334	12-48 weeks
-mean age 34.6 years	9606	Homo sapiens (human)	2335	mean age 34.6 years
-mean age 50.7 years	9606	Homo sapiens (human)	2336	mean age 50.7 years
-mean age 40 years	9606	Homo sapiens (human)	2337	mean age 40 years
-1.5-3 years	9615	Canis lupus familiaris (dogs)	2338	1.5-3 years
-8-12 weeks	10000233	Mus musculus CBA/Ca	2339	8-12 weeks
-8-16 weeks	10000227	Mus musculus OT-1 TCR Tg	2340	8-16 weeks
-4 months	10000635	Mus musculus NOD/Lt	2341	4 months
-NULL	10001770	Mus musculus RIP-OVA	2342	null
-23 to 81 years	9606	Homo sapiens (human)	2343	23 to 81 years
-38 to 71 years	9606	Homo sapiens (human)	2344	38 to 71 years
-8-12 weeks.	10001221	Mus musculus C57BL/6 x SJL	2345	8-12 weeks.
-2-20 months	10000263	Mus musculus B10.BR	2346	2-20 months
-22 - 64 years	9606	Homo sapiens (human)	2347	22 - 64 years
-25-56 years	9606	Homo sapiens (human)	2348	25-56 years
-8 to 10 weeks	10000649	Mus musculus SJL	2349	8 to 10 weeks
-9-35 years	9606	Homo sapiens (human)	2350	9-35 years
-12-36 years	9606	Homo sapiens (human)	2351	12-36 years
-8 to 14 weeks	10000274	Mus musculus B10.PL	2352	8 to 14 weeks
-26-58 years	9606	Homo sapiens (human)	2353	26-58 years
-4 weeks	10000922	Sus scrofa German Landrace	2354	4 weeks
-8-12 weeks	10001346	Rattus norvegicus LEWIS.1AR2	2355	8-12 weeks
-NULL	10001397	Mus musculus MOG null	2356	null
-6-8 weeks	10001415	Mus musculus SM1 TCR Tg	2357	6-8 weeks
-28-61 years	9606	Homo sapiens (human)	2358	28-61 years
-12-29 years	9606	Homo sapiens (human)	2359	12-29 years
-8-20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2360	8-20 weeks
-8-12 weeks	10001338	Rattus norvegicus LEWIS.1L	2361	8-12 weeks
-8-12 weeks	10001340	Rattus norvegicus LEWIS.1C	2362	8-12 weeks
-8-12 weeks	10001343	Rattus norvegicus LEWIS.1WR1	2363	8-12 weeks
-8-12 weeks	10001341	Rattus norvegicus LEWIS.1D	2364	8-12 weeks
-8-12 weeks	10001342	Rattus norvegicus LEWIS.1F	2365	8-12 weeks
-8-12 weeks	10001344	Rattus norvegicus LEWIS.1WR2	2366	8-12 weeks
-8-12 weeks	10001345	Rattus norvegicus LEWIS.1AR1	2367	8-12 weeks
-2 to 3 months	10000662	Rattus norvegicus Lewis	2368	2 to 3 months
-NULL	10001394	Mus musculus POT TCR Tg	2369	null
-27-49 years	9606	Homo sapiens (human)	2370	27-49 years
-8 - 9 weeks old	10000000	Mus musculus BALB/c	2371	8 - 9 weeks old
-6 weeks	10001022	Mus musculus A.BY/SnJ	2372	6 weeks
-6-7 weeks	10001221	Mus musculus C57BL/6 x SJL	2373	6-7 weeks
-5 to 10 weeks	10000274	Mus musculus B10.PL	2374	5 to 10 weeks
-8-12 weeks	10000605	Mus musculus HLA-DR2 Tg	2375	8-12 weeks
-2-6 months	10000258	Mus musculus B10.A(2R)	2376	2-6 months
-12 to 14 weeks	10090	Mus musculus (mouse)	2377	12 to 14 weeks
-12 to 14 weeks	10000067	Mus musculus C57BL/6	2378	12 to 14 weeks
-12 to 14 weeks	10000610	Mus musculus HLA-DR4 Tg	2379	12 to 14 weeks
-NULL	10001349	Mus musculus SJL X SWR	2380	null
-8-16 weeks	10000038	Mus musculus C3H/He	2381	8-16 weeks
-32-63	9606	Homo sapiens (human)	2382	32-63
-33-45 years	9606	Homo sapiens (human)	2383	33-45 years
-26-44 years	9606	Homo sapiens (human)	2384	26-44 years
-8-10	10000067	Mus musculus C57BL/6	2385	8-10
-45	9606	Homo sapiens (human)	2386	45
-48-59 years old	9606	Homo sapiens (human)	2387	48-59 years old
-21 to 68 years	9606	Homo sapiens (human)	2388	21 to 68 years
-NULL	10001538	Mus musculus HLA Transgenic	2389	null
-5-8 weeks	10000063	Mus musculus B10.A	2390	5-8 weeks
-NULL	10001393	Mus musculus NOD B7-2 null	2391	null
-28-64 years	10000119	Homo sapiens Caucasian	2392	28-64 years
-2.5-6 months	10001291	Mus musculus CBA/Igb	2393	2.5-6 months
-10 to 14 weeks	10000649	Mus musculus SJL	2394	10 to 14 weeks
-5 weeks	10001324	Mus musculus shiverer (MBP null)	2395	5 weeks
-2-12 months	10000275	Mus musculus B10.RIII	2396	2-12 months
-8-10	10001221	Mus musculus C57BL/6 x SJL	2397	8-10
-5 to 8 weeks	10000025	Mus musculus Biozzi AB/H	2398	5 to 8 weeks
-6 to 8 weeks	10001133	Rattus norvegicus DA	2399	6 to 8 weeks
-8-14 weeks	10001347	Mus musculus 129/Sv	2400	8-14 weeks
-2-4 months	10000236	Mus musculus CBA/J	2401	2-4 months
-8-12 weeks	10000607	Mus musculus HLA-DR3 Tg	2402	8-12 weeks
-7 to 14 weeks	10000649	Mus musculus SJL	2403	7 to 14 weeks
-8-10 weeks	10001537	Mus musculus PL	2404	8-10 weeks
-10 to 12 weeks	10000667	Rattus norvegicus Sprague-Dawley	2405	10 to 12 weeks
-7 to 14 weeks	10000653	Mus musculus Swiss	2406	7 to 14 weeks
-2.5-6 months	10001362	Mus musculus B10.A(5R) X B10.D2	2407	2.5-6 months
-63-85 years	9606	Homo sapiens (human)	2408	63-85 years
-21-73 years	9606	Homo sapiens (human)	2409	21-73 years
-6-8 weeks	10001354	Mus musculus SJL X BALB/c	2410	6-8 weeks
-2-12 months	10000258	Mus musculus B10.A(2R)	2411	2-12 months
-5-8 weeks	10000228	Mus musculus CBA	2412	5-8 weeks
-28-36 years	9606	Homo sapiens (human)	2413	28-36 years
-33-39	9606	Homo sapiens (human)	2414	33-39
-6 weeks old	10000038	Mus musculus C3H/He	2415	6 weeks old
-37-45 years	9606	Homo sapiens (human)	2416	37-45 years
-NULL	10001353	Rattus norvegicus DA X LEW	2417	null
-2 to 3 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	2418	2 to 3 months
-8 to 13 weeks	10000067	Mus musculus C57BL/6	2419	8 to 13 weeks
-25-54 years	9606	Homo sapiens (human)	2420	25-54 years
-26-55	9606	Homo sapiens (human)	2421	26-55
-9-66 years	9606	Homo sapiens (human)	2422	9-66 years
-63-66 years	9606	Homo sapiens (human)	2423	63-66 years
-26-93 years	9606	Homo sapiens (human)	2424	26-93 years
-5-16 weeks	10001327	Mus musculus PL/J X SJL	2425	5-16 weeks
-5-16 weeks	10001537	Mus musculus PL	2426	5-16 weeks
-8-12 weeks	10000047	Mus musculus C57BL/10	2427	8-12 weeks
-34-72 years	9606	Homo sapiens (human)	2428	34-72 years
-19-31 years	9606	Homo sapiens (human)	2429	19-31 years
-5 to 12 week	10001375	Mus musculus NOD X NOR	2430	5 to 12 week
-5 to 12 week	10001244	Mus musculus NOR	2431	5 to 12 week
-5 to 12 week	10000632	Mus musculus NOD	2432	5 to 12 week
-6 to 8 weeks	10001363	Mus musculus 2D2 TCR Tg	2433	6 to 8 weeks
-5-16 weeks	10000649	Mus musculus SJL	2434	5-16 weeks
-7-12 weeks	10001349	Mus musculus SJL X SWR	2435	7-12 weeks
-12-16 weeks	10001387	Mus musculus 1.4HBV-Smut Tg	2436	12-16 weeks
-8-12 weeks	10001019	Mus musculus B10.D2	2437	8-12 weeks
-8-12 weeks	10000064	Mus musculus C57BL/10.Q	2438	8-12 weeks
-29-42 years	9606	Homo sapiens (human)	2439	29-42 years
-10 to 14 weeks	10000653	Mus musculus Swiss	2440	10 to 14 weeks
-NULL	10036	Mesocricetus auratus (Syrian golden hamster)	2441	null
-8 to 20 weeks	10001331	Mus musculus SJL X B10.PL	2442	8 to 20 weeks
-NULL	10001366	Mus musculus Foxp3gfp.KI	2443	null
-29 to 61 years	9606	Homo sapiens (human)	2444	29 to 61 years
-5 to 8 weeks	10000024	Mus musculus Biozzi	2445	5 to 8 weeks
-42 to 100 days	10001410	Mus musculus 5B6 TCR Tg	2446	42 to 100 days
-42 to 116 days	10001410	Mus musculus 5B6 TCR Tg	2447	42 to 116 days
-30 to 40 days	10001410	Mus musculus 5B6 TCR Tg	2448	30 to 40 days
-6-10 weeks	10001324	Mus musculus shiverer (MBP null)	2449	6-10 weeks
-24-40 years	9606	Homo sapiens (human)	2450	24-40 years
-22 to 59 years	9606	Homo sapiens (human)	2451	22 to 59 years
-24 to 48 years	9606	Homo sapiens (human)	2452	24 to 48 years
-70 years	9606	Homo sapiens (human)	2453	70 years
-8-12 weeks	10001327	Mus musculus PL/J X SJL	2454	8-12 weeks
-6-12 weeks	10000605	Mus musculus HLA-DR2 Tg	2455	6-12 weeks
-26 to 64 years	9606	Homo sapiens (human)	2456	26 to 64 years
-7-12 weeks	10000649	Mus musculus SJL	2457	7-12 weeks
-6 to 12 weeks	10001410	Mus musculus 5B6 TCR Tg	2458	6 to 12 weeks
-Neonates	10001537	Mus musculus PL	2459	neonates
-6 to 9 weeks	10000662	Rattus norvegicus Lewis	2460	6 to 9 weeks
-24-38 years	9606	Homo sapiens (human)	2461	24-38 years
-37-78 years	9606	Homo sapiens (human)	2462	37-78 years
-2 to 76 years	9606	Homo sapiens (human)	2463	2 to 76 years
-6 to 83 years	9606	Homo sapiens (human)	2464	6 to 83 years
-24 to 68 years	9606	Homo sapiens (human)	2465	24 to 68 years
-NULL	10001352	Mus musculus III	2466	null
-24 hours	10000274	Mus musculus B10.PL	2467	24 hours
-adult (>18 years)	9606	Homo sapiens (human)	2468	adult (>18 years)
-60-72 years	9606	Homo sapiens (human)	2469	60-72 years
-39-43 years	9606	Homo sapiens (human)	2470	39-43 years
-19-72 years	9606	Homo sapiens (human)	2471	19-72 years
-18-75 years (mean 39.1)	9606	Homo sapiens (human)	2472	18-75 years (mean 39.1)
-18-75 years (mean 46)	9606	Homo sapiens (human)	2473	18-75 years (mean 46)
-6 weeks old	10000054	Mus musculus DBA/1	2474	6 weeks old
-6 weeks old	10000067	Mus musculus C57BL/6	2475	6 weeks old
-23-37 years	9606	Homo sapiens (human)	2476	23-37 years
-5-8 weeks	10000025	Mus musculus Biozzi AB/H	2477	5-8 weeks
-7-8 weeks	10000662	Rattus norvegicus Lewis	2478	7-8 weeks
-8 -11 weeks old	10000067	Mus musculus C57BL/6	2479	8 -11 weeks old
-8 -11 weeks old	10000000	Mus musculus BALB/c	2480	8 -11 weeks old
-mean age 22.8 years	9606	Homo sapiens (human)	2481	mean age 22.8 years
-15 to 61 years	9606	Homo sapiens (human)	2482	15 to 61 years
-15 to 70 years	9606	Homo sapiens (human)	2483	15 to 70 years
-6-8 weeks	10000287	Mus musculus P14 TCR Tg	2484	6-8 weeks
-4 to 8 weeks	10001327	Mus musculus PL/J X SJL	2485	4 to 8 weeks
-at least 8 weeks	10000067	Mus musculus C57BL/6	2486	at least 8 weeks
-39-48 years	9606	Homo sapiens (human)	2487	39-48 years
-20 to 48 years	9606	Homo sapiens (human)	2488	20 to 48 years
-19 to 57 years	9606	Homo sapiens (human)	2489	19 to 57 years
-36-57 years	9606	Homo sapiens (human)	2490	36-57 years
-25-47 years	9606	Homo sapiens (human)	2491	25-47 years
-39 years	9606	Homo sapiens (human)	2492	39 years
-neonatal	10000662	Rattus norvegicus Lewis	2493	neonatal
-39-43	9606	Homo sapiens (human)	2494	39-43
-5-20 weeks	10000649	Mus musculus SJL	2495	5-20 weeks
-7 weeks	10001405	Mus musculus NZB X NZW	2496	7 weeks
-27 weeks	10001405	Mus musculus NZB X NZW	2497	27 weeks
-NULL	10001409	Mus musculus B6 Qa-1b null	2498	null
-8-10 weeks	10000063	Mus musculus B10.A	2499	8-10 weeks
-6-10 weeks	10001405	Mus musculus NZB X NZW	2500	6-10 weeks
-6-7 weeks	10000055	Mus musculus DBA/2	2501	6-7 weeks
-6-7 weeks	10000289	Mus musculus BALB.B	2502	6-7 weeks
-19-51 years	9606	Homo sapiens (human)	2503	19-51 years
-21 years	9606	Homo sapiens (human)	2504	21 years
-Adults	10141	Cavia porcellus (guinea pig)	2505	adults
-4 weeks	10000228	Mus musculus CBA	2506	4 weeks
-3 to 4 weeks	10000649	Mus musculus SJL	2507	3 to 4 weeks
-14.1 years	9606	Homo sapiens (human)	2508	14.1 years
-4 weeks	10001407	Mus musculus SNF1	2509	4 weeks
-5.4-16.4 years	9606	Homo sapiens (human)	2510	5.4-16.4 years
-8-10 weeks	10001405	Mus musculus NZB X NZW	2511	8-10 weeks
-4-10 weeks	10001326	Mus musculus Tg4 TCR Tg	2512	4-10 weeks
-6 months	10001407	Mus musculus SNF1	2513	6 months
-8.4-16.4 years	9606	Homo sapiens (human)	2514	8.4-16.4 years
-Young adult	10000601	Mus musculus HLA-DR1 Tg	2515	young adult
-25 years	9606	Homo sapiens (human)	2516	25 years
-10 to 14 weeks	10000662	Rattus norvegicus Lewis	2517	10 to 14 weeks
-76 years	9606	Homo sapiens (human)	2518	76 years
-8 to 14 weeks	10000649	Mus musculus SJL	2519	8 to 14 weeks
-3 months	10001405	Mus musculus NZB X NZW	2520	3 months
-> 8 weeks	10000028	Mus musculus C3H	2521	> 8 weeks
-29-53 years	9606	Homo sapiens (human)	2522	29-53 years
-> 8 weeks	10001165	Mus musculus C57BR/cdJ	2523	> 8 weeks
-5-7 weeks	10000023	Mus musculus BDF1	2524	5-7 weeks
-14-80 years	9606	Homo sapiens (human)	2525	14-80 years
-5-7 weeks	10000236	Mus musculus CBA/J	2526	5-7 weeks
-2 months	10001406	Mus musculus MLR/lpr	2527	2 months
-28.8-41.9 years	9606	Homo sapiens (human)	2528	28.8-41.9 years
-32.8-35.6 years	10000119	Homo sapiens Caucasian	2529	32.8-35.6 years
-5-20 weeks	10001327	Mus musculus PL/J X SJL	2530	5-20 weeks
-2-3 months	10000033	Mus musculus C3H.SW	2531	2-3 months
-5-20 weeks	10001537	Mus musculus PL	2532	5-20 weeks
-29-63	9606	Homo sapiens (human)	2533	29-63
-7 weeks	10001406	Mus musculus MLR/lpr	2534	7 weeks
-4-5 weeks	10001332	Rattus norvegicus LEW.1AV1	2535	4-5 weeks
-8-10 weeks	10001411	Rattus norvegicus Buffalo	2536	8-10 weeks
-8-10 weeks	10001412	Rattus norvegicus Wistar-Furth	2537	8-10 weeks
-5 to 6 weeks	10000228	Mus musculus CBA	2538	5 to 6 weeks
-22 to 51 years	10000119	Homo sapiens Caucasian	2539	22 to 51 years
-3-17 years	9606	Homo sapiens (human)	2540	3-17 years
-4 weeks	10001406	Mus musculus MLR/lpr	2541	4 weeks
-6 to 60 years	10000119	Homo sapiens Caucasian	2542	6 to 60 years
-5.4 years	9606	Homo sapiens (human)	2543	5.4 years
-8 to 12 weeks	10000038	Mus musculus C3H/He	2544	8 to 12 weeks
-8 to 10 weeks	10001405	Mus musculus NZB X NZW	2545	8 to 10 weeks
-14 weeks	10001405	Mus musculus NZB X NZW	2546	14 weeks
-6-8 weeks	10001251	Mus musculus RIP-B7	2547	6-8 weeks
-Fetal	10000649	Mus musculus SJL	2548	fetal
-10 weeks	10000253	Mus musculus A/J	2549	10 weeks
-18-45	9606	Homo sapiens (human)	2550	18-45
-19-61	9606	Homo sapiens (human)	2551	19-61
-6-7 weeks	10000236	Mus musculus CBA/J	2552	6-7 weeks
-4 weeks	10000263	Mus musculus B10.BR	2553	4 weeks
-6 to 8 weeks	10000253	Mus musculus A/J	2554	6 to 8 weeks
-6 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2555	6 to 10 weeks
-8 to 12 weeks	10000067	Mus musculus C57BL/6	2556	8 to 12 weeks
-69-83 years	9606	Homo sapiens (human)	2557	69-83 years
-2 months	10000028	Mus musculus C3H	2558	2 months
-65-85 years	9606	Homo sapiens (human)	2559	65-85 years
-58-85 years	9606	Homo sapiens (human)	2560	58-85 years
-< 42 days	10001410	Mus musculus 5B6 TCR Tg	2561	< 42 days
-27 days	10001410	Mus musculus 5B6 TCR Tg	2562	27 days
-7-8 weeks	10001244	Mus musculus NOR	2563	7-8 weeks
-5.4-12 years	9606	Homo sapiens (human)	2564	5.4-12 years
-2 months	10000038	Mus musculus C3H/He	2565	2 months
-24-67	9606	Homo sapiens (human)	2566	24-67
-5 weeks	10001406	Mus musculus MLR/lpr	2567	5 weeks
-8-10 weeks	10001407	Mus musculus SNF1	2568	8-10 weeks
-NULL	10000016	Mus musculus BALB/c X C57BL/10	2569	null
-8.4-12 years	9606	Homo sapiens (human)	2570	8.4-12 years
-NULL	10001407	Mus musculus SNF1	2571	null
-2-4 months	10000662	Rattus norvegicus Lewis	2572	2-4 months
-15-81 years	9606	Homo sapiens (human)	2573	15-81 years
-25-62 years	9606	Homo sapiens (human)	2574	25-62 years
-28-36 years	10000119	Homo sapiens Caucasian	2575	28-36 years
-18-36 months	10000194	Bos taurus Holstein-Friesian	2576	18-36 months
-26-50 years	9606	Homo sapiens (human)	2577	26-50 years
-3 months	10000625	Mus musculus MRL	2578	3 months
-3 months	10000236	Mus musculus CBA/J	2579	3 months
-25 to 55 years	9606	Homo sapiens (human)	2580	25 to 55 years
-34 to 67 years	9606	Homo sapiens (human)	2581	34 to 67 years
-8-10 weeks	10001208	Mus musculus B6.C-H-2bm1	2582	8-10 weeks
-10 weeks	10001405	Mus musculus NZB X NZW	2583	10 weeks
-6-12 weeks	10000653	Mus musculus Swiss	2584	6-12 weeks
-4-7 weeks	10000649	Mus musculus SJL	2585	4-7 weeks
-30 or 35 years	9606	Homo sapiens (human)	2586	30 or 35 years
-12-14 weeks	10001405	Mus musculus NZB X NZW	2587	12-14 weeks
-NULL	10001420	Mus musculus BXSB	2588	null
-8 to 10 weeks	10000274	Mus musculus B10.PL	2589	8 to 10 weeks
-8-10 weeks	10000658	Rattus norvegicus Brown Norway	2590	8-10 weeks
-8-10 weeks	10001413	Rattus norvegicus ACI	2591	8-10 weeks
-21 to 67 years	9606	Homo sapiens (human)	2592	21 to 67 years
-4.1-16.3 years	9606	Homo sapiens (human)	2593	4.1-16.3 years
-30-34 years	9606	Homo sapiens (human)	2594	30-34 years
-16-52 years	9606	Homo sapiens (human)	2595	16-52 years
-less than 24 hours	10000282	Mus musculus B6(C)-H2-Ab1bm12	2596	less than 24 hours
-NULL	10000282	Mus musculus B6(C)-H2-Ab1bm12	2597	null
-6 to 7 weeks	10000662	Rattus norvegicus Lewis	2598	6 to 7 weeks
-6 to 7 weeks	10000658	Rattus norvegicus Brown Norway	2599	6 to 7 weeks
-6 to 7 weeks	10001412	Rattus norvegicus Wistar-Furth	2600	6 to 7 weeks
-6 to 8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2601	6 to 8 weeks
-8-10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2602	8-10 weeks
-NULL	10001095	Mus musculus C57BL/6 IL-4 null	2603	null
-6 to 7 weeks	10001411	Rattus norvegicus Buffalo	2604	6 to 7 weeks
-33-87	9606	Homo sapiens (human)	2605	33-87
-NULL	10001378	Mus musculus HLA-DRB5*01:01 Tg	2606	null
-4 weeks	10001440	Mus musculus B16:A dKO NOD	2607	4 weeks
-24 hours	10000662	Rattus norvegicus Lewis	2608	24 hours
-38-71 years	9606	Homo sapiens (human)	2609	38-71 years
-6-14 weeks	10000274	Mus musculus B10.PL	2610	6-14 weeks
-5 to 6 weeks	10000000	Mus musculus BALB/c	2611	5 to 6 weeks
-25 to 76 years	9606	Homo sapiens (human)	2612	25 to 76 years
-2-3 months	10000658	Rattus norvegicus Brown Norway	2613	2-3 months
-8 to 12 weeks	10001133	Rattus norvegicus DA	2614	8 to 12 weeks
-23-67	9606	Homo sapiens (human)	2615	23-67
-34-55 years	9606	Homo sapiens (human)	2616	34-55 years
-2-12 months	10001357	Mus musculus D2.GD	2617	2-12 months
-8-20 weeks	10001019	Mus musculus B10.D2	2618	8-20 weeks
-21 to 56 years	9606	Homo sapiens (human)	2619	21 to 56 years
-6-15	9606	Homo sapiens (human)	2620	6-15
-26 to 50 years	9606	Homo sapiens (human)	2621	26 to 50 years
-18-22 months or 4-6 months	10000067	Mus musculus C57BL/6	2622	18-22 months or 4-6 months
-4 weeks	10000653	Mus musculus Swiss	2623	4 weeks
-29-48 years	9606	Homo sapiens (human)	2624	29-48 years
-8 days or 4-6 months	10000067	Mus musculus C57BL/6	2625	8 days or 4-6 months
-36-70 years	9606	Homo sapiens (human)	2626	36-70 years
-24-43 years	9606	Homo sapiens (human)	2627	24-43 years
-10-14 weeks	10001405	Mus musculus NZB X NZW	2628	10-14 weeks
-52-91 years	9606	Homo sapiens (human)	2629	52-91 years
-NULL	10001419	Mus musculus B6.11 TCR Tg	2630	null
-2-20 months	10000067	Mus musculus C57BL/6	2631	2-20 months
-20-58	9606	Homo sapiens (human)	2632	20-58
-20 to 43 years	9606	Homo sapiens (human)	2633	20 to 43 years
-10 to 14 weeks	10001337	Rattus norvegicus LEWIS.1W	2634	10 to 14 weeks
-10 to 14 weeks	10001333	Rattus norvegicus LEW.1N	2635	10 to 14 weeks
-23-78 years	9606	Homo sapiens (human)	2636	23-78 years
-10 to 14 weeks	10001332	Rattus norvegicus LEW.1AV1	2637	10 to 14 weeks
-7-8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2638	7-8 weeks
-6 to 10 weeks	10000038	Mus musculus C3H/He	2639	6 to 10 weeks
-6-8 weeks	10000597	Mus musculus HLA-DQ6 Tg	2640	6-8 weeks
-3-4 months	10001240	Mus musculus APPsw	2641	3-4 months
-3-4 months	10000067	Mus musculus C57BL/6	2642	3-4 months
-6 to 12 weeks	10001354	Mus musculus SJL X BALB/c	2643	6 to 12 weeks
-72 years	9606	Homo sapiens (human)	2644	72 years
-23-87 years	9606	Homo sapiens (human)	2645	23-87 years
-18 weeks	10001407	Mus musculus SNF1	2646	18 weeks
-23 to 77 years	9606	Homo sapiens (human)	2647	23 to 77 years
-6 to 8 weeks	10001782	Mus musculus HLA-B*07:02 Tg	2648	6 to 8 weeks
-6-8 weeks	10000607	Mus musculus HLA-DR3 Tg	2649	6-8 weeks
-6-8 weeks	10000598	Mus musculus HLA-DQ8 Tg	2650	6-8 weeks
-43 to 67 years	9606	Homo sapiens (human)	2651	43 to 67 years
-8-9 weeks	10000067	Mus musculus C57BL/6	2652	8-9 weeks
-2-4 months	10001019	Mus musculus B10.D2	2653	2-4 months
-15 years	9606	Homo sapiens (human)	2654	15 years
-2-4 months	10000053	Mus musculus DBA	2655	2-4 months
-26-39	9606	Homo sapiens (human)	2656	26-39
-12 weeks old	10000000	Mus musculus BALB/c	2657	12 weeks old
-24-60 years	9606	Homo sapiens (human)	2658	24-60 years
-7 to 10 weeks	10000000	Mus musculus BALB/c	2659	7 to 10 weeks
-6-16 weeks	10000253	Mus musculus A/J	2660	6-16 weeks
-3-17.7 years	9606	Homo sapiens (human)	2661	3-17.7 years
-5-31 years	9606	Homo sapiens (human)	2662	5-31 years
-6-16 weeks	10000252	Mus musculus A.SW	2663	6-16 weeks
-8 to 10 weels	10000662	Rattus norvegicus Lewis	2664	8 to 10 weeks
-Mean age 10.6 years	9606	Homo sapiens (human)	2665	mean age 10.6 years
-6 to 10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2666	6 to 10 weeks
-6-16 weeks	10000038	Mus musculus C3H/He	2667	6-16 weeks
-6-16 weeks	10000055	Mus musculus DBA/2	2668	6-16 weeks
-2-20 months	10000000	Mus musculus BALB/c	2669	2-20 months
-25-45	9606	Homo sapiens (human)	2670	25-45
-6-8 weeks	10001426	Mus musculus B6 X bm12	2671	6-8 weeks
-10 to 14 weeks	10001343	Rattus norvegicus LEWIS.1WR1	2672	10 to 14 weeks
-10 to 14 weeks	10001345	Rattus norvegicus LEWIS.1AR1	2673	10 to 14 weeks
-10 to 14 weeks	10001339	Rattus norvegicus LEWIS.1A	2674	10 to 14 weeks
-22 to 85 years	9606	Homo sapiens (human)	2675	22 to 85 years
-10 to 14 weeks	10001346	Rattus norvegicus LEWIS.1AR2	2676	10 to 14 weeks
-10 to 14 weeks	10001344	Rattus norvegicus LEWIS.1WR2	2677	10 to 14 weeks
-10 to 14 weeks	10001133	Rattus norvegicus DA	2678	10 to 14 weeks
-10 to 14 weeks	10001275	Rattus norvegicus PVG-RT1u	2679	10 to 14 weeks
-10 to 14 weeks	10001413	Rattus norvegicus ACI	2680	10 to 14 weeks
-10 to 12 weeks	10000662	Rattus norvegicus Lewis	2681	10 to 12 weeks
-NULL	10002211	Mus musculus MBP121-150 TCR Tg	2682	null
-6-8 weeks	10000275	Mus musculus B10.RIII	2683	6-8 weeks
-3 months	10001041	Rattus norvegicus Wistar	2684	3 months
-13 to 67 months	9606	Homo sapiens (human)	2685	13 to 67 months
-4-6 weeks	10000662	Rattus norvegicus Lewis	2686	4-6 weeks
-mean age 39 years	9606	Homo sapiens (human)	2687	mean age 39 years
-8-10 weeks	10001434	Rattus norvegicus LEWIS X Wistar-Furth	2688	8-10 weeks
-8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2689	8 weeks
-5-10 weeks	10000067	Mus musculus C57BL/6	2690	5-10 weeks
-18-84 years	9606	Homo sapiens (human)	2691	18-84 years
-26-68 years	9606	Homo sapiens (human)	2692	26-68 years
-8-12 weeks	10000658	Rattus norvegicus Brown Norway	2693	8-12 weeks
-27-40 years	9606	Homo sapiens (human)	2694	27-40 years
-6-15 years	9606	Homo sapiens (human)	2695	6-15 years
-18 to 49 years	9606	Homo sapiens (human)	2696	18 to 49 years
-7-10 weeks	10000000	Mus musculus BALB/c	2697	7-10 weeks
-10-14 weeks	10000662	Rattus norvegicus Lewis	2698	10-14 weeks
-7-8 weeks	10000225	Mus musculus C57BL/6N	2699	7-8 weeks
-33-73 years	9606	Homo sapiens (human)	2700	33-73 years
-6 to 8 weeks	10000275	Mus musculus B10.RIII	2701	6 to 8 weeks
-less than 24 hours	10000067	Mus musculus C57BL/6	2702	less than 24 hours
-19-33 years	9606	Homo sapiens (human)	2703	19-33 years
-6-8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2704	6-8 weeks
-9-10 weeks	10000067	Mus musculus C57BL/6	2705	9-10 weeks
-NULL	10001369	Mus musculus C57L	2706	null
-25-33 years	9606	Homo sapiens (human)	2707	25-33 years
-6-16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2708	6-16 weeks
-28-44 years	9606	Homo sapiens (human)	2709	28-44 years
-6 to 10 weeks	10000255	Mus musculus AKR	2710	6 to 10 weeks
-7-64 years	9606	Homo sapiens (human)	2711	7-64 years
-28-52 years	9606	Homo sapiens (human)	2712	28-52 years
-8 to 10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2713	8 to 10 weeks
-10 weeks	10000662	Rattus norvegicus Lewis	2714	10 weeks
-8-10	10000662	Rattus norvegicus Lewis	2715	8-10
-under 16 weeks	10000067	Mus musculus C57BL/6	2716	under 16 weeks
-10 to 14 weeks	10000067	Mus musculus C57BL/6	2717	10 to 14 weeks
-20 to 40 years	9606	Homo sapiens (human)	2718	20 to 40 years
-33 to 73 years	9606	Homo sapiens (human)	2719	33 to 73 years
-6-7 weeks	10000228	Mus musculus CBA	2720	6-7 weeks
-6-16 weeks	10001347	Mus musculus 129/Sv	2721	6-16 weeks
-10 to 14 weeks	10000275	Mus musculus B10.RIII	2722	10 to 14 weeks
-14 days	10001436	Gallus gallus P2a	2723	14 days
-15 years old	9606	Homo sapiens (human)	2724	15 years old
-3-6 weeks	10090	Mus musculus (mouse)	2725	3-6 weeks
-16-39 years	9606	Homo sapiens (human)	2726	16-39 years
-66 years	9606	Homo sapiens (human)	2727	66 years
-3 months	10000638	Mus musculus Nude	2728	3 months
-4 weeks	10000638	Mus musculus Nude	2729	4 weeks
-6 to 12 weeks	10000275	Mus musculus B10.RIII	2730	6 to 12 weeks
-NULL	10001452	Mus musculus C57/BL6J IRBP null	2731	null
-27 to 53 years	9606	Homo sapiens (human)	2732	27 to 53 years
-34 to 50 years	9606	Homo sapiens (human)	2733	34 to 50 years
-4 months	10001407	Mus musculus SNF1	2734	4 months
-17 to 47 years	9606	Homo sapiens (human)	2735	17 to 47 years
-Average age = 60.5 years	9606	Homo sapiens (human)	2736	average age = 60.5 years
-6 to 7 weeks	10000607	Mus musculus HLA-DR3 Tg	2737	6 to 7 weeks
-24 to 51 years	9606	Homo sapiens (human)	2738	24 to 51 years
-6-9 weeks	10001211	Mus musculus (C57BL/6 X A/J)	2739	6-9 weeks
-6 to 12 weeks	10001445	Mus musculus FVB/B X B10.RIII	2740	6 to 12 weeks
-5 to 8 weeks	10000263	Mus musculus B10.BR	2741	5 to 8 weeks
-6-8 weeks	10001349	Mus musculus SJL X SWR	2742	6-8 weeks
-6 to 7 weeks	10000000	Mus musculus BALB/c	2743	6 to 7 weeks
-Average age = 36.9 years	9606	Homo sapiens (human)	2744	average age = 36.9 years
-38 to 75 years	9606	Homo sapiens (human)	2745	38 to 75 years
-34-64 years	9606	Homo sapiens (human)	2746	34-64 years
-5-7 weeks	10000662	Rattus norvegicus Lewis	2747	5-7 weeks
-NULL	10001454	Mus musculus C57BL/10 X A.BY	2748	null
-38-67 years	9606	Homo sapiens (human)	2749	38-67 years
-22 to 41 years	9606	Homo sapiens (human)	2750	22 to 41 years
-21 to 33 years	9606	Homo sapiens (human)	2751	21 to 33 years
-18 to 45 years	9606	Homo sapiens (human)	2752	18 to 45 years
-NULL	9540	Macaca arctoides (bear macaque)	2753	null
-7-8 weeks	10001412	Rattus norvegicus Wistar-Furth	2754	7-8 weeks
-7-8 weeks	10000661	Rattus norvegicus Fischer 344	2755	7-8 weeks
-7-8 weeks	10001446	Rattus norvegicus Wistar Kyoto	2756	7-8 weeks
-8-10 weeks	10000236	Mus musculus CBA/J	2757	8-10 weeks
-31 to 47 years	9606	Homo sapiens (human)	2758	31 to 47 years
-6-15 weeks	10001437	Mus musculus Tapasin null	2759	6-15 weeks
-15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2760	15 weeks
-6 to 8 weeks	10001211	Mus musculus (C57BL/6 X A/J)	2761	6 to 8 weeks
-12 to 14 weeks	10000275	Mus musculus B10.RIII	2762	12 to 14 weeks
-8 weeks	10000054	Mus musculus DBA/1	2763	8 weeks
-7-10 weeks	10000662	Rattus norvegicus Lewis	2764	7-10 weeks
-14 weeks	10000662	Rattus norvegicus Lewis	2765	14 weeks
-8 to 12 weeks	10000007	Mus musculus 6.5 TCR Tg	2766	8 to 12 weeks
-12 to 26 weeks	10000276	Mus musculus B10.S	2767	12 to 26 weeks
-6-8 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	2768	6-8 weeks
-6-8 weeks	10001321	Rattus norvegicus DR-BB/Wor	2769	6-8 weeks
-Adults	10000662	Rattus norvegicus Lewis	2770	adults
-8 to 10 weeks	10001438	Mus musculus BALB/cAnN	2771	8 to 10 weeks
-26-46 years	9606	Homo sapiens (human)	2772	26-46 years
-6 to 8 weeks	10000263	Mus musculus B10.BR	2773	6 to 8 weeks
-NULL	10001453	Mus musculus B10.RIII IRBP null	2774	null
-31-64 years	9606	Homo sapiens (human)	2775	31-64 years
-2 to 62	9606	Homo sapiens (human)	2776	2 to 62
-6-8 weeks	10001331	Mus musculus SJL X B10.PL	2777	6-8 weeks
-4 to 8 months	10001221	Mus musculus C57BL/6 x SJL	2778	4 to 8 months
-6 to 7 days or 8 to 12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2779	6 to 7 days or 8 to 12 weeks
-mean age 30 +/- 7 years	9606	Homo sapiens (human)	2780	mean age 30 ± 7 years
-56.6 ± 19.3 years	9606	Homo sapiens (human)	2781	56.6  19.3 years
-42.7 years	9606	Homo sapiens (human)	2782	42.7 years
-24 to 79 years	9606	Homo sapiens (human)	2783	24 to 79 years
-NULL	10002209	Mus musculus qCII24 TCR Tg	2784	null
-22-38 years	9606	Homo sapiens (human)	2785	22-38 years
-19-38 years	9606	Homo sapiens (human)	2786	19-38 years
-28.7 years	9606	Homo sapiens (human)	2787	28.7 years
-5 tp 7 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	2788	5 tp 7 weeks
-average age = 54.7 years	9606	Homo sapiens (human)	2789	average age = 54.7 years
-9 to 71 years	9606	Homo sapiens (human)	2790	9 to 71 years
-22-83 years	9606	Homo sapiens (human)	2791	22-83 years
-8-10 weeks	10001350	Mus musculus B7-2 null	2792	8-10 weeks
-16-36 years	9606	Homo sapiens (human)	2793	16-36 years
-8 weeks	10000625	Mus musculus MRL	2794	8 weeks
-28-29 years	9606	Homo sapiens (human)	2795	28-29 years
-6 to 12 weeks	10001444	Mus musculus IRBP Tg	2796	6 to 12 weeks
-5-6 weeks	10000625	Mus musculus MRL	2797	5-6 weeks
-8-10 weeks	10000597	Mus musculus HLA-DQ6 Tg	2798	8-10 weeks
-8-10 weeks	10000598	Mus musculus HLA-DQ8 Tg	2799	8-10 weeks
-6.5 months	10001405	Mus musculus NZB X NZW	2800	6.5 months
-16-80 years	9606	Homo sapiens (human)	2801	16-80 years
-6-12 weeks	10001103	Mus musculus SV40 Tg	2802	6-12 weeks
-8 to 12 weeks	10000028	Mus musculus C3H	2803	8 to 12 weeks
-21-24 years	9606	Homo sapiens (human)	2804	21-24 years
-29-79 years	9606	Homo sapiens (human)	2805	29-79 years
-11-24 years	9606	Homo sapiens (human)	2806	11-24 years
-2-3 months	10000038	Mus musculus C3H/He	2807	2-3 months
-6 to 7 weeks	10001257	Mus musculus NOD.H-2h4	2808	6 to 7 weeks
-10 to 13 weeks	10000054	Mus musculus DBA/1	2809	10 to 13 weeks
-NULL	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	2810	null
-28-38 years	9606	Homo sapiens (human)	2811	28-38 years
-25-42 years	9606	Homo sapiens (human)	2812	25-42 years
-28 to 87 years	9606	Homo sapiens (human)	2813	28 to 87 years
-NULL	10001090	Mus musculus YA26 TCR Tg	2814	null
-31 to 62 years	9606	Homo sapiens (human)	2815	31 to 62 years
-Average age = 59.4	9606	Homo sapiens (human)	2816	average age = 59.4
-7-15 weeks	10000000	Mus musculus BALB/c	2817	7-15 weeks
-65-94 years	9606	Homo sapiens (human)	2818	65-94 years
-6 to 8 weeks	10090	Mus musculus (mouse)	2819	6 to 8 weeks
-12 weeks	9615	Canis lupus familiaris (dogs)	2820	12 weeks
-7-15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2821	7-15 weeks
-7 weeks	10000038	Mus musculus C3H/He	2822	7 weeks
-8-14 weeks	10000632	Mus musculus NOD	2823	8-14 weeks
-7-15 weeks	10090	Mus musculus (mouse)	2824	7-15 weeks
-33 to 50 years	9606	Homo sapiens (human)	2825	33 to 50 years
-6-8 weeks	10001363	Mus musculus 2D2 TCR Tg	2826	6-8 weeks
-21-70 years	10000119	Homo sapiens Caucasian	2827	21-70 years
-NULL	10000102	Mus musculus C57BL/6 Prp null	2828	null
-6-8 weeks	10000206	Oryctolagus cuniculus New Zealand White	2829	6-8 weeks
-mean age  48.2 years	9606	Homo sapiens (human)	2830	mean age  48.2 years
-mean age  40.1 years	9606	Homo sapiens (human)	2831	mean age  40.1 years
-10-14 weeks	10001333	Rattus norvegicus LEW.1N	2832	10-14 weeks
-NULL	10001440	Mus musculus B16:A dKO NOD	2833	null
-24-85 years	9606	Homo sapiens (human)	2834	24-85 years
-18-23 years	9606	Homo sapiens (human)	2835	18-23 years
-27-64 years	9606	Homo sapiens (human)	2836	27-64 years
-10-16 weeks	10000047	Mus musculus C57BL/10	2837	10-16 weeks
-7-11 weeks	10000662	Rattus norvegicus Lewis	2838	7-11 weeks
-8-14 weeks	10001271	Mus musculus NOD-PI/NOD8.3	2839	8-14 weeks
-NULL	10001472	Mus musculus 1E4 TCR Tg	2840	null
-11-79 years old	9606	Homo sapiens (human)	2841	11-79 years old
-54-82 years	9606	Homo sapiens (human)	2842	54-82 years
-6 weeks	10000253	Mus musculus A/J	2843	6 weeks
-3-24 weeks	10000639	Mus musculus NZB	2844	3-24 weeks
-54 years	10000113	Homo sapiens Black	2845	54 years
-2-3 months	10000002	Mus musculus BALB/c beta2m null	2846	2-3 months
-6 to 8 weeks	10001480	Mus musculus C3H/HePAS	2847	6 to 8 weeks
-8-16 weeks	10000649	Mus musculus SJL	2848	8-16 weeks
-NULL	10002214	Mus musculus A51 TCR Tg	2849	null
-NULL	10001446	Rattus norvegicus Wistar Kyoto	2850	null
-6-10 years	9606	Homo sapiens (human)	2851	6-10 years
-8 to 12 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	2852	8 to 12 weeks
-10-16 weeks	10001475	Mus musculus H2A+E+	2853	10-16 weeks
-7-12 months	10000063	Mus musculus B10.A	2854	7-12 months
-8 to 18 weeks	10000000	Mus musculus BALB/c	2855	8 to 18 weeks
-8 to 18 weeks	10000067	Mus musculus C57BL/6	2856	8 to 18 weeks
-NULL	10001479	Mus musculus A23 TCR Tg	2857	null
-4 to 6 weeks	10001446	Rattus norvegicus Wistar Kyoto	2858	4 to 6 weeks
-71 years	9606	Homo sapiens (human)	2859	71 years
-6-10 weeks	10000066	Mus musculus C57BL/1Flu NP(328-498) Tg	2860	6-10 weeks
-NULL	10001474	Mus musculus GAD specific TCR	2861	null
-8 to 12 weeks	10000607	Mus musculus HLA-DR3 Tg	2862	8 to 12 weeks
-8 to 12 weeks	10000598	Mus musculus HLA-DQ8 Tg	2863	8 to 12 weeks
-6 years	9606	Homo sapiens (human)	2864	6 years
-19-62	9606	Homo sapiens (human)	2865	19-62
-NULL	10000627	Mus musculus MRL/MpJ	2866	null
-28 to 52 years	9606	Homo sapiens (human)	2867	28 to 52 years
-6 weeks	10000639	Mus musculus NZB	2868	6 weeks
-8 weeks	10000597	Mus musculus HLA-DQ6 Tg	2869	8 weeks
-37 ± 12 years	9606	Homo sapiens (human)	2870	37  12 years
-36 ± 13 years	9606	Homo sapiens (human)	2871	36  13 years
-74-92 years	9606	Homo sapiens (human)	2872	74-92 years
-NULL	10000053	Mus musculus DBA	2873	null
-8 to 12 weeks	10000252	Mus musculus A.SW	2874	8 to 12 weeks
-4-6 months	10000639	Mus musculus NZB	2875	4-6 months
-3 to 24 years	9606	Homo sapiens (human)	2876	3 to 24 years
-4 to 57 years	9606	Homo sapiens (human)	2877	4 to 57 years
-12 to 18 weeks	10000000	Mus musculus BALB/c	2878	12 to 18 weeks
-8-10 weeks	10001446	Rattus norvegicus Wistar Kyoto	2879	8-10 weeks
-8 to 12 weeks	10000597	Mus musculus HLA-DQ6 Tg	2880	8 to 12 weeks
-20 weeks	10000639	Mus musculus NZB	2881	20 weeks
-4-6 weeks	10001322	Oryctolagus cuniculus HLA-A2.1 Tg	2882	4-6 weeks
-24-69 years	9606	Homo sapiens (human)	2883	24-69 years
-27-87 years	9606	Homo sapiens (human)	2884	27-87 years
-NULL	10001271	Mus musculus NOD-PI/NOD8.3	2885	null
-2 to 3 months	10000260	Mus musculus B10.A(4R)	2886	2 to 3 months
-58-74 years	9606	Homo sapiens (human)	2887	58-74 years
-3-8 months	10000260	Mus musculus B10.A(4R)	2888	3-8 months
-30-58 years old	9606	Homo sapiens (human)	2889	30-58 years old
-NULL	10001679	Mus musculus B10.LP	2890	null
-NULL	10002836	Mus musculus HLA-DQ2 Tg	2891	null
-8 to 10 weeks	10000236	Mus musculus CBA/J	2892	8 to 10 weeks
-NULL	10000658	Rattus norvegicus Brown Norway	2893	null
-20-24 weeks	10000632	Mus musculus NOD	2894	20-24 weeks
-Young	10000662	Rattus norvegicus Lewis	2895	young
-30-54 years old	9606	Homo sapiens (human)	2896	30-54 years old
-27-56 years old	9606	Homo sapiens (human)	2897	27-56 years old
-4 to 7 weeks	10001473	Mus musculus 1H3.1 TCR Tg	2898	4 to 7 weeks
-8 to 12 weeks	10000251	Mus musculus A.BY	2899	8 to 12 weeks
-10-15 weeks	10000582	Mus musculus HLA-A2 Tg	2900	10-15 weeks
-12 to 26 weeks	10000263	Mus musculus B10.BR	2901	12 to 26 weeks
-6-10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	2902	6-10 weeks
-38-77 years	9606	Homo sapiens (human)	2903	38-77 years
-32-76 years	9606	Homo sapiens (human)	2904	32-76 years
-5-25 months	10000067	Mus musculus C57BL/6	2905	5-25 months
-10 years	9606	Homo sapiens (human)	2906	10 years
-24-48 years	9606	Homo sapiens (human)	2907	24-48 years
-16 weeks	10001406	Mus musculus MLR/lpr	2908	16 weeks
-26 to 44 years	9606	Homo sapiens (human)	2909	26 to 44 years
-8-12 weeks	10001980	Mus musculus Ob.1A12 TCR Tg	2910	8-12 weeks
-9-11 weeks	10001347	Mus musculus 129/Sv	2911	9-11 weeks
-9-11 weeks	10000067	Mus musculus C57BL/6	2912	9-11 weeks
-15-41 years	9606	Homo sapiens (human)	2913	15-41 years
-13-50 years	9606	Homo sapiens (human)	2914	13-50 years
-6- to 7- months	10001407	Mus musculus SNF1	2915	6- to 7- months
-4 to 21 years	9544	Macaca mulatta (rhesus macaque)	2916	4 to 21 years
-NULL	10001481	Mus musculus B6.CAS3	2917	null
-16 weeks	10000000	Mus musculus BALB/c	2918	16 weeks
-23 years-old	9606	Homo sapiens (human)	2919	23 years-old
-16 to 63 years	9606	Homo sapiens (human)	2920	16 to 63 years
-2-3 months	9823	Sus scrofa (pig)	2921	2-3 months
-37	9606	Homo sapiens (human)	2922	37
-19 to 83 years	9606	Homo sapiens (human)	2923	19 to 83 years
-33-68 years old	9606	Homo sapiens (human)	2924	33-68 years old
-25-59 years	9606	Homo sapiens (human)	2925	25-59 years
-6-8 weeks	10001327	Mus musculus PL/J X SJL	2926	6-8 weeks
-8 weeks	10090	Mus musculus (mouse)	2927	8 weeks
-6-10 weeks	10000007	Mus musculus 6.5 TCR Tg	2928	6-10 weeks
-41 years old	10000113	Homo sapiens Black	2929	41 years old
-2 to 3 months	10000028	Mus musculus C3H	2930	2 to 3 months
-34-65 years	9606	Homo sapiens (human)	2931	34-65 years
-21 to 87 years	9606	Homo sapiens (human)	2932	21 to 87 years
-6 years	9544	Macaca mulatta (rhesus macaque)	2933	6 years
-52 and 70 years	9606	Homo sapiens (human)	2934	52 and 70 years
-10 weeks	10000025	Mus musculus Biozzi AB/H	2935	10 weeks
-6-67 years	9606	Homo sapiens (human)	2936	6-67 years
-3 to 8 months	10000258	Mus musculus B10.A(2R)	2937	3 to 8 months
-8 to 9 weeks	10000038	Mus musculus C3H/He	2938	8 to 9 weeks
-4-6 weeks old	10000253	Mus musculus A/J	2939	4-6 weeks old
-3 to 8 months	10000000	Mus musculus BALB/c	2940	3 to 8 months
-3 to 8 months	10000021	Mus musculus BALB/c-H2dm2	2941	3 to 8 months
-6 to 8 weeks	10000228	Mus musculus CBA	2942	6 to 8 weeks
-8 to 12 weeks	10000601	Mus musculus HLA-DR1 Tg	2943	8 to 12 weeks
-NULL	10001506	Mus musculus M3R null	2944	null
-NULL	10001542	Mus musculus BALB/c TCR Transgenic	2945	null
-3-20 weeks	10000635	Mus musculus NOD/Lt	2946	3-20 weeks
-20 weeks	10000635	Mus musculus NOD/Lt	2947	20 weeks
-18-44 years	9606	Homo sapiens (human)	2948	18-44 years
-25-65 years old	9606	Homo sapiens (human)	2949	25-65 years old
-26.7 +/- 1.0 years	9606	Homo sapiens (human)	2950	26.7 ± 1.0 years
-0-13 years	9606	Homo sapiens (human)	2951	0-13 years
-22-47 years	9606	Homo sapiens (human)	2952	22-47 years
-10-14 weeks	10001413	Rattus norvegicus ACI	2953	10-14 weeks
-7 to 9 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2954	7 to 9 weeks
-10-14 weeks	10001337	Rattus norvegicus LEWIS.1W	2955	10-14 weeks
-12 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	2956	12 weeks
-8 weeks	10000053	Mus musculus DBA	2957	8 weeks
-2- 4 months	10000000	Mus musculus BALB/c	2958	2- 4 months
-8 to 12 weeks	10000605	Mus musculus HLA-DR2 Tg	2959	8 to 12 weeks
-39-61 years	10000119	Homo sapiens Caucasian	2960	39-61 years
-NULL	10000029	Mus musculus C3H X DBA/2	2961	null
-2-33 months	10000067	Mus musculus C57BL/6	2962	2-33 months
-8 weeks	10001487	Mus musculus Apolipoprotein E null	2963	8 weeks
-2, 12, or 20 months	10000067	Mus musculus C57BL/6	2964	2, 12, or 20 months
-22-43 years	9606	Homo sapiens (human)	2965	22-43 years
-8-14 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	2966	8-14 weeks old
-NULL	10000185	Canis familiaris beagle	2967	null
-10-14 weeks	10001412	Rattus norvegicus Wistar-Furth	2968	10-14 weeks
-NULL	10001612	Mus musculus B10.C-H7b(47N)/SN	2969	null
-NULL	10001595	Mus musculus B6.2.16 TCR Tg	2970	null
-8 weeks	10000667	Rattus norvegicus Sprague-Dawley	2971	8 weeks
-25-89 years	9606	Homo sapiens (human)	2972	25-89 years
-30-68 years old	9606	Homo sapiens (human)	2973	30-68 years old
-neonate	9606	Homo sapiens (human)	2974	neonate
-newborn	10000032	Mus musculus C3H.Q	2975	newborn
-NULL	10001613	Mus musculus Thy1.1+Bg1	2976	null
-6 to 10 weeks	10000104	Mus musculus C57BL/6 TAP null	2977	6 to 10 weeks
-28-43 years	9606	Homo sapiens (human)	2978	28-43 years
-Six week old	10000000	Mus musculus BALB/c	2979	6 week old
-newborn	10001287	Mus musculus DBA/1 X B10.Q	2980	newborn
-6-16 weeks	10000033	Mus musculus C3H.SW	2981	6-16 weeks
-newborn	10001288	Mus musculus MMC-1 (collagen mutant)	2982	newborn
-24 hours	10000669	Cavia porcellus Hartley	2983	24 hours
-NULL	10000631	Mus musculus NMRI	2984	null
-6 and 8 weeks	10001438	Mus musculus BALB/cAnN	2985	6 and 8 weeks
-NULL	10001208	Mus musculus B6.C-H-2bm1	2986	null
-23-77 years	9606	Homo sapiens (human)	2987	23-77 years
-NULL	10002216	Mus musculus Matahari TCR Tg	2988	null
-6-10 weeks	10001470	Mus musculus Factor VIII null	2989	6-10 weeks
-24-37 years	9606	Homo sapiens (human)	2990	24-37 years
-0-12 years	9606	Homo sapiens (human)	2991	0-12 years
-23-91 years	9606	Homo sapiens (human)	2992	23-91 years
-9-50 years	9606	Homo sapiens (human)	2993	9-50 years
-7-55 years	9606	Homo sapiens (human)	2994	7-55 years
-5-8 weeks	10001634	Mus musculus IFNR null	2995	5-8 weeks
-8-12 weeks	10000068	Mus musculus 2C TCR Tg	2996	8-12 weeks
-mean = 32.17±13.32 years	9606	Homo sapiens (human)	2997	mean = 32.1713.32 years
-mean = 73±8.53 years	9606	Homo sapiens (human)	2998	mean = 738.53 years
-30 weeks	10001241	Mus musculus APP	2999	30 weeks
-17-78 years	9606	Homo sapiens (human)	3000	17-78 years
-19-82 years	9606	Homo sapiens (human)	3001	19-82 years
-34-85 years	9606	Homo sapiens (human)	3002	34-85 years
-11-50 years	9606	Homo sapiens (human)	3003	11-50 years
-8 to 12 weeks	10001041	Rattus norvegicus Wistar	3004	8 to 12 weeks
-8 weeks	10001634	Mus musculus IFNR null	3005	8 weeks
-35-62 years	9606	Homo sapiens (human)	3006	35-62 years
-NULL	10001413	Rattus norvegicus ACI	3007	null
-8-12 weeks	10000019	Mus musculus BALB/cByJ	3008	8-12 weeks
-38.1 ± 14.8 years	9606	Homo sapiens (human)	3009	38.1  14.8 years
-20-70 years	9606	Homo sapiens (human)	3010	20-70 years
-6 to 12 weeks	10000000	Mus musculus BALB/c	3011	6 to 12 weeks
-20-41 years	9606	Homo sapiens (human)	3012	20-41 years
-23-50 years	9606	Homo sapiens (human)	3013	23-50 years
-42 to 50 years	9606	Homo sapiens (human)	3014	42 to 50 years
-8 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	3015	8 to 12 weeks
-6 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	3016	6 to 12 weeks
-29-54 years	9606	Homo sapiens (human)	3017	29-54 years
-57-75 years	9606	Homo sapiens (human)	3018	57-75 years
-6-8 weeks	10000233	Mus musculus CBA/Ca	3019	6-8 weeks
-8-12 weeks	10000007	Mus musculus 6.5 TCR Tg	3020	8-12 weeks
-9 weeks	10000233	Mus musculus CBA/Ca	3021	9 weeks
-36 to 65 years	9606	Homo sapiens (human)	3022	36 to 65 years
-NULL	10001241	Mus musculus APP	3023	null
-2-4 months	10000649	Mus musculus SJL	3024	2-4 months
-2 to 4 monts	10001208	Mus musculus B6.C-H-2bm1	3025	2 to 4 months
-NULL	10000273	Mus musculus B10.P	3026	null
-4-6 weeks	10001655	Mus musculus BALB/c Thy 1.1	3027	4-6 weeks
-8-10 weeks	10000661	Rattus norvegicus Fischer 344	3028	8-10 weeks
-NULL	10001632	Mus musculus Va14i TCR Tg	3029	null
-6-10 weeks	10000287	Mus musculus P14 TCR Tg	3030	6-10 weeks
-46-67 years	9606	Homo sapiens (human)	3031	46-67 years
-11 weeks	10000000	Mus musculus BALB/c	3032	11 weeks
-25 to 59 years	9606	Homo sapiens (human)	3033	25 to 59 years
-2-4 months	10001208	Mus musculus B6.C-H-2bm1	3034	2-4 months
-8-24 weeks old	10000277	Mus musculus B10.S(7R)	3035	8-24 weeks old
-NULL	10002217	Mus musculus C10.4 TCR Tg	3036	null
-21-65 years	9606	Homo sapiens (human)	3037	21-65 years
-8-10 weeks	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	3038	8-10 weeks
-6 to 8 weeks	10000274	Mus musculus B10.PL	3039	6 to 8 weeks
-42.8±11.9 years	9606	Homo sapiens (human)	3040	42.811.9 years
-5-9 months	9823	Sus scrofa (pig)	3041	5-9 months
-28-34 years	9606	Homo sapiens (human)	3042	28-34 years
-NULL	10001575	Mus musculus C57BL/6 alpha1,3GT null	3043	null
-48.1±12.7 years	9606	Homo sapiens (human)	3044	48.112.7 years
-19 to 54 years	9606	Homo sapiens (human)	3045	19 to 54 years
-NULL	10001553	Mus musculus 2B4 TCR Tg	3046	null
-3-4 weeks	10000662	Rattus norvegicus Lewis	3047	3-4 weeks
-4 weeks	10141	Cavia porcellus (guinea pig)	3048	4 weeks
-2-3 months	10000635	Mus musculus NOD/Lt	3049	2-3 months
-6 weeks	10000287	Mus musculus P14 TCR Tg	3050	6 weeks
-newborn	10141	Cavia porcellus (guinea pig)	3051	newborn
-2 to 3 months	10000000	Mus musculus BALB/c	3052	2 to 3 months
-25-67 years	9606	Homo sapiens (human)	3053	25-67 years
-6-10 weeks	10002848	Mus musculus HLA-DPw4 Tg	3054	6-10 weeks
-4-6 weeks	35658	Mastomys coucha (southern multimammate mouse)	3055	4-6 weeks
-3-8 months	10000263	Mus musculus B10.BR	3056	3-8 months
-<24 hours	10000063	Mus musculus B10.A	3057	<24 hours
->8 weeks	10000067	Mus musculus C57BL/6	3058	>8 weeks
-6 to 8 weeks	10000271	Mus musculus B10.M	3059	6 to 8 weeks
-3 to 5 weeks	10000067	Mus musculus C57BL/6	3060	3 to 5 weeks
-NULL	10000050	Mus musculus C57BL/10 X C3H/HeJ	3061	null
-NULL	10000225	Mus musculus C57BL/6N	3062	null
-7 to 8 weeks	10001410	Mus musculus 5B6 TCR Tg	3063	7 to 8 weeks
-23-76 years	9606	Homo sapiens (human)	3064	23-76 years
-4-6 weeks	10000582	Mus musculus HLA-A2 Tg	3065	4-6 weeks
-5 to 6 weeks	10000632	Mus musculus NOD	3066	5 to 6 weeks
-21-63 years	9606	Homo sapiens (human)	3067	21-63 years
-1 to 5 years	9685	Felis catus (cat)	3068	1 to 5 years
-6-7 weeks	10001339	Rattus norvegicus LEWIS.1A	3069	6-7 weeks
-28 to 76 years	9606	Homo sapiens (human)	3070	28 to 76 years
-2-6 months	10001679	Mus musculus B10.LP	3071	2-6 months
-3 weeks	9031	Gallus gallus (chicken)	3072	3 weeks
-mean age = 13.8 years	9606	Homo sapiens (human)	3073	mean age = 13.8 years
-5 to 6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3074	5 to 6 weeks
-mean age = 34.8 years	9606	Homo sapiens (human)	3075	mean age = 34.8 years
-5 to 6 weeks	10001248	Mus musculus NOD.Cg-Tg	3076	5 to 6 weeks
-6-8 weeks	10000654	Mus musculus Swiss albino	3077	6-8 weeks
-7 to 10 weeks	10000601	Mus musculus HLA-DR1 Tg	3078	7 to 10 weeks
-25-48 years	9606	Homo sapiens (human)	3079	25-48 years
-3 months	10000635	Mus musculus NOD/Lt	3080	3 months
-adult	10000667	Rattus norvegicus Sprague-Dawley	3081	adult
-4-5 months	10000635	Mus musculus NOD/Lt	3082	4-5 months
-5 weeks	10000669	Cavia porcellus Hartley	3083	5 weeks
-NULL	10002218	Mus musculus TCR75 TCR Tg	3084	null
-NULL	10001996	Mus musculus DbGagL TCR Tg	3085	null
-6 to 12 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3086	6 to 12 weeks
-10 to 20 weeks	10000662	Rattus norvegicus Lewis	3087	10 to 20 weeks
-6 to 8 weeks	10000054	Mus musculus DBA/1	3088	6 to 8 weeks
-8 months	10001405	Mus musculus NZB X NZW	3089	8 months
-7	10000632	Mus musculus NOD	3090	7
-6 to 8 weeks	10000019	Mus musculus BALB/cByJ	3091	6 to 8 weeks
-9-16 weeks	10000582	Mus musculus HLA-A2 Tg	3092	9-16 weeks
-69 years	9606	Homo sapiens (human)	3093	69 years
-3 weeks	10002232	Mus musculus BDC2.5 TCR Tg	3094	3 weeks
-mean age = 37.7 years	9606	Homo sapiens (human)	3095	mean age = 37.7 years
-6-10 weeks	10000227	Mus musculus OT-1 TCR Tg	3096	6-10 weeks
-7 to 8 weeks	10001122	Mus musculus µMT	3097	7 to 8 weeks
-21 to 24 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3098	21 to 24 weeks
-56-85	9606	Homo sapiens (human)	3099	56-85
-2-17 years	9606	Homo sapiens (human)	3100	2-17 years
-63	9606	Homo sapiens (human)	3101	63
-4 to 6 weeks	10000233	Mus musculus CBA/Ca	3102	4 to 6 weeks
-40-50 years-old	9606	Homo sapiens (human)	3103	40-50 years-old
-2-3 months	10000220	Mus musculus C57BL/6 X DBA/2	3104	2-3 months
-4 to 5 weeks	10000187	Sus scrofa Landrace X Large White	3105	4 to 5 weeks
-NULL	10001994	Mus musculus OVA23-3 TCR Tg	3106	null
-6 to 12 weeks	10001220	Mus musculus OT-II TCR Tg	3107	6 to 12 weeks
-6 to 12 weeks	10001473	Mus musculus 1H3.1 TCR Tg	3108	6 to 12 weeks
-28 to 86 years	9606	Homo sapiens (human)	3109	28 to 86 years
-3 months	10000067	Mus musculus C57BL/6	3110	3 months
-NULL	10001677	Mus musculus N-acetylgalactosaminyltransferase null	3111	null
-NULL	10001710	Bos taurus Holstein X Charolais	3112	null
-NULL	10001718	Mus musculus B10.A(4R) Kbw9	3113	null
-NULL	10001165	Mus musculus C57BR/cdJ	3114	null
-4 to 10 weeks	10000028	Mus musculus C3H	3115	4 to 10 weeks
-4 to 10 weeks	10000000	Mus musculus BALB/c	3116	4 to 10 weeks
-8 to 45 years	9606	Homo sapiens (human)	3117	8 to 45 years
-0.9-29.4 years	9606	Homo sapiens (human)	3118	0.9-29.4 years
-5-7 weeks	10000263	Mus musculus B10.BR	3119	5-7 weeks
-22-45 years-old	9606	Homo sapiens (human)	3120	22-45 years-old
-NULL	10000648	Mus musculus RIIIS	3121	null
-9 weeks	10000055	Mus musculus DBA/2	3122	9 weeks
-41 and 43 years	9606	Homo sapiens (human)	3123	41 and 43 years
-6-10 weeks	10001612	Mus musculus B10.C-H7b(47N)/SN	3124	6-10 weeks
-9 to 12 weeks	10000649	Mus musculus SJL	3125	9 to 12 weeks
-12-18 weeks	10000635	Mus musculus NOD/Lt	3126	12-18 weeks
-35-58 years	9606	Homo sapiens (human)	3127	35-58 years
-54-63 years	9606	Homo sapiens (human)	3128	54-63 years
-23 to 33 years	9606	Homo sapiens (human)	3129	23 to 33 years
-2-12 months	10000270	Mus musculus B10.HTT	3130	2-12 months
-1-85 years	9606	Homo sapiens (human)	3131	1-85 years
-2 to 3 months	10000033	Mus musculus C3H.SW	3132	2 to 3 months
-8 to 10 weeks old	10000067	Mus musculus C57BL/6	3133	8 to 10 weeks old
-26 to 60 years	9606	Homo sapiens (human)	3134	26 to 60 years
-39-55 years	9606	Homo sapiens (human)	3135	39-55 years
-37-55 years	9606	Homo sapiens (human)	3136	37-55 years
-2-12 months	10000055	Mus musculus DBA/2	3137	2-12 months
-2-12 months	10000253	Mus musculus A/J	3138	2-12 months
-2-12 months	10001348	Mus musculus A.CA	3139	2-12 months
-2-12 months	10000252	Mus musculus A.SW	3140	2-12 months
-2-12 months	10001024	Mus musculus CE/J	3141	2-12 months
-6-10 weeks	10001327	Mus musculus PL/J X SJL	3142	6-10 weeks
-40-45 years	9606	Homo sapiens (human)	3143	40-45 years
-35-63 years	9606	Homo sapiens (human)	3144	35-63 years
-2-12 months	10000000	Mus musculus BALB/c	3145	2-12 months
-39-58 years	9606	Homo sapiens (human)	3146	39-58 years
-55-66 years	9606	Homo sapiens (human)	3147	55-66 years
-55 years	9606	Homo sapiens (human)	3148	55 years
-7 to 10 weeks	10000662	Rattus norvegicus Lewis	3149	7 to 10 weeks
-26-68 years	10000119	Homo sapiens Caucasian	3150	26-68 years
-6 to 8 weeks	10000219	Mus musculus C57BL/6 X CBA	3151	6 to 8 weeks
-5 to 8 weeks	10001363	Mus musculus 2D2 TCR Tg	3152	5 to 8 weeks
-6-10 weeks	10000275	Mus musculus B10.RIII	3153	6-10 weeks
-44 years old	9606	Homo sapiens (human)	3154	44 years old
-2-12 months	10090	Mus musculus (mouse)	3155	2-12 months
-2-12 months	10000278	Mus musculus B10.S(9R)	3156	2-12 months
-2-12 months	10000054	Mus musculus DBA/1	3157	2-12 months
-2-12 months	10000030	Mus musculus C3H.JK	3158	2-12 months
-2-12 months	10000032	Mus musculus C3H.Q	3159	2-12 months
-2-12 months	10000033	Mus musculus C3H.SW	3160	2-12 months
-NULL	10000638	Mus musculus Nude	3161	null
-2-6 months	10000272	Mus musculus B10.MBR	3162	2-6 months
-2-12 months	10000031	Mus musculus C3H.NB	3163	2-12 months
-27 years old	9606	Homo sapiens (human)	3164	27 years old
-18 years old	9606	Homo sapiens (human)	3165	18 years old
-19 years old	9606	Homo sapiens (human)	3166	19 years old
-25 years old	9606	Homo sapiens (human)	3167	25 years old
-49 years old	9606	Homo sapiens (human)	3168	49 years old
-33 years old	9606	Homo sapiens (human)	3169	33 years old
-40 years old	9606	Homo sapiens (human)	3170	40 years old
-47 years old	9606	Homo sapiens (human)	3171	47 years old
-35 years old	9606	Homo sapiens (human)	3172	35 years old
-19-70 years	9606	Homo sapiens (human)	3173	19-70 years
-53 years old	9606	Homo sapiens (human)	3174	53 years old
-26-64	9606	Homo sapiens (human)	3175	26-64
-55 years old	9606	Homo sapiens (human)	3176	55 years old
-21 years old	9606	Homo sapiens (human)	3177	21 years old
-31-54	9606	Homo sapiens (human)	3178	31-54
-18-62 years	9606	Homo sapiens (human)	3179	18-62 years
-28 years old	9606	Homo sapiens (human)	3180	28 years old
-30-43 years	9606	Homo sapiens (human)	3181	30-43 years
-42 years old	9606	Homo sapiens (human)	3182	42 years old
-24-63 years	9606	Homo sapiens (human)	3183	24-63 years
-35 to 77 years	9606	Homo sapiens (human)	3184	35 to 77 years
-27-40 years-old	9606	Homo sapiens (human)	3185	27-40 years-old
-27-39 years-old	9606	Homo sapiens (human)	3186	27-39 years-old
-23-53 years-old	9606	Homo sapiens (human)	3187	23-53 years-old
-23-41 years-old	9606	Homo sapiens (human)	3188	23-41 years-old
-12 to 20 weeks	10000067	Mus musculus C57BL/6	3189	12 to 20 weeks
-21-28 years	9606	Homo sapiens (human)	3190	21-28 years
-9-78 years	9606	Homo sapiens (human)	3191	9-78 years
-27-42 years-old	9606	Homo sapiens (human)	3192	27-42 years-old
-21-29 years	9606	Homo sapiens (human)	3193	21-29 years
-10 months	10001286	Mus musculus APPswe/PSEN1	3194	10 months
-6-12 weeks	10001220	Mus musculus OT-II TCR Tg	3195	6-12 weeks
-23-43 years-old	9606	Homo sapiens (human)	3196	23-43 years-old
-6 months to 14 years	9606	Homo sapiens (human)	3197	6 months to 14 years
-2-71 years	9606	Homo sapiens (human)	3198	2-71 years
-32-42 years-old	9606	Homo sapiens (human)	3199	32-42 years-old
-10-16 weeks	10000067	Mus musculus C57BL/6	3200	10-16 weeks
-28-40 years-old	9606	Homo sapiens (human)	3201	28-40 years-old
-22 years old	9606	Homo sapiens (human)	3202	22 years old
-28-32 years-old	9606	Homo sapiens (human)	3203	28-32 years-old
-27-32 years-old	9606	Homo sapiens (human)	3204	27-32 years-old
-7-12 weeks	10000067	Mus musculus C57BL/6	3205	7-12 weeks
-3 months	10002062	Ovis aries Mallorquina	3206	3 months
-4 months	10002063	Ovis aries Merino	3207	4 months
-22-58 years-old	9606	Homo sapiens (human)	3208	22-58 years-old
-18-54 years-old	9606	Homo sapiens (human)	3209	18-54 years-old
-18-55 years-old	9606	Homo sapiens (human)	3210	18-55 years-old
-6-8 weeks	10000019	Mus musculus BALB/cByJ	3211	6-8 weeks
-18-56 years-old	9606	Homo sapiens (human)	3212	18-56 years-old
-12 to 16 weeks	10000635	Mus musculus NOD/Lt	3213	12 to 16 weeks
-21-55 years-old	9606	Homo sapiens (human)	3214	21-55 years-old
-18-53 years-old	9606	Homo sapiens (human)	3215	18-53 years-old
-mean of 12.2 years	9606	Homo sapiens (human)	3216	mean of 12.2 years
-mean of 37.0 years	9606	Homo sapiens (human)	3217	mean of 37.0 years
-24-76 years	9606	Homo sapiens (human)	3218	24-76 years
-20 weeks	10090	Mus musculus (mouse)	3219	20 weeks
-5 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3220	5 weeks
-27- 60 years	9606	Homo sapiens (human)	3221	27- 60 years
-23-47 years-old	9606	Homo sapiens (human)	3222	23-47 years-old
-6 months	10000187	Sus scrofa Landrace X Large White	3223	6 months
-30-50 years-old	9606	Homo sapiens (human)	3224	30-50 years-old
-6-8 weels	10000067	Mus musculus C57BL/6	3225	6-8 weeks
-30 weeks	10000635	Mus musculus NOD/Lt	3226	30 weeks
-3 weeks	10000038	Mus musculus C3H/He	3227	3 weeks
-3-4 months	10001405	Mus musculus NZB X NZW	3228	3-4 months
-5 to 16 weeks	10000000	Mus musculus BALB/c	3229	5 to 16 weeks
-6 to 8 weeks or 20 to 22 months	10000067	Mus musculus C57BL/6	3230	6 to 8 weeks or 20 to 22 months
-7-10 weeks	10002209	Mus musculus qCII24 TCR Tg	3231	7-10 weeks
-35-76 years	9606	Homo sapiens (human)	3232	35-76 years
-17-67 years	9606	Homo sapiens (human)	3233	17-67 years
-32-67 years	9606	Homo sapiens (human)	3234	32-67 years
-15 day	10000007	Mus musculus 6.5 TCR Tg	3235	15 day
-15 days	10000007	Mus musculus 6.5 TCR Tg	3236	15 days
-19-86 years	9606	Homo sapiens (human)	3237	19-86 years
-7-26 years	9544	Macaca mulatta (rhesus macaque)	3238	7-26 years
-3 months	9940	Ovis aries (domestic sheep)	3239	3 months
-8-24 weeks	10001383	Mus musculus Clone 4 TCR Tg	3240	8-24 weeks
-6-10 weeks	10000019	Mus musculus BALB/cByJ	3241	6-10 weeks
-9-39 years	9606	Homo sapiens (human)	3242	9-39 years
-6-8 weeks	10001068	Mus musculus C57/BL/6 LCMV NP Tg	3243	6-8 weeks
-2-12 months	10000063	Mus musculus B10.A	3244	2-12 months
-33-63	9606	Homo sapiens (human)	3245	33-63
-18-49	9606	Homo sapiens (human)	3246	18-49
-25-54	9606	Homo sapiens (human)	3247	25-54
-7-16 weeks	10000038	Mus musculus C3H/He	3248	7-16 weeks
-7-16 weeks	10000000	Mus musculus BALB/c	3249	7-16 weeks
-36 to 67 years	9606	Homo sapiens (human)	3250	36 to 67 years
-26-57	9606	Homo sapiens (human)	3251	26-57
-4 to 12 weeks	10000632	Mus musculus NOD	3252	4 to 12 weeks
-43-61 years	10000119	Homo sapiens Caucasian	3253	43-61 years
-24-28 years	9606	Homo sapiens (human)	3254	24-28 years
-22-57 years	9606	Homo sapiens (human)	3255	22-57 years
-34-35	9606	Homo sapiens (human)	3256	34-35
-6-8 weeks	10000102	Mus musculus C57BL/6 Prp null	3257	6-8 weeks
-34-64	9606	Homo sapiens (human)	3258	34-64
-32-35	9606	Homo sapiens (human)	3259	32-35
-35-64	9606	Homo sapiens (human)	3260	35-64
-61	9606	Homo sapiens (human)	3261	61
-mean age of 49 years	9606	Homo sapiens (human)	3262	mean age of 49 years
-mean age of 57 years	9606	Homo sapiens (human)	3263	mean age of 57 years
-15-90	9606	Homo sapiens (human)	3264	15-90
-49-60 years	9606	Homo sapiens (human)	3265	49-60 years
-8-16 weeks	10000287	Mus musculus P14 TCR Tg	3266	8-16 weeks
-39-50 years	9606	Homo sapiens (human)	3267	39-50 years
-8-12 weeks old	10001935	Mus musculus 129/SVE GAA-/-	3268	8-12 weeks old
-6-7 weeks	10001487	Mus musculus Apolipoprotein E null	3269	6-7 weeks
-4-15 months	10000067	Mus musculus C57BL/6	3270	4-15 months
-6-12 weeks	10001397	Mus musculus MOG null	3271	6-12 weeks
-NULL	10002213	Mus musculus 1C6 TCR Tg	3272	null
-54-74	9606	Homo sapiens (human)	3273	54-74
-43-60 years	9606	Homo sapiens (human)	3274	43-60 years
-6-8 weeks	10000063	Mus musculus B10.A	3275	6-8 weeks
-7 days or 8-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3276	7 days or 8-10 weeks
-4-week-old	10000632	Mus musculus NOD	3277	4-week-old
-2 weeks	10000067	Mus musculus C57BL/6	3278	2 weeks
-six to eight weeks old	10000000	Mus musculus BALB/c	3279	6 to 8 weeks old
-six to eight weeks old	10000067	Mus musculus C57BL/6	3280	6 to 8 weeks old
-20-64 months	9483	Callithrix jacchus (common marmoset)	3281	20-64 months
-20-75 years	9606	Homo sapiens (human)	3282	20-75 years
-Adult (6 weeks)	10000669	Cavia porcellus Hartley	3283	adult (6 weeks)
-NULL	10002225	Mus musculus gp150 TCR	3284	null
-37-46 years	9606	Homo sapiens (human)	3285	37-46 years
-52-96 years	9606	Homo sapiens (human)	3286	52-96 years
-6-12 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	3287	6-12 weeks
-6-12 weeks	10002226	Mus musculus C3K TCR Tg	3288	6-12 weeks
-6-8 weeks	10000651	Mus musculus SMARTA TCR Tg	3289	6-8 weeks
-58-78 years	9606	Homo sapiens (human)	3290	58-78 years
-fetal	10000227	Mus musculus OT-1 TCR Tg	3291	fetal
-12-14 weeks	10000275	Mus musculus B10.RIII	3292	12-14 weeks
-6-10 weeks	10000013	Mus musculus BALB/c X A/J	3293	6-10 weeks
-8 to 10 weeks	10000187	Sus scrofa Landrace X Large White	3294	8 to 10 weeks
-4-7 weeks	10001933	Mus musculus C57BL/6 Aire null	3295	4-7 weeks
-6-7 weeks	10000187	Sus scrofa Landrace X Large White	3296	6-7 weeks
-23–52 years	9606	Homo sapiens (human)	3297	2352 years
-19–67 years	9606	Homo sapiens (human)	3298	1967 years
-8 weeks	10002848	Mus musculus HLA-DPw4 Tg	3299	8 weeks
-4-5 weeks	10001933	Mus musculus C57BL/6 Aire null	3300	4-5 weeks
-10-20 weeks	10001933	Mus musculus C57BL/6 Aire null	3301	10-20 weeks
-4-7 weeks	10000067	Mus musculus C57BL/6	3302	4-7 weeks
-6-12 weeks	10000582	Mus musculus HLA-A2 Tg	3303	6-12 weeks
-20-68 years	9606	Homo sapiens (human)	3304	20-68 years
-50-62 years	9606	Homo sapiens (human)	3305	50-62 years
-8 weeks	10000601	Mus musculus HLA-DR1 Tg	3306	8 weeks
-6-9 weeks old	10000038	Mus musculus C3H/He	3307	6-9 weeks old
-58-75	9606	Homo sapiens (human)	3308	58-75
-56-63	9606	Homo sapiens (human)	3309	56-63
->8 weeks	10000227	Mus musculus OT-1 TCR Tg	3310	>8 weeks
-16-24 weeks	10000000	Mus musculus BALB/c	3311	16-24 weeks
-16-24 weeks	10000067	Mus musculus C57BL/6	3312	16-24 weeks
-10 weeks	10002213	Mus musculus 1C6 TCR Tg	3313	10 weeks
-32-86 years	9606	Homo sapiens (human)	3314	32-86 years
-20-81 years	9606	Homo sapiens (human)	3315	20-81 years
-1 week	9606	Homo sapiens (human)	3316	1 week
-37-80 years	9606	Homo sapiens (human)	3317	37-80 years
-25 to 52 years	9606	Homo sapiens (human)	3318	25 to 52 years
-6-30 years	9606	Homo sapiens (human)	3319	6-30 years
-NULL	10002235	Mus musculus 506 TCR Tg	3320	null
-3 to 6 years	9615	Canis lupus familiaris (dogs)	3321	3 to 6 years
-21-35 years	9606	Homo sapiens (human)	3322	21-35 years
-6 to 8 weeks	10000605	Mus musculus HLA-DR2 Tg	3323	6 to 8 weeks
-NULL	10001979	Mus musculus class II null	3324	null
-3 years	9615	Canis lupus familiaris (dogs)	3325	3 years
-7-30	9606	Homo sapiens (human)	3326	7-30
-23-35 years	9606	Homo sapiens (human)	3327	23-35 years
-3 to 75 years	9606	Homo sapiens (human)	3328	3 to 75 years
-8 to 12 weeks	10001363	Mus musculus 2D2 TCR Tg	3329	8 to 12 weeks
-39-54 years	9606	Homo sapiens (human)	3330	39-54 years
-9 weeks	10000662	Rattus norvegicus Lewis	3331	9 weeks
-average 44.3 years	9606	Homo sapiens (human)	3332	average 44.3 years
-NULL	10001721	Mus musculus HEL expression Tg	3333	null
-5-18 years	9606	Homo sapiens (human)	3334	5-18 years
-average 40.8 years	9606	Homo sapiens (human)	3335	average 40.8 years
-15-17 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3336	15-17 weeks
-15-17 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3337	15-17 weeks
-36-52 years	9606	Homo sapiens (human)	3338	36-52 years
-NULL	10002232	Mus musculus BDC2.5 TCR Tg	3339	null
-6 weeks	10000607	Mus musculus HLA-DR3 Tg	3340	6 weeks
-NULL	10002207	Mus musculus OT-3 TCR Tg	3341	null
-8-10 weeks old	10000101	Mus musculus C57BL/6 Perforin null	3342	8-10 weeks old
-NULL	10000286	Mus musculus B6.PL Thy1a/Cy	3343	null
-16-20 weeks	10000000	Mus musculus BALB/c	3344	16-20 weeks
-33-62 years	9606	Homo sapiens (human)	3345	33-62 years
-38-62 years	9606	Homo sapiens (human)	3346	38-62 years
-3.6-14.8 years	9606	Homo sapiens (human)	3347	3.6-14.8 years
-14-75 years	9606	Homo sapiens (human)	3348	14-75 years
-4-6.1 years	9606	Homo sapiens (human)	3349	4-6.1 years
-35-68 years	9606	Homo sapiens (human)	3350	35-68 years
-19-32 years	9606	Homo sapiens (human)	3351	19-32 years
-23–63 years	9606	Homo sapiens (human)	3352	2363 years
-24–62 years	9606	Homo sapiens (human)	3353	2462 years
-NULL	10000674	Mus musculus CB6F1 H-2d chimeric scid	3354	null
-21-79	9606	Homo sapiens (human)	3355	21-79
-21-37	9606	Homo sapiens (human)	3356	21-37
-26 and 54 years	9606	Homo sapiens (human)	3357	26 and 54 years
-11-64 years	9606	Homo sapiens (human)	3358	11-64 years
-16-20 weeks	10001982	Mus musculus 5/4E8 TCR Tg	3359	16-20 weeks
-34-63 years	9606	Homo sapiens (human)	3360	34-63 years
-NULL	10002012	Mus musculus B6.HOD	3361	null
-4-6 months	10001221	Mus musculus C57BL/6 x SJL	3362	4-6 months
-NULL	10002234	Mus musculus 508 TCR Tg	3363	null
-15 or 24 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3364	15 or 24 weeks
-37-492 months	9606	Homo sapiens (human)	3365	37-492 months
-11-71 years	9606	Homo sapiens (human)	3366	11-71 years
-31-73 years	9606	Homo sapiens (human)	3367	31-73 years
-6-20 weeks	10000067	Mus musculus C57BL/6	3368	6-20 weeks
-12 weeks	10001301	Mus musculus HLA-DR15 Tg	3369	12 weeks
-48-60 years	9606	Homo sapiens (human)	3370	48-60 years
-2-6 months	10000610	Mus musculus HLA-DR4 Tg	3371	2-6 months
-29 years ± 6.5	9606	Homo sapiens (human)	3372	29 years  6.5
-8 weeks	10001407	Mus musculus SNF1	3373	8 weeks
-8 to 12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3374	8 to 12 weeks
-20 to 56 years	9606	Homo sapiens (human)	3375	20 to 56 years
-4.5-14.3 years	9606	Homo sapiens (human)	3376	4.5-14.3 years
-2.0-15.1 years	9606	Homo sapiens (human)	3377	2.0-15.1 years
-8-12 weeks	10001470	Mus musculus Factor VIII null	3378	8-12 weeks
-59 to 77 years	9606	Homo sapiens (human)	3379	59 to 77 years
-6 to 8 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3380	6 to 8 weeks
-57 to 81 years	9606	Homo sapiens (human)	3381	57 to 81 years
-17 to 24	9606	Homo sapiens (human)	3382	17 to 24
-12-77 years	9606	Homo sapiens (human)	3383	12-77 years
-22-60 years	9606	Homo sapiens (human)	3384	22-60 years
-8 weeks	9823	Sus scrofa (pig)	3385	8 weeks
-30 years or younger	9606	Homo sapiens (human)	3386	30 years or younger
-25 to 40 years	9606	Homo sapiens (human)	3387	25 to 40 years
-3 to 5 months	10000067	Mus musculus C57BL/6	3388	3 to 5 months
-6 - 10 weeks	10000067	Mus musculus C57BL/6	3389	6 - 10 weeks
-NULL	10001283	Mus musculus BALB/c X B10.Q	3390	null
-25-51 years	9606	Homo sapiens (human)	3391	25-51 years
-6 - 8 weeks	10000582	Mus musculus HLA-A2 Tg	3392	6 - 8 weeks
-8-12 weeks	10001438	Mus musculus BALB/cAnN	3393	8-12 weeks
-32-66 years (mean = 50.3 year)	9606	Homo sapiens (human)	3394	32-66 years (mean = 50.3 year)
-18 to 55 years	9606	Homo sapiens (human)	3395	18 to 55 years
-8 - 16 weeks	10000067	Mus musculus C57BL/6	3396	8 - 16 weeks
-8 to 10 weeks or 21 months	10000067	Mus musculus C57BL/6	3397	8 to 10 weeks or 21 months
-6 weeks	10090	Mus musculus (mouse)	3398	6 weeks
-8-10 weeks	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	3399	8-10 weeks
-3 - 4 weeks	10000000	Mus musculus BALB/c	3400	3 - 4 weeks
-11-59 years	9606	Homo sapiens (human)	3401	11-59 years
-75-78 years	9606	Homo sapiens (human)	3402	75-78 years
-NULL	10002838	Mus musculus HLA-B*08:01 Tg	3403	null
-40 - 63 years	9606	Homo sapiens (human)	3404	40 - 63 years
-31-72 years	9606	Homo sapiens (human)	3405	31-72 years
-26-64 years	9606	Homo sapiens (human)	3406	26-64 years
-20-92 years	9606	Homo sapiens (human)	3407	20-92 years
-mean age = 45.2 years	9606	Homo sapiens (human)	3408	mean age = 45.2 years
-41-51 years	9606	Homo sapiens (human)	3409	41-51 years
-6 to 12 weeks	10090	Mus musculus (mouse)	3410	6 to 12 weeks
-6 - 8 weeks	10000595	Mus musculus HLA-B7 Tg	3411	6 - 8 weeks
-6 weeks to 22 months	10000067	Mus musculus C57BL/6	3412	6 weeks to 22 months
-5 to 6 weeks	10002014	Mus musculus Apolipoprotein B null	3413	5 to 6 weeks
-22 to 66 years	9606	Homo sapiens (human)	3414	22 to 66 years
-> 6 weeks	10000000	Mus musculus BALB/c	3415	> 6 weeks
-NULL	10002049	Mus musculus HLA-DRB1*03:02 Tg	3416	null
-8 months	10000017	Mus musculus BALB/c X DBA/2	3417	8 months
-10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3418	10 weeks
-3-12 months	10000017	Mus musculus BALB/c X DBA/2	3419	3-12 months
-2-3 months and 18-22 months	10000067	Mus musculus C57BL/6	3420	2-3 months and 18-22 months
-12 months	10000017	Mus musculus BALB/c X DBA/2	3421	12 months
-18 months	10000067	Mus musculus C57BL/6	3422	18 months
-6 - 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3423	6 - 8 weeks
-6-16 weeks	10090	Mus musculus (mouse)	3424	6-16 weeks
-8-12 weeks	10001347	Mus musculus 129/Sv	3425	8-12 weeks
-8 weeks	10001349	Mus musculus SJL X SWR	3426	8 weeks
-3 to 25 years	9606	Homo sapiens (human)	3427	3 to 25 years
-49-59 years	9606	Homo sapiens (human)	3428	49-59 years
-8 weeks	10002210	Mus musculus 8F10 TCR Tg	3429	8 weeks
-20-58 years	9606	Homo sapiens (human)	3430	20-58 years
-NULL	10001982	Mus musculus 5/4E8 TCR Tg	3431	null
-46 to 61 years	9606	Homo sapiens (human)	3432	46 to 61 years
-4 days to 5 weeks	10000067	Mus musculus C57BL/6	3433	4 days to 5 weeks
-8 to 20 weeks	10000067	Mus musculus C57BL/6	3434	8 to 20 weeks
-NULL	10002841	Mus musculus HLA-B44 Tg	3435	null
-NULL	10002845	Mus musculus HLA-C*07:01 Tg	3436	null
-22 - 53 years	9606	Homo sapiens (human)	3437	22 - 53 years
-NULL	10001989	Mus musculus HLA-A*01:01 Tg	3438	null
-NULL	10002212	Mus musculus 8.6 TCR Tg	3439	null
-8 weeks	10000973	Mus musculus 129	3440	8 weeks
-26 - 52 years	9606	Homo sapiens (human)	3441	26 - 52 years
-4 to 6 months	10001240	Mus musculus APPsw	3442	4 to 6 months
-21-54 years	9606	Homo sapiens (human)	3443	21-54 years
-8-16 weeks	10000047	Mus musculus C57BL/10	3444	8-16 weeks
-34-66.5 years	9606	Homo sapiens (human)	3445	34-66.5 years
-4 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3446	4 to 8 weeks
-8-16 weeks	10000601	Mus musculus HLA-DR1 Tg	3447	8-16 weeks
-newborn	10000263	Mus musculus B10.BR	3448	newborn
-46-78 years	9606	Homo sapiens (human)	3449	46-78 years
-6 to 8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3450	6 to 8 weeks
-> 6 weeks	10090	Mus musculus (mouse)	3451	> 6 weeks
-23-55 years-old	9606	Homo sapiens (human)	3452	23-55 years-old
-6 to 7 months	10000067	Mus musculus C57BL/6	3453	6 to 7 months
-10 months	10000220	Mus musculus C57BL/6 X DBA/2	3454	10 months
-32-55 years-old	9606	Homo sapiens (human)	3455	32-55 years-old
-31-43 years-old	9606	Homo sapiens (human)	3456	31-43 years-old
-2-3 months or 18-20 months	10001383	Mus musculus Clone 4 TCR Tg	3457	2-3 months or 18-20 months
-NULL	10002210	Mus musculus 8F10 TCR Tg	3458	null
-46-58 years	9606	Homo sapiens (human)	3459	46-58 years
-5 to 6 weeks	10000618	Mus musculus ICR	3460	5 to 6 weeks
-6 - 8 weeks	10000000	Mus musculus BALB/c	3461	6 - 8 weeks
-22 to 54 years	9606	Homo sapiens (human)	3462	22 to 54 years
-4-5 weeks	10001260	Mus musculus Tg AI4-NOD.Rag1-/-	3463	4-5 weeks
-6-13 weeks	10000649	Mus musculus SJL	3464	6-13 weeks
-24-71 years	9606	Homo sapiens (human)	3465	24-71 years
-18 months	10000000	Mus musculus BALB/c	3466	18 months
-30-62 years	9606	Homo sapiens (human)	3467	30-62 years
-8-12 weeks	10001098	Mus musculus RAG-1 null	3468	8-12 weeks
-8 weeks	10001414	Mus musculus 172.10 TCR Tg	3469	8 weeks
-34 to 58 years	9606	Homo sapiens (human)	3470	34 to 58 years
-NULL	10001634	Mus musculus IFNR null	3471	null
-6 weeks to 22 months	10000287	Mus musculus P14 TCR Tg	3472	6 weeks to 22 months
-5 to 7 weeks	10001438	Mus musculus BALB/cAnN	3473	5 to 7 weeks
-18 to 24 months	10000000	Mus musculus BALB/c	3474	18 to 24 months
-35 to 55 years	9606	Homo sapiens (human)	3475	35 to 55 years
-12 months	10000067	Mus musculus C57BL/6	3476	12 months
-6 months	10000017	Mus musculus BALB/c X DBA/2	3477	6 months
-8 -12 weeks	10000067	Mus musculus C57BL/6	3478	8 -12 weeks
-9-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3479	9-10 weeks
-6-8 weeks	10001383	Mus musculus Clone 4 TCR Tg	3480	6-8 weeks
-9-10 weeks	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	3481	9-10 weeks
-6 to 12 weeks	10000287	Mus musculus P14 TCR Tg	3482	6 to 12 weeks
-4-10 months	10000067	Mus musculus C57BL/6	3483	4-10 months
-1-3 weeks	9031	Gallus gallus (chicken)	3484	1-3 weeks
-10 to 12 weeks	10000649	Mus musculus SJL	3485	10 to 12 weeks
-21-42 years old	9606	Homo sapiens (human)	3486	21-42 years old
-18-78 years old	9606	Homo sapiens (human)	3487	18-78 years old
-NULL	10002840	Mus musculus HLA-B35 Tg	3488	null
-12-20 weeks	10000067	Mus musculus C57BL/6	3489	12-20 weeks
-26-28 months	10000067	Mus musculus C57BL/6	3490	26-28 months
-2 to 6 months	10000276	Mus musculus B10.S	3491	2 to 6 months
-2 to 6 months	10000047	Mus musculus C57BL/10	3492	2 to 6 months
-14 to 15 weeks	10001326	Mus musculus Tg4 TCR Tg	3493	14 to 15 weeks
-2 to 6 months	10000257	Mus musculus B10 X B10.S	3494	2 to 6 months
-6 weeks	10000973	Mus musculus 129	3495	6 weeks
-9-12 years	9606	Homo sapiens (human)	3496	9-12 years
-11-13 years	9606	Homo sapiens (human)	3497	11-13 years
-6 to 8 weeks or > 18 months	10001438	Mus musculus BALB/cAnN	3498	6 to 8 weeks or > 18 months
-38 to 63 years	9606	Homo sapiens (human)	3499	38 to 63 years
-12 to 16 weeks	10000028	Mus musculus C3H	3500	12 to 16 weeks
-mean age = 58 years	9606	Homo sapiens (human)	3501	mean age = 58 years
-NULL	10002220	Mus musculus P25 TCR Tg	3502	null
-5 to 6 weeks	10001592	Mus musculus LCMV GP33 TCR Tg	3503	5 to 6 weeks
-6 to 8 weeks	10001601	Mus musculus C57BL/6 X 129	3504	6 to 8 weeks
-8-10 weeks old	10001983	Mus musculus HLA-DRB1*03:01 Tg	3505	8-10 weeks old
-8 to 10 weeks	10000064	Mus musculus C57BL/10.Q	3506	8 to 10 weeks
-2 to 49 years	9606	Homo sapiens (human)	3507	2 to 49 years
-22 to 26 months	10000067	Mus musculus C57BL/6	3508	22 to 26 months
-2 to 26 months	10000067	Mus musculus C57BL/6	3509	2 to 26 months
-23-70 years	9606	Homo sapiens (human)	3510	23-70 years
-7 to 12 weeks	10000067	Mus musculus C57BL/6	3511	7 to 12 weeks
-16-59 years	10000113	Homo sapiens Black	3512	16-59 years
-NULL	10001438	Mus musculus BALB/cAnN	3513	null
-20 - 57 years	9606	Homo sapiens (human)	3514	20 - 57 years
-10-14 weeks	10000000	Mus musculus BALB/c	3515	10-14 weeks
-<16 hours	10001165	Mus musculus C57BR/cdJ	3516	<16 hours
-3 months	10000662	Rattus norvegicus Lewis	3517	3 months
-NULL	10000064	Mus musculus C57BL/10.Q	3518	null
-6 - 12 weeks	10000000	Mus musculus BALB/c	3519	6 - 12 weeks
-17 - 60 years	9606	Homo sapiens (human)	3520	17 - 60 years
-7-12 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	3521	7-12 weeks
-8-12 weeks	10000629	Mus musculus ND4 Swiss Webster	3522	8-12 weeks
-39.8 +/- 10.6 years	9606	Homo sapiens (human)	3523	39.8 ± 10.6 years
-8 to 16 weeks	10000067	Mus musculus C57BL/6	3524	8 to 16 weeks
-30 years old	9606	Homo sapiens (human)	3525	30 years old
-NULL	10002050	Mus musculus HLA-DQB1*03:02 Tg	3526	null
-8-16 weeks	10000289	Mus musculus BALB.B	3527	8-16 weeks
-5-7 weeks	10000649	Mus musculus SJL	3528	5-7 weeks
-5 to 6 weeks	10000287	Mus musculus P14 TCR Tg	3529	5 to 6 weeks
-14-56 years	9606	Homo sapiens (human)	3530	14-56 years
-4 week old	10000067	Mus musculus C57BL/6	3531	4 week old
-46 years old	9606	Homo sapiens (human)	3532	46 years old
-18-68 years	9606	Homo sapiens (human)	3533	18-68 years
-NULL	10002222	Mus musculus D1C55 TCR Tg	3534	null
-8-12 weeks	10000227	Mus musculus OT-1 TCR Tg	3535	8-12 weeks
-58 years old	9606	Homo sapiens (human)	3536	58 years old
-38 years old	9606	Homo sapiens (human)	3537	38 years old
-52 years old	9606	Homo sapiens (human)	3538	52 years old
-34 years old	9606	Homo sapiens (human)	3539	34 years old
-59 years old	9606	Homo sapiens (human)	3540	59 years old
-10-28 weeks	10000632	Mus musculus NOD	3541	10-28 weeks
-17 to 26 weeks	10000632	Mus musculus NOD	3542	17 to 26 weeks
-56 years old	9606	Homo sapiens (human)	3543	56 years old
-8 months	9940	Ovis aries (domestic sheep)	3544	8 months
-22-53 years	9606	Homo sapiens (human)	3545	22-53 years
-21-55 years	9606	Homo sapiens (human)	3546	21-55 years
-23-57 years	9606	Homo sapiens (human)	3547	23-57 years
-7 to 16 weeks	10000649	Mus musculus SJL	3548	7 to 16 weeks
-24-52	9606	Homo sapiens (human)	3549	24-52
-19-30	9606	Homo sapiens (human)	3550	19-30
-26-58	9606	Homo sapiens (human)	3551	26-58
-57	9606	Homo sapiens (human)	3552	57
-6-58 years	9606	Homo sapiens (human)	3553	6-58 years
-24-46	9606	Homo sapiens (human)	3554	24-46
-10 weeks	10000649	Mus musculus SJL	3555	10 weeks
-35-43 years-old	9606	Homo sapiens (human)	3556	35-43 years-old
-18 to 35, or 65 to 95 years.	9606	Homo sapiens (human)	3557	18 to 35, or 65 to 95 years.
-7 to 10 weeks	10000054	Mus musculus DBA/1	3558	7 to 10 weeks
-56 years	10000119	Homo sapiens Caucasian	3559	56 years
-6 to 8 weeks or 18 to 24 months	10000000	Mus musculus BALB/c	3560	6 to 8 weeks or 18 to 24 months
-7 to 8 week	10000067	Mus musculus C57BL/6	3561	7 to 8 week
-1-8 mos	10000067	Mus musculus C57BL/6	3562	1-8 months
-NULL	10001347	Mus musculus 129/Sv	3563	null
-NULL	10001406	Mus musculus MLR/lpr	3564	null
-7-15 weeks	10000067	Mus musculus C57BL/6	3565	7-15 weeks
-11-13 weeks	10001406	Mus musculus MLR/lpr	3566	11-13 weeks
-6-8 weeks	10002221	Mus musculus L9.6 TCR Tg	3567	6-8 weeks
-4 months	10000067	Mus musculus C57BL/6	3568	4 months
-7-10 weeks	10000595	Mus musculus HLA-B7 Tg	3569	7-10 weeks
-7-10 weeks	10000594	Mus musculus HLA-B27 Tg	3570	7-10 weeks
-7-10 weeks	10000582	Mus musculus HLA-A2 Tg	3571	7-10 weeks
-18-19 weeks	10000067	Mus musculus C57BL/6	3572	18-19 weeks
-32-39 weeks	10001405	Mus musculus NZB X NZW	3573	32-39 weeks
-8-14 weeks	10001405	Mus musculus NZB X NZW	3574	8-14 weeks
-6 to 8 weeks	10000607	Mus musculus HLA-DR3 Tg	3575	6 to 8 weeks
-31-39 years old	9606	Homo sapiens (human)	3576	31-39 years old
-5-6 weeks	10000619	Mus musculus ICR X Swiss	3577	5-6 weeks
-> 2 months	10000252	Mus musculus A.SW	3578	> 2 months
-8-16 weeks	10000255	Mus musculus AKR	3579	8-16 weeks
-6 week old	10000067	Mus musculus C57BL/6	3580	6 week old
-21-66 years	9606	Homo sapiens (human)	3581	21-66 years
-2-12 months	10001358	Mus musculus CWB	3582	2-12 months
-2-12 months	10000973	Mus musculus 129	3583	2-12 months
-24-82 years	9606	Homo sapiens (human)	3584	24-82 years
-21-51 years	9606	Homo sapiens (human)	3585	21-51 years
-at least 7 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3586	at least 7 weeks
-at least 7 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3587	at least 7 weeks
-8.9 to 18.7 years	9606	Homo sapiens (human)	3588	8.9 to 18.7 years
-8 to 10 weeks	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	3589	8 to 10 weeks
-20-73 years	9606	Homo sapiens (human)	3590	20-73 years
-48-75 years	9606	Homo sapiens (human)	3591	48-75 years
-23 to 69 years	9606	Homo sapiens (human)	3592	23 to 69 years
-6 to 12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3593	6 to 12 weeks
-33 to 49 years	9606	Homo sapiens (human)	3594	33 to 49 years
-8 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	3595	8 weeks
-6 to 10 weeks	10001989	Mus musculus HLA-A*01:01 Tg	3596	6 to 10 weeks
-6 to 10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3597	6 to 10 weeks
-35 to 50 years	9606	Homo sapiens (human)	3598	35 to 50 years
-30-51 years	9606	Homo sapiens (human)	3599	30-51 years
-6 motnhs to 15 years	9606	Homo sapiens (human)	3600	6 motnhs to 15 years
-30 to 70 years	9606	Homo sapiens (human)	3601	30 to 70 years
-12 weeks	10000105	Mus musculus TRAMP Tg	3602	12 weeks
-51-78 years	9606	Homo sapiens (human)	3603	51-78 years
-6-8 weeks	10001623	Mus musculus AG129	3604	6-8 weeks
-75-77 years	9606	Homo sapiens (human)	3605	75-77 years
-3-32 weeks	10000635	Mus musculus NOD/Lt	3606	3-32 weeks
-28 to 60 years	9606	Homo sapiens (human)	3607	28 to 60 years
-70	9606	Homo sapiens (human)	3608	70
-6 to 12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3609	6 to 12 weeks
->50 years-old	9606	Homo sapiens (human)	3610	>50 years-old
-> 6 weeks	10000067	Mus musculus C57BL/6	3611	> 6 weeks
-23 to 73 years	9606	Homo sapiens (human)	3612	23 to 73 years
-8 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3613	8 to 10 weeks
-9-12 weeks	9823	Sus scrofa (pig)	3614	9-12 weeks
-4 to 6 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3615	4 to 6 weeks
-12 weeks	10000187	Sus scrofa Landrace X Large White	3616	12 weeks
-27 +/- 6 years	9606	Homo sapiens (human)	3617	27 ± 6 years
-median age = 27 years	9606	Homo sapiens (human)	3618	median age = 27 years
-6-8 weeks	10002078	Mus musculus HLA-DP2 Tg	3619	6-8 weeks
-6 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3620	6 weeks
-6 weeks	10001998	Mus musculus CD1	3621	6 weeks
-19-76 years	9606	Homo sapiens (human)	3622	19-76 years
-5-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3623	5-8 weeks
-8-10 weeks	10001634	Mus musculus IFNR null	3624	8-10 weeks
-8 to 10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3625	8 to 10 weeks
-17 +/- 6 years	9606	Homo sapiens (human)	3626	17 ± 6 years
-26-57 years	9606	Homo sapiens (human)	3627	26-57 years
-5-62 years	9606	Homo sapiens (human)	3628	5-62 years
-55.2 +/- 20.1 years	9606	Homo sapiens (human)	3629	55.2 ± 20.1 years
-8-14 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3630	8-14 weeks
-46.1 +/- 14.8 years	9606	Homo sapiens (human)	3631	46.1 ± 14.8 years
-21-76 years	9606	Homo sapiens (human)	3632	21-76 years
-3 weeks	10000241	Gallus gallus H.B15	3633	3 weeks
-27-72 years	9606	Homo sapiens (human)	3634	27-72 years
-18-77 years	9606	Homo sapiens (human)	3635	18-77 years
-18-81 years	9606	Homo sapiens (human)	3636	18-81 years
-30-53 years old	9606	Homo sapiens (human)	3637	30-53 years old
-5-7 weeks	10002842	Mus musculus HLA-A*33:03 Tg	3638	5-7 weeks
-20-58 years-old	9606	Homo sapiens (human)	3639	20-58 years-old
-29-62	9606	Homo sapiens (human)	3640	29-62
-21-48 years-old	9606	Homo sapiens (human)	3641	21-48 years-old
-> 8 weeks	10000067	Mus musculus C57BL/6	3642	> 8 weeks
-4 to 7 weeks	10090	Mus musculus (mouse)	3643	4 to 7 weeks
-25-77 years	9606	Homo sapiens (human)	3644	25-77 years
-8-10 weeks	10000061	Mus musculus FVB	3645	8-10 weeks
-4-13 years	9606	Homo sapiens (human)	3646	4-13 years
-5 to 12 weeks	10000000	Mus musculus BALB/c	3647	5 to 12 weeks
-64	9606	Homo sapiens (human)	3648	64
-4-6 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3649	4-6 weeks
-6-20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3650	6-20 weeks
-8-12 weeks	10002229	Mus musculus CTL-9 TCR Tg	3651	8-12 weeks
-25-49 years	9606	Homo sapiens (human)	3652	25-49 years
-4 months	10000667	Rattus norvegicus Sprague-Dawley	3653	4 months
-8-44	9606	Homo sapiens (human)	3654	8-44
-8 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3655	8 weeks
-22 to 32 years	9606	Homo sapiens (human)	3656	22 to 32 years
-3-5 months	10001218	Mus musculus B10.A x A.BY	3657	3-5 months
-29-36 years	9606	Homo sapiens (human)	3658	29-36 years
-2-8 months	10001405	Mus musculus NZB X NZW	3659	2-8 months
-21-59 years-old	9606	Homo sapiens (human)	3660	21-59 years-old
-22-48 years-old	9606	Homo sapiens (human)	3661	22-48 years-old
-12-20 weeks	10001220	Mus musculus OT-II TCR Tg	3662	12-20 weeks
-35-95 years	9606	Homo sapiens (human)	3663	35-95 years
-6 to 10 weeks	10000055	Mus musculus DBA/2	3664	6 to 10 weeks
-6-20 weeks	10090	Mus musculus (mouse)	3665	6-20 weeks
-22-55 years-old	9606	Homo sapiens (human)	3666	22-55 years-old
-8 to 12 weeks	10000064	Mus musculus C57BL/10.Q	3667	8 to 12 weeks
-22-66 years	9606	Homo sapiens (human)	3668	22-66 years
-22-59 years-old	9606	Homo sapiens (human)	3669	22-59 years-old
-23-59 years-old	9606	Homo sapiens (human)	3670	23-59 years-old
-2 years 8 months to 3 years 9 months	9544	Macaca mulatta (rhesus macaque)	3671	2 years 8 months to 3 years 9 months
-<55 years	9606	Homo sapiens (human)	3672	<55 years
-58.5 +/- 18.2 years	9606	Homo sapiens (human)	3673	58.5 ± 18.2 years
-8-44 years	9606	Homo sapiens (human)	3674	8-44 years
-22-25 years	9606	Homo sapiens (human)	3675	22-25 years
-1 to 12 years	9606	Homo sapiens (human)	3676	1 to 12 years
-25-55 years-old	9606	Homo sapiens (human)	3677	25-55 years-old
-8 to 12 weeks	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	3678	8 to 12 weeks
-21-53 years-old	9606	Homo sapiens (human)	3679	21-53 years-old
-31-59 years-old	9606	Homo sapiens (human)	3680	31-59 years-old
-32-56 years-old	9606	Homo sapiens (human)	3681	32-56 years-old
-31-55 years-old	9606	Homo sapiens (human)	3682	31-55 years-old
-6-9 weeks	10000635	Mus musculus NOD/Lt	3683	6-9 weeks
-NULL	10001098	Mus musculus RAG-1 null	3684	null
-21-56 years-old	9606	Homo sapiens (human)	3685	21-56 years-old
-32-35 years-old	9606	Homo sapiens (human)	3686	32-35 years-old
-19-54 years-old	9606	Homo sapiens (human)	3687	19-54 years-old
-6 to 10 weeks	10000582	Mus musculus HLA-A2 Tg	3688	6 to 10 weeks
-5 to 8 weeks	10000000	Mus musculus BALB/c	3689	5 to 8 weeks
-NULL	10001483	Mus musculus HLA-A*0201/DRB1*0101	3690	null
-25-58 years-old	9606	Homo sapiens (human)	3691	25-58 years-old
-21-54 years-old	9606	Homo sapiens (human)	3692	21-54 years-old
-4-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3693	4-8 weeks
-30-55 years old	9606	Homo sapiens (human)	3694	30-55 years old
-25-59 years-old	9606	Homo sapiens (human)	3695	25-59 years-old
-6 to 8 weeks	10002070	Mus musculus C57BL/6 HBV1.3 HBV	3696	6 to 8 weeks
-8-12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3697	8-12 weeks
-22-49 years-old	9606	Homo sapiens (human)	3698	22-49 years-old
-25-43 years-old	9606	Homo sapiens (human)	3699	25-43 years-old
-29-62 years	9606	Homo sapiens (human)	3700	29-62 years
-4-6 weeks	10000595	Mus musculus HLA-B7 Tg	3701	4-6 weeks
-6 to 8 weeks	10000575	Mus musculus HBV(adr) transgenic BALB/c	3702	6 to 8 weeks
-8 to 10 weeks	10001998	Mus musculus CD1	3703	8 to 10 weeks
-30-55 years-old	9606	Homo sapiens (human)	3704	30-55 years-old
-33-53 years old	9606	Homo sapiens (human)	3705	33-53 years old
-32-53 years old	9606	Homo sapiens (human)	3706	32-53 years old
-35-53 years-old	9606	Homo sapiens (human)	3707	35-53 years-old
-33-41 years old	9606	Homo sapiens (human)	3708	33-41 years old
-prenatal	9606	Homo sapiens (human)	3709	prenatal
-33-55 years-old	9606	Homo sapiens (human)	3710	33-55 years-old
-31-53 years old	9606	Homo sapiens (human)	3711	31-53 years old
-33-55 years old	9606	Homo sapiens (human)	3712	33-55 years old
-40-53 years-old	9606	Homo sapiens (human)	3713	40-53 years-old
-32-53 years-old	9606	Homo sapiens (human)	3714	32-53 years-old
-32-40 years old	9606	Homo sapiens (human)	3715	32-40 years old
-32-47 years-old	9606	Homo sapiens (human)	3716	32-47 years-old
-31-56 years-old	9606	Homo sapiens (human)	3717	31-56 years-old
-33-48 years-old	9606	Homo sapiens (human)	3718	33-48 years-old
-22-51 years-old	9606	Homo sapiens (human)	3719	22-51 years-old
-30-48 years-old	9606	Homo sapiens (human)	3720	30-48 years-old
-30-53 years-old	9606	Homo sapiens (human)	3721	30-53 years-old
-33-53 years-old	9606	Homo sapiens (human)	3722	33-53 years-old
-33-40 years old	9606	Homo sapiens (human)	3723	33-40 years old
-32-44 years-old	9606	Homo sapiens (human)	3724	32-44 years-old
-31-48 years-old	9606	Homo sapiens (human)	3725	31-48 years-old
-31-55 years old	9606	Homo sapiens (human)	3726	31-55 years old
-43-55 years-old	9606	Homo sapiens (human)	3727	43-55 years-old
-32-55 years old	9606	Homo sapiens (human)	3728	32-55 years old
-32-59 years-old	9606	Homo sapiens (human)	3729	32-59 years-old
-33-34 years-old	9606	Homo sapiens (human)	3730	33-34 years-old
-32-48 years old	9606	Homo sapiens (human)	3731	32-48 years old
-39-53 years old	9606	Homo sapiens (human)	3732	39-53 years old
-32-47 years old	9606	Homo sapiens (human)	3733	32-47 years old
-22-47 years-old	9606	Homo sapiens (human)	3734	22-47 years-old
-21-45 years-old	9606	Homo sapiens (human)	3735	21-45 years-old
-22-53 years-old	9606	Homo sapiens (human)	3736	22-53 years-old
-21-47 years-old	9606	Homo sapiens (human)	3737	21-47 years-old
-22-54 years-old	9606	Homo sapiens (human)	3738	22-54 years-old
-32-49 years-old	9606	Homo sapiens (human)	3739	32-49 years-old
-21-24 days	10001248	Mus musculus NOD.Cg-Tg	3740	21-24 days
-31-54 years-old	9606	Homo sapiens (human)	3741	31-54 years-old
-12 to 15 weeks	10000067	Mus musculus C57BL/6	3742	12 to 15 weeks
-22-44 years-old	9606	Homo sapiens (human)	3743	22-44 years-old
-23-45 years-old	9606	Homo sapiens (human)	3744	23-45 years-old
-NULL	10002228	Mus musculus TRBV13-2 TCR Tg	3745	null
-3 years old	9544	Macaca mulatta (rhesus macaque)	3746	3 years old
-35-55 years-old	9606	Homo sapiens (human)	3747	35-55 years-old
-4-8 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3748	4-8 weeks
-21-32 years-old	9606	Homo sapiens (human)	3749	21-32 years-old
-> 8 weeks	10000000	Mus musculus BALB/c	3750	> 8 weeks
-21-52 years-old	9606	Homo sapiens (human)	3751	21-52 years-old
-27-53 years-old	9606	Homo sapiens (human)	3752	27-53 years-old
-4 and 12 weeks	10002071	Mus musculus LLO56 TCR Tg	3753	4 and 12 weeks
-4 and 12 weeks	10002072	Mus musculus LLO118 TCR Tg	3754	4 and 12 weeks
-22-43 years-old	9606	Homo sapiens (human)	3755	22-43 years-old
-23-44 years-old	9606	Homo sapiens (human)	3756	23-44 years-old
-10 to 12 weeks	10000067	Mus musculus C57BL/6	3757	10 to 12 weeks
-NULL	10002206	Mus musculus 5CC7 TCR Tg	3758	null
-21-49 years-old	9606	Homo sapiens (human)	3759	21-49 years-old
-6 to 14 weeks	10000067	Mus musculus C57BL/6	3760	6 to 14 weeks
-23-60 years	9606	Homo sapiens (human)	3761	23-60 years
-10 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	3762	10 weeks
-12-16 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3763	12-16 weeks
-8-12 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3764	8-12 weeks
-25 to 82 years	9606	Homo sapiens (human)	3765	25 to 82 years
-25 to 81 years	9606	Homo sapiens (human)	3766	25 to 81 years
-39 to 57 years	9606	Homo sapiens (human)	3767	39 to 57 years
-23-48 years-old	9606	Homo sapiens (human)	3768	23-48 years-old
-25-54 years-old	9606	Homo sapiens (human)	3769	25-54 years-old
-27-55 years-old	9606	Homo sapiens (human)	3770	27-55 years-old
-16 weeks	10000632	Mus musculus NOD	3771	16 weeks
-6 to 8 weeks	9544	Macaca mulatta (rhesus macaque)	3772	6 to 8 weeks
-44-45 years old	9606	Homo sapiens (human)	3773	44-45 years old
-31-45 years-old	9606	Homo sapiens (human)	3774	31-45 years-old
-12-71 years	9606	Homo sapiens (human)	3775	12-71 years
-25 years	9598	Pan troglodytes (chimpanzee)	3776	25 years
-10 weeks or 23 weeks	10000067	Mus musculus C57BL/6	3777	10 weeks or 23 weeks
-8-9 months	10000067	Mus musculus C57BL/6	3778	8-9 months
-8 to 10 months	10000067	Mus musculus C57BL/6	3779	8 to 10 months
-28-57 years	9606	Homo sapiens (human)	3780	28-57 years
-8-10 weeks	10000227	Mus musculus OT-1 TCR Tg	3781	8-10 weeks
-8-10 weeks	10001220	Mus musculus OT-II TCR Tg	3782	8-10 weeks
-17 to 59 years	9606	Homo sapiens (human)	3783	17 to 59 years
-8-10 weeks or 18-22 months	10000067	Mus musculus C57BL/6	3784	8-10 weeks or 18-22 months
-7-66 years	9606	Homo sapiens (human)	3785	7-66 years
-6 weeks	10001347	Mus musculus 129/Sv	3786	6 weeks
-19-41 years	9606	Homo sapiens (human)	3787	19-41 years
-6 weeks	10000582	Mus musculus HLA-A2 Tg	3788	6 weeks
-10-63 years	9606	Homo sapiens (human)	3789	10-63 years
-19-54 years	9606	Homo sapiens (human)	3790	19-54 years
-20-61 years	9606	Homo sapiens (human)	3791	20-61 years
-22-39	9606	Homo sapiens (human)	3792	22-39
-5 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3793	5 weeks
-4-6 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3794	4-6 weeks
-24-108 months	9606	Homo sapiens (human)	3795	24-108 months
-8 to 12 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	3796	8 to 12 weeks
-embryonic day 15	10000067	Mus musculus C57BL/6	3797	embryonic day 15
-22-56 years	9606	Homo sapiens (human)	3798	22-56 years
-7 to 8 weeks	10000000	Mus musculus BALB/c	3799	7 to 8 weeks
-7 to 8 weeks	10000649	Mus musculus SJL	3800	7 to 8 weeks
-22-64 years	9606	Homo sapiens (human)	3801	22-64 years
-8 to 12 weeks	10002224	Mus musculus mB29b TCR Tg	3802	8 to 12 weeks
-18 to 56 years	10000119	Homo sapiens Caucasian	3803	18 to 56 years
-9 to 56 years	10000119	Homo sapiens Caucasian	3804	9 to 56 years
-18-40 years, 65 years and over.	9606	Homo sapiens (human)	3805	18-40 years, 65 years and over.
-8-12 weeks	10000597	Mus musculus HLA-DQ6 Tg	3806	8-12 weeks
-12 to 16 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3807	12 to 16 weeks
-3-15 weeks	10000632	Mus musculus NOD	3808	3-15 weeks
-16 to 18 months	10000067	Mus musculus C57BL/6	3809	16 to 18 months
-4 to 6 weeks	10000632	Mus musculus NOD	3810	4 to 6 weeks
-3 to 5 weeks	10000000	Mus musculus BALB/c	3811	3 to 5 weeks
-12-15 weeks	10000067	Mus musculus C57BL/6	3812	12-15 weeks
-8 weeks	10000275	Mus musculus B10.RIII	3813	8 weeks
-53-78 years	9606	Homo sapiens (human)	3814	53-78 years
-8 to 12 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	3815	8 to 12 weeks
-8 to 12 weeks	10001299	Mus musculus HLA-DRB1*04:02 Tg	3816	8 to 12 weeks
-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3817	10 weeks
-18 to 77 years	9606	Homo sapiens (human)	3818	18 to 77 years
-18 to 60 years	9606	Homo sapiens (human)	3819	18 to 60 years
-15-16 weeks	10000632	Mus musculus NOD	3820	15-16 weeks
-1 day, 7-8 days or adult	10000067	Mus musculus C57BL/6	3821	1 day, 7-8 days or adult
-6 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3822	6 weeks
-5-8 weeks	10000632	Mus musculus NOD	3823	5-8 weeks
-5-8 weeks	10000024	Mus musculus Biozzi	3824	5-8 weeks
-5-8 weeks	10000649	Mus musculus SJL	3825	5-8 weeks
-4 to 6 weeks	10047	Meriones unguiculatus (Mongolian jird)	3826	4 to 6 weeks
-23-72 years	9606	Homo sapiens (human)	3827	23-72 years
-22-29 years	9606	Homo sapiens (human)	3828	22-29 years
-23-27 years	9606	Homo sapiens (human)	3829	23-27 years
-22-26 years	9606	Homo sapiens (human)	3830	22-26 years
-NULL	10001626	Mus musculus beta2m null	3831	null
-47-76 years	9606	Homo sapiens (human)	3832	47-76 years
-6 months to 18 years	9606	Homo sapiens (human)	3833	6 months to 18 years
-13 and 21 years	9606	Homo sapiens (human)	3834	13 and 21 years
-1-15 years	9606	Homo sapiens (human)	3835	1-15 years
-26 to 53 months	9483	Callithrix jacchus (common marmoset)	3836	26 to 53 months
-27 to 52 years	9606	Homo sapiens (human)	3837	27 to 52 years
-13 to 21 years	9606	Homo sapiens (human)	3838	13 to 21 years
-9 to 38 years	9606	Homo sapiens (human)	3839	9 to 38 years
-22 to 68 years	9606	Homo sapiens (human)	3840	22 to 68 years
-22 and 68 years	9606	Homo sapiens (human)	3841	22 and 68 years
-3-5 weeks	10000632	Mus musculus NOD	3842	3-5 weeks
-6-16 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	3843	6-16 weeks
-13 to 28 years	9606	Homo sapiens (human)	3844	13 to 28 years
-3 to 5 weeks	10000632	Mus musculus NOD	3845	3 to 5 weeks
-6 to 20 weeks	10000632	Mus musculus NOD	3846	6 to 20 weeks
-mean age 35 +/- 11 years	9606	Homo sapiens (human)	3847	mean age 35 ± 11 years
-6 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3848	6 weeks
-23 weeks	10000067	Mus musculus C57BL/6	3849	23 weeks
-8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3850	8 weeks
-13 to 38 years	9606	Homo sapiens (human)	3851	13 to 38 years
-28-66 years	9606	Homo sapiens (human)	3852	28-66 years
-3-18 years	9606	Homo sapiens (human)	3853	3-18 years
-10 weeks	9825	Sus scrofa domesticus (domestic pig)	3854	10 weeks
-15 to 41 years	9606	Homo sapiens (human)	3855	15 to 41 years
-6 to 12 weeks	10000274	Mus musculus B10.PL	3856	6 to 12 weeks
-20 to 25 years	9606	Homo sapiens (human)	3857	20 to 25 years
-6-10 weeks	10002237	Mus musculus TCR3 Rg	3858	6-10 weeks
-53-63 yeras	9606	Homo sapiens (human)	3859	53-63 years
-average age = 4.38 years	9606	Homo sapiens (human)	3860	average age = 4.38 years
-6 to 8 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3861	6 to 8 weeks
-6 to 8 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3862	6 to 8 weeks
-NULL	10001487	Mus musculus Apolipoprotein E null	3863	null
-22 to 63 years	9606	Homo sapiens (human)	3864	22 to 63 years
-25-78 years	9606	Homo sapiens (human)	3865	25-78 years
-2 weeks	10000000	Mus musculus BALB/c	3866	2 weeks
-11-80 years	9606	Homo sapiens (human)	3867	11-80 years
-41 +/- 11 years	9606	Homo sapiens (human)	3868	41 ± 11 years
-33-55 years	9606	Homo sapiens (human)	3869	33-55 years
-51-67 years	9606	Homo sapiens (human)	3870	51-67 years
-33-59 years-old	9606	Homo sapiens (human)	3871	33-59 years-old
-10 to 27 years	9606	Homo sapiens (human)	3872	10 to 27 years
-21 to 74 years	10000119	Homo sapiens Caucasian	3873	21 to 74 years
-25 to 73 years	9606	Homo sapiens (human)	3874	25 to 73 years
-20 to 55 years	9606	Homo sapiens (human)	3875	20 to 55 years
-47-64 years	9606	Homo sapiens (human)	3876	47-64 years
-1 day	10000067	Mus musculus C57BL/6	3877	1 day
-28-59 years	9606	Homo sapiens (human)	3878	28-59 years
-58-68 years	9606	Homo sapiens (human)	3879	58-68 years
-45-65 years	9606	Homo sapiens (human)	3880	45-65 years
-44-68 years	9606	Homo sapiens (human)	3881	44-68 years
-39-65 years	9606	Homo sapiens (human)	3882	39-65 years
-> 14 weeks	10000047	Mus musculus C57BL/10	3883	> 14 weeks
-64 yeras	9606	Homo sapiens (human)	3884	64 years
-average age=36.5 years	9606	Homo sapiens (human)	3885	average age=36.5 years
-6-27 weeks	10000028	Mus musculus C3H	3886	6-27 weeks
-22 to 76 years	9606	Homo sapiens (human)	3887	22 to 76 years
-NULL	10002223	Mus musculus RSV-M187 TCR Tg	3888	null
-3 months	10002050	Mus musculus HLA-DQB1*03:02 Tg	3889	3 months
-6-8 weeks	10001220	Mus musculus OT-II TCR Tg	3890	6-8 weeks
-18-21 years	9606	Homo sapiens (human)	3891	18-21 years
-14-18 months	9606	Homo sapiens (human)	3892	14-18 months
-5-6 weeks	10000635	Mus musculus NOD/Lt	3893	5-6 weeks
-9 months to 81 years	9606	Homo sapiens (human)	3894	9 months to 81 years
-average age = 48 years	9606	Homo sapiens (human)	3895	average age = 48 years
-42 to 61 years	9606	Homo sapiens (human)	3896	42 to 61 years
-7 -11 years	9606	Homo sapiens (human)	3897	7 -11 years
-7 - 11 years	9606	Homo sapiens (human)	3898	7 - 11 years
-6-12 years	9606	Homo sapiens (human)	3899	6-12 years
-5-6 weeks	10001347	Mus musculus 129/Sv	3900	5-6 weeks
-30-48 years old	9606	Homo sapiens (human)	3901	30-48 years old
-32-44 years old	9606	Homo sapiens (human)	3902	32-44 years old
-4 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3903	4 weeks
-23 to 57 years	9606	Homo sapiens (human)	3904	23 to 57 years
-4 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3905	4 weeks
-19-65 years-old	9606	Homo sapiens (human)	3906	19-65 years-old
-44-55 years	9606	Homo sapiens (human)	3907	44-55 years
-37-63 years	9606	Homo sapiens (human)	3908	37-63 years
-10 to 21 years	9606	Homo sapiens (human)	3909	10 to 21 years
-18+ years	9606	Homo sapiens (human)	3910	18+ years
-19 to 61 years	9606	Homo sapiens (human)	3911	19 to 61 years
-30 to 49 years	9606	Homo sapiens (human)	3912	30 to 49 years
-> 6 weeks	10000582	Mus musculus HLA-A2 Tg	3913	> 6 weeks
-7 days	9031	Gallus gallus (chicken)	3914	7 days
-20 to 80 years	9606	Homo sapiens (human)	3915	20 to 80 years
-26.2 +/- 4.8 years	9606	Homo sapiens (human)	3916	26.2 ± 4.8 years
-12 to 14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3917	12 to 14 weeks
-15 to 72 years	9606	Homo sapiens (human)	3918	15 to 72 years
-median 41.7 years	9606	Homo sapiens (human)	3919	median 41.7 years
-27 to 64 years	9606	Homo sapiens (human)	3920	27 to 64 years
-18 to 51 years	9606	Homo sapiens (human)	3921	18 to 51 years
-9 to 65 years	9606	Homo sapiens (human)	3922	9 to 65 years
-23 to 60 years	9606	Homo sapiens (human)	3923	23 to 60 years
-21 to 60 years	9606	Homo sapiens (human)	3924	21 to 60 years
-21 to 44 years	9606	Homo sapiens (human)	3925	21 to 44 years
-6 to 8 months	10002166	Bos taurus Japanese Black	3926	6 to 8 months
-average age=32 years	9606	Homo sapiens (human)	3927	average age=32 years
-2 months	10000200	Oryctolagus cuniculus Chinchilla	3928	2 months
-19 weeks	10000632	Mus musculus NOD	3929	19 weeks
-8 weeks	10000227	Mus musculus OT-1 TCR Tg	3930	8 weeks
-3 weeks	10000920	Gallus gallus Leghorn	3931	3 weeks
-8 to 12 weeks	10001397	Mus musculus MOG null	3932	8 to 12 weeks
-21-68 years	9606	Homo sapiens (human)	3933	21-68 years
-39-69 years	9606	Homo sapiens (human)	3934	39-69 years
-12 +/- 2 weeks	9913	Bos taurus (bovine)	3935	12 ± 2 weeks
-23-85 years	9606	Homo sapiens (human)	3936	23-85 years
-3 weeks	9823	Sus scrofa (pig)	3937	3 weeks
-18-58 years	9606	Homo sapiens (human)	3938	18-58 years
-1-25 years	9606	Homo sapiens (human)	3939	1-25 years
-6 weeks	10001248	Mus musculus NOD.Cg-Tg	3940	6 weeks
-6 to 8 weeks	10000973	Mus musculus 129	3941	6 to 8 weeks
-22-46 years	9606	Homo sapiens (human)	3942	22-46 years
-20 to 70 years	9606	Homo sapiens (human)	3943	20 to 70 years
-22 to 60 yeras	9606	Homo sapiens (human)	3944	22 to 60 years
-6 to 10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3945	6 to 10 weeks
-27.5 to 32.5 months	9541	Macaca fascicularis (crab eating macaque)	3946	27.5 to 32.5 months
-17-47 years	9606	Homo sapiens (human)	3947	17-47 years
-25–87 years	9606	Homo sapiens (human)	3948	2587 years
-6-8	10000582	Mus musculus HLA-A2 Tg	3949	6-8
-24–88 years	9606	Homo sapiens (human)	3950	2488 years
-24–87 years	9606	Homo sapiens (human)	3951	2487 years
-25–88 years	9606	Homo sapiens (human)	3952	2588 years
-8 to 12 weeks	10000635	Mus musculus NOD/Lt	3953	8 to 12 weeks
-24-88 years	9606	Homo sapiens (human)	3954	24-88 years
-24-87 years	9606	Homo sapiens (human)	3955	24-87 years
-27 to 59 years	9606	Homo sapiens (human)	3956	27 to 59 years
-young adults	10000615	Mus musculus HLA-DRB1*01:01 Tg	3957	young adults
-young adults	10000616	Mus musculus HLA-DRB1*04:01 Tg	3958	young adults
-young adults	10001399	Mus musculus HLA-DQB1*06:02 Tg	3959	young adults
-young adults	10002050	Mus musculus HLA-DQB1*03:02 Tg	3960	young adults
-32-85 years	9606	Homo sapiens (human)	3961	32-85 years
-6 to 10 weeks	10002177	Mus musculus HLA-B*40:01 Tg	3962	6 to 10 weeks
-17-41 years	9606	Homo sapiens (human)	3963	17-41 years
-8-12 weeks	10000225	Mus musculus C57BL/6N	3964	8-12 weeks
-young adults	10001400	Mus musculus HLA-DRB1*15:02 Tg	3965	young adults
-young adults	10001381	Mus musculus HLA-DRB1*15:01 Tg	3966	young adults
-< 6 weeks	10000632	Mus musculus NOD	3967	< 6 weeks
-> 6 weeks	10000632	Mus musculus NOD	3968	> 6 weeks
-6 and 12 weeks	10000632	Mus musculus NOD	3969	6 and 12 weeks
-5 to 6 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3970	5 to 6 weeks
-19 to 65 years	9606	Homo sapiens (human)	3971	19 to 65 years
-6 to 7 weeks	10000661	Rattus norvegicus Fischer 344	3972	6 to 7 weeks
-12 months	9823	Sus scrofa (pig)	3973	12 months
-3 to 8 months	10000601	Mus musculus HLA-DR1 Tg	3974	3 to 8 months
-3 to 8 months	10000610	Mus musculus HLA-DR4 Tg	3975	3 to 8 months
-calf	10000193	Bos taurus Holstein	3976	calf
-6 weeks	10001634	Mus musculus IFNR null	3977	6 weeks
-11 weeks	10001221	Mus musculus C57BL/6 x SJL	3978	11 weeks
-53 to 83 years	9606	Homo sapiens (human)	3979	53 to 83 years
-32 to 78 years	9606	Homo sapiens (human)	3980	32 to 78 years
-2-3 months	10090	Mus musculus (mouse)	3981	2-3 months
-8 to 12 weeks	10001220	Mus musculus OT-II TCR Tg	3982	8 to 12 weeks
-41 to 75 years	9606	Homo sapiens (human)	3983	41 to 75 years
-40 to 73 years	9606	Homo sapiens (human)	3984	40 to 73 years
-21 to 77 years	9606	Homo sapiens (human)	3985	21 to 77 years
-6 to 59 years	9606	Homo sapiens (human)	3986	6 to 59 years
-≥ 18 years	9606	Homo sapiens (human)	3987	 18 years
-6 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3988	6 weeks
-10-14 months	10000188	Sus scrofa NIH miniature pig	3989	10-14 months
-4-6 weeks	10000607	Mus musculus HLA-DR3 Tg	3990	4-6 weeks
-36 to 59 years	9606	Homo sapiens (human)	3991	36 to 59 years
-58	9606	Homo sapiens (human)	3992	58
-21-92 years	9606	Homo sapiens (human)	3993	21-92 years
-18-22 weeks	10000067	Mus musculus C57BL/6	3994	18-22 weeks
-9-14 weeks	10000067	Mus musculus C57BL/6	3995	9-14 weeks
-6 weeks	10001001	Rattus norvegicus WKAH	3996	6 weeks
-6 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3997	6 weeks
-14-38 years	9606	Homo sapiens (human)	3998	14-38 years
-8 to 10 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	3999	8 to 10 weeks
-5 weeks	10001001	Rattus norvegicus WKAH	4000	5 weeks
-2-5 months	10000276	Mus musculus B10.S	4001	2-5 months
-2-6 months	10001656	Mus musculus HNT TCR Tg	4002	2-6 months
-38 to 52 years	9606	Homo sapiens (human)	4003	38 to 52 years
-8-60 years	9606	Homo sapiens (human)	4004	8-60 years
-20-39 years	9606	Homo sapiens (human)	4005	20-39 years
-23.3 to 45.9 years	9606	Homo sapiens (human)	4006	23.3 to 45.9 years
-31.2 to 63.0 years	9606	Homo sapiens (human)	4007	31.2 to 63.0 years
-14 to 19 years	9606	Homo sapiens (human)	4008	14 to 19 years
-23 to 74 years	9606	Homo sapiens (human)	4009	23 to 74 years
-5-60 years	9606	Homo sapiens (human)	4010	5-60 years
-7.3 to 60.0 years	9606	Homo sapiens (human)	4011	7.3 to 60.0 years
-7.4 to 22.9 years	9606	Homo sapiens (human)	4012	7.4 to 22.9 years
-6-12 weeks	10001347	Mus musculus 129/Sv	4013	6-12 weeks
-47-66 years	9606	Homo sapiens (human)	4014	47-66 years
-29-39 years	9606	Homo sapiens (human)	4015	29-39 years
-28-71 years	9606	Homo sapiens (human)	4016	28-71 years
-6 to 12 weeks	10001326	Mus musculus Tg4 TCR Tg	4017	6 to 12 weeks
-23-31 years	9606	Homo sapiens (human)	4018	23-31 years
-8-12 weeks	10001301	Mus musculus HLA-DR15 Tg	4019	8-12 weeks
-16-34 years	9606	Homo sapiens (human)	4020	16-34 years
-54-73 years	9606	Homo sapiens (human)	4021	54-73 years
-6 to 8 weeks	10001438	Mus musculus BALB/cAnN	4022	6 to 8 weeks
-8-10 weeks	10001539	Mus musculus TCR transgenic	4023	8-10 weeks
-11-78 months	9606	Homo sapiens (human)	4024	11-78 months
-18-38 months	9606	Homo sapiens (human)	4025	18-38 months
-21 to 61 years	9606	Homo sapiens (human)	4026	21 to 61 years
-12 to 68 years	9606	Homo sapiens (human)	4027	12 to 68 years
-13-45 years	9606	Homo sapiens (human)	4028	13-45 years
-46-83 years	9606	Homo sapiens (human)	4029	46-83 years
-52-83 years	9606	Homo sapiens (human)	4030	52-83 years
-34-61 years	9606	Homo sapiens (human)	4031	34-61 years
-46-65 years	9606	Homo sapiens (human)	4032	46-65 years
-12 weeks	10000662	Rattus norvegicus Lewis	4033	12 weeks
-6-7 weeks	10001166	Mus musculus HLA-A24 Tg	4034	6-7 weeks
-37-58 years	9606	Homo sapiens (human)	4035	37-58 years
-2-6 months	10000253	Mus musculus A/J	4036	2-6 months
-30.9 to 42.1 years	9606	Homo sapiens (human)	4037	30.9 to 42.1 years
-36 to 88 years	9606	Homo sapiens (human)	4038	36 to 88 years
-25-69 years	9606	Homo sapiens (human)	4039	25-69 years
-4-6 weeks	10000287	Mus musculus P14 TCR Tg	4040	4-6 weeks
-8-9 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4041	8-9 weeks
-2-3 years	9823	Sus scrofa (pig)	4042	2-3 years
-7 to 8 weeks	10000067	Mus musculus C57BL/6	4043	7 to 8 weeks
-19 to 36 years	9606	Homo sapiens (human)	4044	19 to 36 years
-12 to 36 years	9606	Homo sapiens (human)	4045	12 to 36 years
-12 to 18 years	9606	Homo sapiens (human)	4046	12 to 18 years
-63-79 days	9823	Sus scrofa (pig)	4047	63-79 days
-91 days	9823	Sus scrofa (pig)	4048	91 days
-5 to 25 years	9606	Homo sapiens (human)	4049	5 to 25 years
-25 days	8839	Anas platyrhynchos (duck)	4050	25 days
-41-59 years	9606	Homo sapiens (human)	4051	41-59 years
-23-61 years	9606	Homo sapiens (human)	4052	23-61 years
-18-70 years	9606	Homo sapiens (human)	4053	18-70 years
-NULL	10000105	Mus musculus TRAMP Tg	4054	null
-24-74 years	9606	Homo sapiens (human)	4055	24-74 years
-32-64 years	9606	Homo sapiens (human)	4056	32-64 years
-10 to 15 years	9606	Homo sapiens (human)	4057	10 to 15 years
-11 to 27 years	9606	Homo sapiens (human)	4058	11 to 27 years
->18 years	9606	Homo sapiens (human)	4059	>18 years
-27-53 years	9606	Homo sapiens (human)	4060	27-53 years
-61-81 years	9606	Homo sapiens (human)	4061	61-81 years
-59-71 years	9606	Homo sapiens (human)	4062	59-71 years
-22-75 years	9606	Homo sapiens (human)	4063	22-75 years
-22-71 years	9606	Homo sapiens (human)	4064	22-71 years
-8-16 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4065	8-16 weeks
-8-16 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	4066	8-16 weeks
-8-16 weeks	10001256	Mus musculus GAD286 TCR Tg	4067	8-16 weeks
-8 to 24 years	9606	Homo sapiens (human)	4068	8 to 24 years
-8-16 weeks	10001261	Mus musculus G9Calpha –/ –.NOD	4069	8-16 weeks
-9 to 23 years	9606	Homo sapiens (human)	4070	9 to 23 years
-13 to 35 years	9606	Homo sapiens (human)	4071	13 to 35 years
-6 to 8 weeks	10001347	Mus musculus 129/Sv	4072	6 to 8 weeks
-2 months	9940	Ovis aries (domestic sheep)	4073	2 months
-12 to 18 weeks	10002220	Mus musculus P25 TCR Tg	4074	12 to 18 weeks
-49-61 years	9606	Homo sapiens (human)	4075	49-61 years
-18 years	10000119	Homo sapiens Caucasian	4076	18 years
-Neonates (3 or 7 days)	10000067	Mus musculus C57BL/6	4077	neonates (3 or 7 days)
-16-86 years	9606	Homo sapiens (human)	4078	16-86 years
-8 to 16 weeks	10000610	Mus musculus HLA-DR4 Tg	4079	8 to 16 weeks
-8-12 months	10002063	Ovis aries Merino	4080	8-12 months
-NULL	10002277	Mus musculus MOG-specific TCR beta-chain Tg	4081	null
-7 to 10 weeks	10000096	Mus musculus C57BL/6 IL-10 null	4082	7 to 10 weeks
-Neonates (3 days)	10000067	Mus musculus C57BL/6	4083	neonates (3 days)
-adult	10000227	Mus musculus OT-1 TCR Tg	4084	adult
-6-11 weeks	10000067	Mus musculus C57BL/6	4085	6-11 weeks
-6-11 weeks	10001363	Mus musculus 2D2 TCR Tg	4086	6-11 weeks
-8 to 12 weeks	10002220	Mus musculus P25 TCR Tg	4087	8 to 12 weeks
-6-8 weeks	10001979	Mus musculus class II null	4088	6-8 weeks
-40-58 years	9606	Homo sapiens (human)	4089	40-58 years
-Infant	9606	Homo sapiens (human)	4090	infant
-4 week	10000635	Mus musculus NOD/Lt	4091	4 week
-5 to 6 weeks	10000253	Mus musculus A/J	4092	5 to 6 weeks
-17 to 40 years	9606	Homo sapiens (human)	4093	17 to 40 years
-29 and 53 years	9606	Homo sapiens (human)	4094	29 and 53 years
-30 days	8855	Cairina moschata (muscovy)	4095	30 days
-20-60 years	9606	Homo sapiens (human)	4096	20-60 years
-37-74	9606	Homo sapiens (human)	4097	37-74
-8-16 weeks	10001802	Mus musculus NY8.3 TCR Tg	4098	8-16 weeks
-12 to 62 years	9606	Homo sapiens (human)	4099	12 to 62 years
-24 to 42 years	9606	Homo sapiens (human)	4100	24 to 42 years
-NULL	10001758	Mus musculus 6218 TCR Tg	4101	null
-26-39 years	9606	Homo sapiens (human)	4102	26-39 years
-26-62 years	9606	Homo sapiens (human)	4103	26-62 years
-2-12 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	4104	2-12 months
-8-18 weeks	10000067	Mus musculus C57BL/6	4105	8-18 weeks
-6 to 53 years	9606	Homo sapiens (human)	4106	6 to 53 years
-6 yo 8 weeks	10000000	Mus musculus BALB/c	4107	6 year 8 weeks
-6 yo 8 weeks	10000067	Mus musculus C57BL/6	4108	6 year 8 weeks
-53-71 years	9606	Homo sapiens (human)	4109	53-71 years
-23-33 years	9606	Homo sapiens (human)	4110	23-33 years
-46 to 64 years	9606	Homo sapiens (human)	4111	46 to 64 years
-8 to 16 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4112	8 to 16 weeks
-8 to 16 weeks	10000632	Mus musculus NOD	4113	8 to 16 weeks
-55 to 70 years	9606	Homo sapiens (human)	4114	55 to 70 years
-8 to 16 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	4115	8 to 16 weeks
-8 to 16 weeks	10001802	Mus musculus NY8.3 TCR Tg	4116	8 to 16 weeks
-21.6 to 60.6 years	9606	Homo sapiens (human)	4117	21.6 to 60.6 years
-6 weeks	10000975	Mus musculus FVB Db Tg	4118	6 weeks
-Pediatric	9606	Homo sapiens (human)	4119	pediatric
-27-82 years	9606	Homo sapiens (human)	4120	27-82 years
-12-18 weeks	10000253	Mus musculus A/J	4121	12-18 weeks
-3-65 years	9606	Homo sapiens (human)	4122	3-65 years
-6-8 weeks	10001438	Mus musculus BALB/cAnN	4123	6-8 weeks
-45 to 72 years	9606	Homo sapiens (human)	4124	45 to 72 years
-6 weeks	10000618	Mus musculus ICR	4125	6 weeks
-55	9606	Homo sapiens (human)	4126	55
-7-21 years	9606	Homo sapiens (human)	4127	7-21 years
-5 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4128	5 to 8 weeks
-18 to 43 years	9606	Homo sapiens (human)	4129	18 to 43 years
-19 to 59 years	9606	Homo sapiens (human)	4130	19 to 59 years
-2.5 to 17 years	9606	Homo sapiens (human)	4131	2.5 to 17 years
-10 to 14 weeks	10002763	Mus musculus HLA-A*11:01 Tg	4132	10 to 14 weeks
-62 years	9606	Homo sapiens (human)	4133	62 years
-8-12 weeks	10002274	Mus musculus CD1a	4134	8-12 weeks
-22 to >60 years	9606	Homo sapiens (human)	4135	22 to >60 years
-65-78 years	9606	Homo sapiens (human)	4136	65-78 years
-28 to 69 years	9606	Homo sapiens (human)	4137	28 to 69 years
-77 years	9606	Homo sapiens (human)	4138	77 years
-14-16 weeks	10000067	Mus musculus C57BL/6	4139	14-16 weeks
-65-72 years	9606	Homo sapiens (human)	4140	65-72 years
-5 weeks	10001487	Mus musculus Apolipoprotein E null	4141	5 weeks
-6 months	10000191	Bos taurus Hereford	4142	6 months
->40 years	9606	Homo sapiens (human)	4143	>40 years
-9-64 years	9606	Homo sapiens (human)	4144	9-64 years
-Adult	9615	Canis lupus familiaris (dogs)	4145	adult
-7-14 weeks	10000067	Mus musculus C57BL/6	4146	7-14 weeks
-8-10 weeks	10001512	Mus musculus C57BL/6 GalNAc Transferase null	4147	8-10 weeks
-6 to 7 months	10000105	Mus musculus TRAMP Tg	4148	6 to 7 months
-9 weeks	10001933	Mus musculus C57BL/6 Aire null	4149	9 weeks
-12-16 weeks or 18-22 months	10000067	Mus musculus C57BL/6	4150	12-16 weeks or 18-22 months
-5–10 weeks old	10000106	Mus musculus HY-A1 TCR beta chain Tg	4151	510 weeks old
-10 to 41 years	9606	Homo sapiens (human)	4152	10 to 41 years
-9 to 64 years	9606	Homo sapiens (human)	4153	9 to 64 years
-8 to 62 years	9606	Homo sapiens (human)	4154	8 to 62 years
-24 to 34 years	9606	Homo sapiens (human)	4155	24 to 34 years
-12 to 18 weeks	10000067	Mus musculus C57BL/6	4156	12 to 18 weeks
-8 to 64 years	9606	Homo sapiens (human)	4157	8 to 64 years
-10-12 weeks	10001634	Mus musculus IFNR null	4158	10-12 weeks
-6 to 9 months	10000067	Mus musculus C57BL/6	4159	6 to 9 months
-0-6 years	9606	Homo sapiens (human)	4160	0-6 years
-35-51 years	9606	Homo sapiens (human)	4161	35-51 years
-38-51 years	9606	Homo sapiens (human)	4162	38-51 years
-39-41 years	9606	Homo sapiens (human)	4163	39-41 years
-10 to 56 years	9606	Homo sapiens (human)	4164	10 to 56 years
-18 years or older	9606	Homo sapiens (human)	4165	18 years or older
-8 to 47 years	9606	Homo sapiens (human)	4166	8 to 47 years
-12 to 61 years	9606	Homo sapiens (human)	4167	12 to 61 years
-29 to 56 years	9606	Homo sapiens (human)	4168	29 to 56 years
-8-10 weeks	10001301	Mus musculus HLA-DR15 Tg	4169	8-10 weeks
-32 to 56 years	9606	Homo sapiens (human)	4170	32 to 56 years
-4-5 weeks	10001328	Mus musculus PLP TCR Tg	4171	4-5 weeks
-7 to 16 weeks	10000067	Mus musculus C57BL/6	4172	7 to 16 weeks
-8 to 12 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	4173	8 to 12 weeks
-4 to 15 weeks	10000632	Mus musculus NOD	4174	4 to 15 weeks
-4 to 15 weeks	10000596	Mus musculus HLA-DQ Transgenic	4175	4 to 15 weeks
-4 to 15 weeks	10001258	Mus musculus C57BL/6-H-2g7	4176	4 to 15 weeks
-3 to 67 years	9606	Homo sapiens (human)	4177	3 to 67 years
-10 to 63 years	9606	Homo sapiens (human)	4178	10 to 63 years
-7-62 years	9606	Homo sapiens (human)	4179	7-62 years
-27-60 years	9606	Homo sapiens (human)	4180	27-60 years
-24	9606	Homo sapiens (human)	4181	24
-5-7 weeks	10000253	Mus musculus A/J	4182	5-7 weeks
-8 weeks	10001098	Mus musculus RAG-1 null	4183	8 weeks
-1-55 years	9606	Homo sapiens (human)	4184	1-55 years
-12-14 weeks	10000055	Mus musculus DBA/2	4185	12-14 weeks
-19 to 68 years	9606	Homo sapiens (human)	4186	19 to 68 years
-5 months	10002166	Bos taurus Japanese Black	4187	5 months
-42 and 43 years	9606	Homo sapiens (human)	4188	42 and 43 years
-8-10 weeks	10001414	Mus musculus 172.10 TCR Tg	4189	8-10 weeks
-10 to 12 weeks	10000632	Mus musculus NOD	4190	10 to 12 weeks
-6 weeks	10000915	Mus musculus Kunming	4191	6 weeks
-31-63 years	9606	Homo sapiens (human)	4192	31-63 years
-15-53 years	9606	Homo sapiens (human)	4193	15-53 years
-24-75	9606	Homo sapiens (human)	4194	24-75
-2 months	10000043	Mus musculus C3HeB/FeJ	4195	2 months
-27-71 years	9606	Homo sapiens (human)	4196	27-71 years
-12 weeks - 22 months	10000067	Mus musculus C57BL/6	4197	12 weeks - 22 months
-NULL	10001623	Mus musculus AG129	4198	null
-36-75 years	10000119	Homo sapiens Caucasian	4199	36-75 years
-7-13 months	10000194	Bos taurus Holstein-Friesian	4200	7-13 months
-19-46 years	9606	Homo sapiens (human)	4201	19-46 years
-21 -54 years	9606	Homo sapiens (human)	4202	21 -54 years
-35-47 years	9606	Homo sapiens (human)	4203	35-47 years
-25 weeks	10001487	Mus musculus Apolipoprotein E null	4204	25 weeks
-21-38 years	9606	Homo sapiens (human)	4205	21-38 years
-52-71 years	9606	Homo sapiens (human)	4206	52-71 years
-59-84 years	9606	Homo sapiens (human)	4207	59-84 years
-19-71 years	9606	Homo sapiens (human)	4208	19-71 years
-36 to 85 years	9606	Homo sapiens (human)	4209	36 to 85 years
-26 to 34 years	9606	Homo sapiens (human)	4210	26 to 34 years
-6-8 weeks	10001366	Mus musculus Foxp3gfp.KI	4211	6-8 weeks
-2 months	10000922	Sus scrofa German Landrace	4212	2 months
-29-74 years	9606	Homo sapiens (human)	4213	29-74 years
-23-62 years	9606	Homo sapiens (human)	4214	23-62 years
-8 to 50 years	9606	Homo sapiens (human)	4215	8 to 50 years
-6-8 weeks	10002220	Mus musculus P25 TCR Tg	4216	6-8 weeks
-3.8 to 18.7 years	9606	Homo sapiens (human)	4217	3.8 to 18.7 years
-32 or 34 years	9606	Homo sapiens (human)	4218	32 or 34 years
-14-28 years	9606	Homo sapiens (human)	4219	14-28 years
-4 weeks	10002172	Sus scrofa Large White X Duroc	4220	4 weeks
-2 to 14 years	9606	Homo sapiens (human)	4221	2 to 14 years
-6 to 34 years	9606	Homo sapiens (human)	4222	6 to 34 years
-19-45	9606	Homo sapiens (human)	4223	19-45
-5 weeks-old	10000038	Mus musculus C3H/He	4224	5 weeks-old
-12 weeks to 20 months	10000067	Mus musculus C57BL/6	4225	12 weeks to 20 months
-6 weeks to 20 months	10000067	Mus musculus C57BL/6	4226	6 weeks to 20 months
-12-24 years	9606	Homo sapiens (human)	4227	12-24 years
-8-9 weeks	10000649	Mus musculus SJL	4228	8-9 weeks
-45-71 years	9606	Homo sapiens (human)	4229	45-71 years
-3-4 years	9544	Macaca mulatta (rhesus macaque)	4230	3-4 years
-28-54 years	9606	Homo sapiens (human)	4231	28-54 years
-46-86 years	9606	Homo sapiens (human)	4232	46-86 years
-39-75 years	9606	Homo sapiens (human)	4233	39-75 years
-5 to 12 weeks	10002072	Mus musculus LLO118 TCR Tg	4234	5 to 12 weeks
-9-52 years	9606	Homo sapiens (human)	4235	9-52 years
-3 to 5 weeks	10000274	Mus musculus B10.PL	4236	3 to 5 weeks
-20 to 74 years	9606	Homo sapiens (human)	4237	20 to 74 years
-24 to 37 years	9606	Homo sapiens (human)	4238	24 to 37 years
-15 to 27 years	9606	Homo sapiens (human)	4239	15 to 27 years
-8 months	10000067	Mus musculus C57BL/6	4240	8 months
-19-63 years	9606	Homo sapiens (human)	4241	19-63 years
-16-74 years	9606	Homo sapiens (human)	4242	16-74 years
-14-45 years	9606	Homo sapiens (human)	4243	14-45 years
-36-84 years	9606	Homo sapiens (human)	4244	36-84 years
-21 to 53 years	9606	Homo sapiens (human)	4245	21 to 53 years
-NULL	10000037	Mus musculus C3H/FeJ X C57BL/6	4246	null
-8-10 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4247	8-10 weeks
-6-12 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4248	6-12 weeks
-22-46	9606	Homo sapiens (human)	4249	22-46
-29-83	9606	Homo sapiens (human)	4250	29-83
-6-10 weeks	10001237	Mus musculus HLA-B*35:01 Tg	4251	6-10 weeks
-58.8 (average)	9606	Homo sapiens (human)	4252	58.8 (average)
-6-10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	4253	6-10 weeks
-18-73 years	9606	Homo sapiens (human)	4254	18-73 years
-19 to 27 years	9606	Homo sapiens (human)	4255	19 to 27 years
-6-10 weeks	10001166	Mus musculus HLA-A24 Tg	4256	6-10 weeks
-20-66 years	9606	Homo sapiens (human)	4257	20-66 years
-37 to 61 years old	9606	Homo sapiens (human)	4258	37 to 61 years old
-21 to 66 years	9606	Homo sapiens (human)	4259	21 to 66 years
-12-24 months	10000193	Bos taurus Holstein	4260	12-24 months
-7-53 years	9606	Homo sapiens (human)	4261	7-53 years
-5-15 years	9606	Homo sapiens (human)	4262	5-15 years
-8-17 years	9606	Homo sapiens (human)	4263	8-17 years
-20 to 72 years	9606	Homo sapiens (human)	4264	20 to 72 years
-NULL	10000104	Mus musculus C57BL/6 TAP null	4265	null
-50-80 years	9606	Homo sapiens (human)	4266	50-80 years
-6-12 weeks	10001601	Mus musculus C57BL/6 X 129	4267	6-12 weeks
-6-12 weeks	10000225	Mus musculus C57BL/6N	4268	6-12 weeks
-9-10 weeks	10002306	Mus musculus NOD.InsY16A Tg	4269	9-10 weeks
-47-58 years	9606	Homo sapiens (human)	4270	47-58 years
-8-10 weeks	10002306	Mus musculus NOD.InsY16A Tg	4271	8-10 weeks
-14 to 38 years	9606	Homo sapiens (human)	4272	14 to 38 years
-10 weeks or older	10000632	Mus musculus NOD	4273	10 weeks or older
-20 to 41 years	9606	Homo sapiens (human)	4274	20 to 41 years
-5 to 20 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4275	5 to 20 weeks
-20-77 years	9606	Homo sapiens (human)	4276	20-77 years
-14-53 years	9606	Homo sapiens (human)	4277	14-53 years
-24-81 years	9606	Homo sapiens (human)	4278	24-81 years
-0-2 years	9544	Macaca mulatta (rhesus macaque)	4279	0-2 years
-3-4 weeks	10001998	Mus musculus CD1	4280	3-4 weeks
-20 to 58 years	9606	Homo sapiens (human)	4281	20 to 58 years
-5 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	4282	5 weeks
-14-56	9606	Homo sapiens (human)	4283	14-56
-NULL	10000667	Rattus norvegicus Sprague-Dawley	4284	null
-5-70 years	9606	Homo sapiens (human)	4285	5-70 years
-15-44 years	9606	Homo sapiens (human)	4286	15-44 years
-26-78 years	9606	Homo sapiens (human)	4287	26-78 years
-21-81 years	9606	Homo sapiens (human)	4288	21-81 years
-27-65 years	9606	Homo sapiens (human)	4289	27-65 years
-30.1 to 59.1 years	9606	Homo sapiens (human)	4290	30.1 to 59.1 years
-2-56 years	9606	Homo sapiens (human)	4291	2-56 years
-2-43 years	9606	Homo sapiens (human)	4292	2-43 years
-33	9606	Homo sapiens (human)	4293	33
-6 to 8 weeks	10000217	Mus musculus C57BL/6 X BALB/c-H2dm2	4294	6 to 8 weeks
-6 to 8 weeks	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	4295	6 to 8 weeks
-24 to 82 years	9606	Homo sapiens (human)	4296	24 to 82 years
-73 years	9606	Homo sapiens (human)	4297	73 years
-6 to 10 weeks	10000656	Mus musculus VM X DBA/2	4298	6 to 10 weeks
-40 to 62.1 years	9606	Homo sapiens (human)	4299	40 to 62.1 years
-35-73 Years	9606	Homo sapiens (human)	4300	35-73 years
-6-14 weeks	10000067	Mus musculus C57BL/6	4301	6-14 weeks
-44-60 years	9606	Homo sapiens (human)	4302	44-60 years
-> 50 years	9606	Homo sapiens (human)	4303	> 50 years
-mean 34.59 years	9606	Homo sapiens (human)	4304	mean 34.59 years
-32-74 years	9606	Homo sapiens (human)	4305	32-74 years
-57-79 years	9606	Homo sapiens (human)	4306	57-79 years
-6 to 10 weeks	10001347	Mus musculus 129/Sv	4307	6 to 10 weeks
-5 to 6 weeks	10001097	Sus scrofa Yorkshire	4308	5 to 6 weeks
-46 to 84 years	9606	Homo sapiens (human)	4309	46 to 84 years
-4-8 years	9544	Macaca mulatta (rhesus macaque)	4310	4-8 years
-2-6 months	10000649	Mus musculus SJL	4311	2-6 months
-2-6 months	10000047	Mus musculus C57BL/10	4312	2-6 months
-15-21 years	9606	Homo sapiens (human)	4313	15-21 years
-2-6 months	10000274	Mus musculus B10.PL	4314	2-6 months
-6-10 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4315	6-10 weeks
-22-58 years	9606	Homo sapiens (human)	4316	22-58 years
-18-69 years	9606	Homo sapiens (human)	4317	18-69 years
-6 ± 2 weeks	10000067	Mus musculus C57BL/6	4318	6  2 weeks
-6 to 10 months	10000194	Bos taurus Holstein-Friesian	4319	6 to 10 months
-25-41 years	9606	Homo sapiens (human)	4320	25-41 years
-15-38 years	9606	Homo sapiens (human)	4321	15-38 years
-25-82 years	9606	Homo sapiens (human)	4322	25-82 years
-48-79 years	9606	Homo sapiens (human)	4323	48-79 years
-18-52 years	9606	Homo sapiens (human)	4324	18-52 years
-41-78 years	9606	Homo sapiens (human)	4325	41-78 years
-13-75 years	9606	Homo sapiens (human)	4326	13-75 years
-36-56 years	9606	Homo sapiens (human)	4327	36-56 years
-7 to 62 years	9606	Homo sapiens (human)	4328	7 to 62 years
-22 to 45 years	9606	Homo sapiens (human)	4329	22 to 45 years
-19 to 44 years	9606	Homo sapiens (human)	4330	19 to 44 years
-6 to 10 weeks	10001301	Mus musculus HLA-DR15 Tg	4331	6 to 10 weeks
-over 5 weeks	10000067	Mus musculus C57BL/6	4332	over 5 weeks
-36 to 68.2 years	9606	Homo sapiens (human)	4333	36 to 68.2 years
-19.9 to 22.1 years	9606	Homo sapiens (human)	4334	19.9 to 22.1 years
-6-10 weeks	10001098	Mus musculus RAG-1 null	4335	6-10 weeks
-7-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4336	7-10 weeks
-29-45 years	9606	Homo sapiens (human)	4337	29-45 years
-12-48 years	9606	Homo sapiens (human)	4338	12-48 years
-21, 25 and 44 years	9606	Homo sapiens (human)	4339	21, 25 and 44 years
-21-70 years	9606	Homo sapiens (human)	4340	21-70 years
-18-46 years	9606	Homo sapiens (human)	4341	18-46 years
-8-12 weeks	10001539	Mus musculus TCR transgenic	4342	8-12 weeks
-7 to 48 years	9606	Homo sapiens (human)	4343	7 to 48 years
-51-53 years	9606	Homo sapiens (human)	4344	51-53 years
-38-73 years	9606	Homo sapiens (human)	4345	38-73 years
-12-62 years	9606	Homo sapiens (human)	4346	12-62 years
-22.5-35.5	9606	Homo sapiens (human)	4347	22.5-35.5
-< 10 weeks	10000632	Mus musculus NOD	4348	< 10 weeks
-21 and 44 years	9606	Homo sapiens (human)	4349	21 and 44 years
-62	9606	Homo sapiens (human)	4350	62
-16 and 44 years	9606	Homo sapiens (human)	4351	16 and 44 years
-18 to 39 years	9606	Homo sapiens (human)	4352	18 to 39 years
-38 and 48 years	9606	Homo sapiens (human)	4353	38 and 48 years
-38 and 44 years	9606	Homo sapiens (human)	4354	38 and 44 years
-47-83 years	9606	Homo sapiens (human)	4355	47-83 years
-20 to 60 years	9606	Homo sapiens (human)	4356	20 to 60 years
-6 weeks	10002128	Mus musculus SKH-1	4357	6 weeks
-6-10 weeks	10000225	Mus musculus C57BL/6N	4358	6-10 weeks
-4-6 weeks	10001217	Mus musculus pmel-1 TCR Tg	4359	4-6 weeks
-20-46 years	9606	Homo sapiens (human)	4360	20-46 years
-47 to 57 years	9606	Homo sapiens (human)	4361	47 to 57 years
-47 to 63 years	9606	Homo sapiens (human)	4362	47 to 63 years
-16-71 years	9606	Homo sapiens (human)	4363	16-71 years
-17 to 58 years	9606	Homo sapiens (human)	4364	17 to 58 years
-4 weeks	10000582	Mus musculus HLA-A2 Tg	4365	4 weeks
-12 weeks	10000582	Mus musculus HLA-A2 Tg	4366	12 weeks
-4-8 weeks	10000000	Mus musculus BALB/c	4367	4-8 weeks
-11 years	9606	Homo sapiens (human)	4368	11 years
-17-56	9606	Homo sapiens (human)	4369	17-56
-15 to 37 years	9606	Homo sapiens (human)	4370	15 to 37 years
-2 months	10000632	Mus musculus NOD	4371	2 months
-24-55	9606	Homo sapiens (human)	4372	24-55
-40-76 years	9606	Homo sapiens (human)	4373	40-76 years
-23-41 years	9606	Homo sapiens (human)	4374	23-41 years
-6-12 weeks	10000601	Mus musculus HLA-DR1 Tg	4375	6-12 weeks
-21-66  years	9606	Homo sapiens (human)	4376	21-66  years
-32-47 years	9606	Homo sapiens (human)	4377	32-47 years
-18 to 30 years	9606	Homo sapiens (human)	4378	18 to 30 years
-< 5 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4379	< 5 weeks
-> 9 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4380	> 9 weeks
-16-56 years	9606	Homo sapiens (human)	4381	16-56 years
-52-78 years	9606	Homo sapiens (human)	4382	52-78 years
-8-12 weeks	10002847	Mus musculus HLA-DPA1*01:03/DPB1*04:01 Tg	4383	8-12 weeks
-56 to 79 years	9606	Homo sapiens (human)	4384	56 to 79 years
-59 to 79 years	9606	Homo sapiens (human)	4385	59 to 79 years
-68 to 75 years	9606	Homo sapiens (human)	4386	68 to 75 years
-13-77 years	9606	Homo sapiens (human)	4387	13-77 years
-6-33 years	9606	Homo sapiens (human)	4388	6-33 years
-42-65 years	9606	Homo sapiens (human)	4389	42-65 years
-19-58 years	9606	Homo sapiens (human)	4390	19-58 years
-6 to 10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4391	6 to 10 weeks
-4 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4392	4 weeks
-9 weeks	10000187	Sus scrofa Landrace X Large White	4393	9 weeks
-59 to 82 years	9606	Homo sapiens (human)	4394	59 to 82 years
-7-8 weeks	42414	Sigmodon (cotton rat)	4395	7-8 weeks
-24 weeks	10000632	Mus musculus NOD	4396	24 weeks
-35-48 years	9606	Homo sapiens (human)	4397	35-48 years
-35-59 years	9606	Homo sapiens (human)	4398	35-59 years
-35-49 years	9606	Homo sapiens (human)	4399	35-49 years
-25-45 years	9606	Homo sapiens (human)	4400	25-45 years
-median 66.5 years	9606	Homo sapiens (human)	4401	median 66.5 years
-24 to 38 years	9606	Homo sapiens (human)	4402	24 to 38 years
-6-8 weeks	10000092	Mus musculus gBT-I TCR Tg	4403	6-8 weeks
-35-37 years	9606	Homo sapiens (human)	4404	35-37 years
-32-87 years	9606	Homo sapiens (human)	4405	32-87 years
-20 to 59 years	9606	Homo sapiens (human)	4406	20 to 59 years
-6 weeks	10000653	Mus musculus Swiss	4407	6 weeks
-Mean age of 32.2 years with a range from 18 to 49 years	9606	Homo sapiens (human)	4408	mean age of 32.2 years with a range from 18 to 49 years
-46-73 years	9606	Homo sapiens (human)	4409	46-73 years
-46-48 months	9544	Macaca mulatta (rhesus macaque)	4410	46-48 months
-6-10 weeks	10000651	Mus musculus SMARTA TCR Tg	4411	6-10 weeks
-28-67 years	9606	Homo sapiens (human)	4412	28-67 years
-18 to 61 years	9606	Homo sapiens (human)	4413	18 to 61 years
-12 to 13 weeks	10000632	Mus musculus NOD	4414	12 to 13 weeks
-1-54 years	9606	Homo sapiens (human)	4415	1-54 years
-12 to 20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4416	12 to 20 weeks
-57-60 years	9606	Homo sapiens (human)	4417	57-60 years
-41	9606	Homo sapiens (human)	4418	41
-79	9606	Homo sapiens (human)	4419	79
-53	9606	Homo sapiens (human)	4420	53
-2 to 3 years	10002352	Sus scrofa Babraham	4421	2 to 3 years
-4-5 weeks old	10000067	Mus musculus C57BL/6	4422	4-5 weeks old
-22 to 71 years	9606	Homo sapiens (human)	4423	22 to 71 years
-54 to 89 years	9606	Homo sapiens (human)	4424	54 to 89 years
-6 weeks	10002328	Mus musculus TCR<sup>mini</sup>	4425	6 weeks
-21-90 years	9606	Homo sapiens (human)	4426	21-90 years
-17-59 years	9606	Homo sapiens (human)	4427	17-59 years
-12.5 to 25.6 years	9606	Homo sapiens (human)	4428	12.5 to 25.6 years
-14.2 to 24.2 years	9606	Homo sapiens (human)	4429	14.2 to 24.2 years
-21-64 years	9606	Homo sapiens (human)	4430	21-64 years
-12.4 to 50.8 years	9606	Homo sapiens (human)	4431	12.4 to 50.8 years
-38-65 years	9606	Homo sapiens (human)	4432	38-65 years
-24 to 60 years	9606	Homo sapiens (human)	4433	24 to 60 years
-24 to 78 years	9606	Homo sapiens (human)	4434	24 to 78 years
-23	9606	Homo sapiens (human)	4435	23
-67 years	9606	Homo sapiens (human)	4436	67 years
-6 to 7 weeks	10000227	Mus musculus OT-1 TCR Tg	4437	6 to 7 weeks
-NULL	10000600	Mus musculus HLA-DR Transgenic	4438	null
-58.8 ± 17.4	9606	Homo sapiens (human)	4439	58.8  17.4
-43-68 years	9606	Homo sapiens (human)	4440	43-68 years
-22.8 to 58.9 years	9606	Homo sapiens (human)	4441	22.8 to 58.9 years
-11 to 71 years	9606	Homo sapiens (human)	4442	11 to 71 years
-NULL	10001476	Mus musculus HA 518-526 TCR Tg	4443	null
-62-65 years	9606	Homo sapiens (human)	4444	62-65 years
-65	9606	Homo sapiens (human)	4445	65
-21 to 70 years	9606	Homo sapiens (human)	4446	21 to 70 years
-24 to 27 years	9606	Homo sapiens (human)	4447	24 to 27 years
-18 to 71 years	9606	Homo sapiens (human)	4448	18 to 71 years
-46.6 to 63.4 years	9606	Homo sapiens (human)	4449	46.6 to 63.4 years
-43-52 years	9606	Homo sapiens (human)	4450	43-52 years
-29 to 52 years	9606	Homo sapiens (human)	4451	29 to 52 years
-3 months- 17 years	9606	Homo sapiens (human)	4452	3 months- 17 years
-1-33 years	9606	Homo sapiens (human)	4453	1-33 years
-26-75 years	9606	Homo sapiens (human)	4454	26-75 years
-4 weeks	10001446	Rattus norvegicus Wistar Kyoto	4455	4 weeks
-1.8-3.3 years	9606	Homo sapiens (human)	4456	1.8-3.3 years
-8-9 weeks	9823	Sus scrofa (pig)	4457	8-9 weeks
-21-26	9606	Homo sapiens (human)	4458	21-26
-NULL	10002263	Mus musculus C7 TCR Tg	4459	null
-3-5 weeks	10000649	Mus musculus SJL	4460	3-5 weeks
-32-39 years	9606	Homo sapiens (human)	4461	32-39 years
-51-58 years	9606	Homo sapiens (human)	4462	51-58 years
-10-11 weeks	10000662	Rattus norvegicus Lewis	4463	10-11 weeks
-18-72 years	9606	Homo sapiens (human)	4464	18-72 years
-32-59 years	9606	Homo sapiens (human)	4465	32-59 years
-63-67 years	9606	Homo sapiens (human)	4466	63-67 years
-21.9 to 29.3 years	9606	Homo sapiens (human)	4467	21.9 to 29.3 years
-24.6 to 44.2 years	9606	Homo sapiens (human)	4468	24.6 to 44.2 years
-21.1 to 43 years	9606	Homo sapiens (human)	4469	21.1 to 43 years
-9-12 weeks	10000187	Sus scrofa Landrace X Large White	4470	9-12 weeks
-34 to 70 years	9606	Homo sapiens (human)	4471	34 to 70 years
-13-26	9606	Homo sapiens (human)	4472	13-26
-23-65 years	9606	Homo sapiens (human)	4473	23-65 years
-13-17	9606	Homo sapiens (human)	4474	13-17
-12 to 14 weeks	10000635	Mus musculus NOD/Lt	4475	12 to 14 weeks
-2 weeks	10000919	Gallus gallus White Leghorn	4476	2 weeks
-7 days	10000919	Gallus gallus White Leghorn	4477	7 days
-18-80 years	9606	Homo sapiens (human)	4478	18-80 years
-6 weeks	10000225	Mus musculus C57BL/6N	4479	6 weeks
-35-57 years	9606	Homo sapiens (human)	4480	35-57 years
-22-73 years	9606	Homo sapiens (human)	4481	22-73 years
-17-72 years	9606	Homo sapiens (human)	4482	17-72 years
-60 to 70 years	9606	Homo sapiens (human)	4483	60 to 70 years
-34 to 56 years	9606	Homo sapiens (human)	4484	34 to 56 years
-9-10 weeks	10000632	Mus musculus NOD	4485	9-10 weeks
-5 to 19 years	9606	Homo sapiens (human)	4486	5 to 19 years
-7 to 35 years	9606	Homo sapiens (human)	4487	7 to 35 years
-11 to 72 years	9606	Homo sapiens (human)	4488	11 to 72 years
-67	9606	Homo sapiens (human)	4489	67
-52	9606	Homo sapiens (human)	4490	52
-66	9606	Homo sapiens (human)	4491	66
-7 to 8 weeks	10000632	Mus musculus NOD	4492	7 to 8 weeks
-71	9606	Homo sapiens (human)	4493	71
-17 weeks	10000105	Mus musculus TRAMP Tg	4494	17 weeks
-12 to 13 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4495	12 to 13 weeks
-59-62 years	9606	Homo sapiens (human)	4496	59-62 years
-NULL	10002072	Mus musculus LLO118 TCR Tg	4497	null
-> 3 years	9544	Macaca mulatta (rhesus macaque)	4498	> 3 years
-85 years	9606	Homo sapiens (human)	4499	85 years
-27 to 49 years	9606	Homo sapiens (human)	4500	27 to 49 years
-27 to 39 years	9606	Homo sapiens (human)	4501	27 to 39 years
-26 to 47 years	9606	Homo sapiens (human)	4502	26 to 47 years
-mean 55 years	9606	Homo sapiens (human)	4503	mean 55 years
-NULL	10002367	Mus musculus C57BL/6 DQ2.5-glia-omega2 TCR transgenic	4504	null
-NULL	10002369	Mus musculus C57BL/6 DQ2.5-glia-gamma1 TCR transgenic	4505	null
-7-8 weeks	10001546	Mus musculus C57BL/6 HLA transgenic	4506	7-8 weeks
-21-79 years	9606	Homo sapiens (human)	4507	21-79 years
-30 to 61 years	9606	Homo sapiens (human)	4508	30 to 61 years
-22-40 years	9606	Homo sapiens (human)	4509	22-40 years
-12-16 weeks	10000632	Mus musculus NOD	4510	12-16 weeks
-38 to 72 years	9606	Homo sapiens (human)	4511	38 to 72 years
-Mean age = 68 years	9606	Homo sapiens (human)	4512	mean age = 68 years
-3-16 years	9606	Homo sapiens (human)	4513	3-16 years
-30-37 years	9606	Homo sapiens (human)	4514	30-37 years
-26-55 years	9606	Homo sapiens (human)	4515	26-55 years
-5 to 72 years	9606	Homo sapiens (human)	4516	5 to 72 years
-15 weeks	10090	Mus musculus (mouse)	4517	15 weeks
-9-12 weeks	9825	Sus scrofa domesticus (domestic pig)	4518	9-12 weeks
-median 58 years	9606	Homo sapiens (human)	4519	median 58 years
-40-42 years	9606	Homo sapiens (human)	4520	40-42 years
-23-80 years	9606	Homo sapiens (human)	4521	23-80 years
-12 to 14 weeks	10001248	Mus musculus NOD.Cg-Tg	4522	12 to 14 weeks
-42.9 to 73.7 years	9606	Homo sapiens (human)	4523	42.9 to 73.7 years
-6-8 weeks	10000952	Mus musculus B6.129P2-B2m tm1Unc/J	4524	6-8 weeks
-66.6 to 84.6 years	9606	Homo sapiens (human)	4525	66.6 to 84.6 years
-59-78 years	9606	Homo sapiens (human)	4526	59-78 years
-56	9606	Homo sapiens (human)	4527	56
-1 day to 40 years	9606	Homo sapiens (human)	4528	1 day to 40 years
-7 to 11 weeks	10000000	Mus musculus BALB/c	4529	7 to 11 weeks
-8 to 68 years	9606	Homo sapiens (human)	4530	8 to 68 years
-28-72 years	9606	Homo sapiens (human)	4531	28-72 years
-> 20 weeks	10000632	Mus musculus NOD	4532	> 20 weeks
-63-92 years	9606	Homo sapiens (human)	4533	63-92 years
-8-10 weeks	10000601	Mus musculus HLA-DR1 Tg	4534	8-10 weeks
-31-77 years	9606	Homo sapiens (human)	4535	31-77 years
-38-75 years	9606	Homo sapiens (human)	4536	38-75 years
-31-70 years	9606	Homo sapiens (human)	4537	31-70 years
-30-79 years	9606	Homo sapiens (human)	4538	30-79 years
-12-81 years	9606	Homo sapiens (human)	4539	12-81 years
-13-88 years	9606	Homo sapiens (human)	4540	13-88 years
-2 to 4 months	10000017	Mus musculus BALB/c X DBA/2	4541	2 to 4 months
-40-80 years	9606	Homo sapiens (human)	4542	40-80 years
-72	9606	Homo sapiens (human)	4543	72
-18 to 68 years	9606	Homo sapiens (human)	4544	18 to 68 years
-20 to 75 years	9606	Homo sapiens (human)	4545	20 to 75 years
-NULL	10002368	Mus musculus C57BL/6 DQ2.5-glia-alpha2 TCR transgenic	4546	null
-34-60 years	9606	Homo sapiens (human)	4547	34-60 years
-31 to 53 years	9606	Homo sapiens (human)	4548	31 to 53 years
-48.5 to 68.9 years	9606	Homo sapiens (human)	4549	48.5 to 68.9 years
-24-79 years	9606	Homo sapiens (human)	4550	24-79 years
-16 to 55 years	9606	Homo sapiens (human)	4551	16 to 55 years
-68 years old	9606	Homo sapiens (human)	4552	68 years old
-10-17 years	9606	Homo sapiens (human)	4553	10-17 years
-6-16 years	9606	Homo sapiens (human)	4554	6-16 years
-22-91 years	9606	Homo sapiens (human)	4555	22-91 years
-56 to 66	9606	Homo sapiens (human)	4556	56 to 66
-22-71	9606	Homo sapiens (human)	4557	22-71
-56-66	9606	Homo sapiens (human)	4558	56-66
-25-81 years	9606	Homo sapiens (human)	4559	25-81 years
-19-68 years	9606	Homo sapiens (human)	4560	19-68 years
-22	9606	Homo sapiens (human)	4561	22
-NULL	9031	Gallus gallus (chicken)	4562	null
-19-81 years	9606	Homo sapiens (human)	4563	19-81 years
-20-24 weeks	10000067	Mus musculus C57BL/6	4564	20-24 weeks
-44 to 59 years	9606	Homo sapiens (human)	4565	44 to 59 years
-10 -17 years	9606	Homo sapiens (human)	4566	10 -17 years
-86 years	9606	Homo sapiens (human)	4567	86 years
-80 years	9606	Homo sapiens (human)	4568	80 years
-82 years	9606	Homo sapiens (human)	4569	82 years
-83 years	9606	Homo sapiens (human)	4570	83 years
-84 years	9606	Homo sapiens (human)	4571	84 years
-NULL	10002078	Mus musculus HLA-DP2 Tg	4572	null
-87 years	9606	Homo sapiens (human)	4573	87 years
-88 years	9606	Homo sapiens (human)	4574	88 years
-51-77 years	9606	Homo sapiens (human)	4575	51-77 years
-19-40 years	9606	Homo sapiens (human)	4576	19-40 years
-79 years	9606	Homo sapiens (human)	4577	79 years
-74	9606	Homo sapiens (human)	4578	74
-10 to 18 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4579	10 to 18 weeks
-78 years	9606	Homo sapiens (human)	4580	78 years
-8-14 weeks	10000610	Mus musculus HLA-DR4 Tg	4581	8-14 weeks
-69	9606	Homo sapiens (human)	4582	69
-69-70	9606	Homo sapiens (human)	4583	69-70
-56-69	9606	Homo sapiens (human)	4584	56-69
-7 years	9606	Homo sapiens (human)	4585	7 years
-70-71	9606	Homo sapiens (human)	4586	70-71
-42-53 years	9606	Homo sapiens (human)	4587	42-53 years
-78 to 84 years	9606	Homo sapiens (human)	4588	78 to 84 years
-40 to 60 years	9606	Homo sapiens (human)	4589	40 to 60 years
-29-76 years	9606	Homo sapiens (human)	4590	29-76 years
-NULL	10001720	Mus musculus Influenza A HA TCR Tg	4591	null
-9 weeks old	10000000	Mus musculus BALB/c	4592	9 weeks old
-NULL	10002848	Mus musculus HLA-DPw4 Tg	4593	null
-38-48 years	9606	Homo sapiens (human)	4594	38-48 years
-24-31 years	9606	Homo sapiens (human)	4595	24-31 years
-9 - 12 weeks	10000067	Mus musculus C57BL/6	4596	9 - 12 weeks
-28-69 years	9606	Homo sapiens (human)	4597	28-69 years
-55-77 years	9606	Homo sapiens (human)	4598	55-77 years
-50–81	9606	Homo sapiens (human)	4599	5081
-54 to 85 years	9606	Homo sapiens (human)	4600	54 to 85 years
-27-69 years	9606	Homo sapiens (human)	4601	27-69 years
-44-50 years	9606	Homo sapiens (human)	4602	44-50 years
-40-54 years	9606	Homo sapiens (human)	4603	40-54 years
-5 weeks	10000187	Sus scrofa Landrace X Large White	4604	5 weeks
-42-70 years	9606	Homo sapiens (human)	4605	42-70 years
-43-50 years	9606	Homo sapiens (human)	4606	43-50 years
-37-54 years	9606	Homo sapiens (human)	4607	37-54 years
-3.3 -54 years	9606	Homo sapiens (human)	4608	3.3 -54 years
-NULL	10002400	Mus musculus HLA-DRB1*15:03 Tg	4609	null
-8.4-27.3 years	9606	Homo sapiens (human)	4610	8.4-27.3 years
-40-50 years	9606	Homo sapiens (human)	4611	40-50 years
-30-80 years	9606	Homo sapiens (human)	4612	30-80 years
-20-90 years	9606	Homo sapiens (human)	4613	20-90 years
-30-90 years	9606	Homo sapiens (human)	4614	30-90 years
-20-80 years	9606	Homo sapiens (human)	4615	20-80 years
-30-40 years	9606	Homo sapiens (human)	4616	30-40 years
-70-80 years	9606	Homo sapiens (human)	4617	70-80 years
-24-27 years	9606	Homo sapiens (human)	4618	24-27 years
-20.6-50.1 years	9606	Homo sapiens (human)	4619	20.6-50.1 years
-29 to 82 years	9606	Homo sapiens (human)	4620	29 to 82 years
-4 to 6 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	4621	4 to 6 weeks old
-23- 51 years	9606	Homo sapiens (human)	4622	23- 51 years
-24 -49 years	9606	Homo sapiens (human)	4623	24 -49 years
-2-32 years	9606	Homo sapiens (human)	4624	2-32 years
-26-40 years	9606	Homo sapiens (human)	4625	26-40 years
-20-48 years	9606	Homo sapiens (human)	4626	20-48 years
-19- 53 years	9606	Homo sapiens (human)	4627	19- 53 years
-52-75 years	9606	Homo sapiens (human)	4628	52-75 years
-24-59 years	9606	Homo sapiens (human)	4629	24-59 years
-6-12 weeks	10001166	Mus musculus HLA-A24 Tg	4630	6-12 weeks
-8 -10 weeks	10000000	Mus musculus BALB/c	4631	8 -10 weeks
-12 weeks	10002839	Mus musculus HLA-B*57:01 Tg	4632	12 weeks
-8-10 weeks	10000019	Mus musculus BALB/cByJ	4633	8-10 weeks
-54–77	9606	Homo sapiens (human)	4634	5477
-21-50 years	9606	Homo sapiens (human)	4635	21-50 years
-< 45 years	9606	Homo sapiens (human)	4636	< 45 years
-41-70 years	9606	Homo sapiens (human)	4637	41-70 years
-19-67 years	9606	Homo sapiens (human)	4638	19-67 years
-37 to 90 years	9606	Homo sapiens (human)	4639	37 to 90 years
-NULL	10002352	Sus scrofa Babraham	4640	null
-5.5 weeks	10002352	Sus scrofa Babraham	4641	5.5 weeks
-60-74	9606	Homo sapiens (human)	4642	60-74
-8-10 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	4643	8-10 weeks
-66-73	9606	Homo sapiens (human)	4644	66-73
-58-84 years	9606	Homo sapiens (human)	4645	58-84 years
-50-76 years	9606	Homo sapiens (human)	4646	50-76 years
-54-78 years	9606	Homo sapiens (human)	4647	54-78 years
-41-56 years	9606	Homo sapiens (human)	4648	41-56 years
-8 - 12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	4649	8 - 12 weeks
-6-13 years	9606	Homo sapiens (human)	4650	6-13 years
-over 12 weeks	10000632	Mus musculus NOD	4651	over 12 weeks
-51-80 years	9606	Homo sapiens (human)	4652	51-80 years
-51 to 83 years	9606	Homo sapiens (human)	4653	51 to 83 years
-30-45 years	9606	Homo sapiens (human)	4654	30-45 years
-12 weeks	10001399	Mus musculus HLA-DQB1*06:02 Tg	4655	12 weeks
-19-28 years	9606	Homo sapiens (human)	4656	19-28 years
-7-8 months	9913	Bos taurus (bovine)	4657	7-8 months
-24-95 years	9606	Homo sapiens (human)	4658	24-95 years
-60+ years	9606	Homo sapiens (human)	4659	60+ years
-20- 54 years	9606	Homo sapiens (human)	4660	20- 54 years
-20-53 years	9606	Homo sapiens (human)	4661	20-53 years
-25- 49 years	9606	Homo sapiens (human)	4662	25- 49 years
-25- 54 years	9606	Homo sapiens (human)	4663	25- 54 years
-25- 27 years	9606	Homo sapiens (human)	4664	25- 27 years
-19-73 years	9606	Homo sapiens (human)	4665	19-73 years
-9-12 weeks	10000653	Mus musculus Swiss	4666	9-12 weeks
-7 months to 44 years	9606	Homo sapiens (human)	4667	7 months to 44 years
-14 to 72 years	9606	Homo sapiens (human)	4668	14 to 72 years
-6 to 74 years	9606	Homo sapiens (human)	4669	6 to 74 years
-28 to 65 years	9606	Homo sapiens (human)	4670	28 to 65 years
-18 to 62 years	9606	Homo sapiens (human)	4671	18 to 62 years
-6-10 weeks	10000582	Mus musculus HLA-A2 Tg	4672	6-10 weeks
-6-12 Weeks	10001782	Mus musculus HLA-B*07:02 Tg	4673	6-12 weeks
-57-74 years	9606	Homo sapiens (human)	4674	57-74 years
-5-8 weeks	10000582	Mus musculus HLA-A2 Tg	4675	5-8 weeks
-17 weeks	10000649	Mus musculus SJL	4676	17 weeks
-4-8 months	246437	Tupaia chinensis (Chinese tree shrew)	4677	4-8 months
-2 days old	10002232	Mus musculus BDC2.5 TCR Tg	4678	2 days old
-6 to 10 week-old	10000610	Mus musculus HLA-DR4 Tg	4679	6 to 10 week-old
-15-23 years	9606	Homo sapiens (human)	4680	15-23 years
-45 to 82 years	9606	Homo sapiens (human)	4681	45 to 82 years
-49-77 years	9606	Homo sapiens (human)	4682	49-77 years
-21- 75 years	9606	Homo sapiens (human)	4683	21- 75 years
-> 24 weeks	10000105	Mus musculus TRAMP Tg	4684	> 24 weeks
-five week old	10000067	Mus musculus C57BL/6	4685	5 week old
-5 to 12 weeks	10000067	Mus musculus C57BL/6	4686	5 to 12 weeks
-6-8 Weeks	10001217	Mus musculus pmel-1 TCR Tg	4687	6-8 weeks
-27-68 years	9606	Homo sapiens (human)	4688	27-68 years
-7-8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4689	7-8 weeks
-63-68 years	9606	Homo sapiens (human)	4690	63-68 years
-54-57 years	9606	Homo sapiens (human)	4691	54-57 years
-21-58 years	9606	Homo sapiens (human)	4692	21-58 years
-53-81 years	9606	Homo sapiens (human)	4693	53-81 years
-50 days	10002503	Sus scrofa Duroc X Large White X Landrace	4694	50 days
-18-26 years	9606	Homo sapiens (human)	4695	18-26 years
-23-53 years	9606	Homo sapiens (human)	4696	23-53 years
-37-47 years	9606	Homo sapiens (human)	4697	37-47 years
-27-48 years	9606	Homo sapiens (human)	4698	27-48 years
-22- 66 years	9606	Homo sapiens (human)	4699	22- 66 years
-18 to 75 years	9606	Homo sapiens (human)	4700	18 to 75 years
-58-90 years	9606	Homo sapiens (human)	4701	58-90 years
-33-68 years	9606	Homo sapiens (human)	4702	33-68 years
-46-84 years	9606	Homo sapiens (human)	4703	46-84 years
-41-75 years	9606	Homo sapiens (human)	4704	41-75 years
-59-76 years	9606	Homo sapiens (human)	4705	59-76 years
-1 day	10001436	Gallus gallus P2a	4706	1 day
-1 day	10002711	Gallus gallus line N	4707	1 day
-67-75 years	9606	Homo sapiens (human)	4708	67-75 years
-25 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4709	25 weeks
-23- 70 years	9606	Homo sapiens (human)	4710	23- 70 years
-22- 67 years	9606	Homo sapiens (human)	4711	22- 67 years
-58-81 years	9606	Homo sapiens (human)	4712	58-81 years
-30-57 years	9606	Homo sapiens (human)	4713	30-57 years
-mean 58 years	9606	Homo sapiens (human)	4714	mean 58 years
-14 months	10000000	Mus musculus BALB/c	4715	14 months
-10-15 weeks	10000632	Mus musculus NOD	4716	10-15 weeks
-23-39 years	9606	Homo sapiens (human)	4717	23-39 years
-30-59 years	9606	Homo sapiens (human)	4718	30-59 years
-20-51 years	9606	Homo sapiens (human)	4719	20-51 years
-7 days	8839	Anas platyrhynchos (duck)	4720	7 days
-mean 39.7 years	9606	Homo sapiens (human)	4721	mean 39.7 years
-44 to 81 years	9606	Homo sapiens (human)	4722	44 to 81 years
-40–74 years	9606	Homo sapiens (human)	4723	4074 years
-5-8 weeks	10002763	Mus musculus HLA-A*11:01 Tg	4724	5-8 weeks
-6 weeks	10000105	Mus musculus TRAMP Tg	4725	6 weeks
-37-65 years	9606	Homo sapiens (human)	4726	37-65 years
-NULL	9825	Sus scrofa domesticus (domestic pig)	4727	null
-68	9606	Homo sapiens (human)	4728	68
-2 day old	10002232	Mus musculus BDC2.5 TCR Tg	4729	2 day old
-4-5  weeks	10000576	Mus musculus HLA-A*02:01 Tg	4730	4-5  weeks
-1 day old	10000632	Mus musculus NOD	4731	1 day old
-32-82 years	9606	Homo sapiens (human)	4732	32-82 years
->50 years	9606	Homo sapiens (human)	4733	>50 years
-33 to 55 years	9606	Homo sapiens (human)	4734	33 to 55 years
-40 to 55 years	9606	Homo sapiens (human)	4735	40 to 55 years
-21-82 years	9606	Homo sapiens (human)	4736	21-82 years
-23-95 years	9606	Homo sapiens (human)	4737	23-95 years
-5-8 weeks	10002764	Mus musculus HLA-B*44:01 Tg	4738	5-8 weeks
-7 -8 weeks	10000601	Mus musculus HLA-DR1 Tg	4739	7 -8 weeks
-24 to 65 years	9606	Homo sapiens (human)	4740	24 to 65 years
-48-80 years	9606	Homo sapiens (human)	4741	48-80 years
-10-15 weeks	10000067	Mus musculus C57BL/6	4742	10-15 weeks
-8.4	9606	Homo sapiens (human)	4743	8.4
-46-72 years	9606	Homo sapiens (human)	4744	46-72 years
-4 - 6 weeks	10000000	Mus musculus BALB/c	4745	4 - 6 weeks
-2 years	9606	Homo sapiens (human)	4746	2 years
-18-40 years old	9606	Homo sapiens (human)	4747	18-40 years old
-mean 29.7 years	9606	Homo sapiens (human)	4748	mean 29.7 years
-43- 79 years	9606	Homo sapiens (human)	4749	43- 79 years
-5-8 weeks	10001166	Mus musculus HLA-A24 Tg	4750	5-8 weeks
-6-20 weeks	10001166	Mus musculus HLA-A24 Tg	4751	6-20 weeks
-6-20 weeks	10000582	Mus musculus HLA-A2 Tg	4752	6-20 weeks
-6-20 weeks	10001782	Mus musculus HLA-B*07:02 Tg	4753	6-20 weeks
-mean 18.75 years	9606	Homo sapiens (human)	4754	mean 18.75 years
-6-20 weeks	10001237	Mus musculus HLA-B*35:01 Tg	4755	6-20 weeks
-60-75 years	9606	Homo sapiens (human)	4756	60-75 years
-50-96 years	9606	Homo sapiens (human)	4757	50-96 years
-42 to 58 years	9606	Homo sapiens (human)	4758	42 to 58 years
-66 to 77 years	9606	Homo sapiens (human)	4759	66 to 77 years
-58 to 67 years	9606	Homo sapiens (human)	4760	58 to 67 years
-56 to 81 years	9606	Homo sapiens (human)	4761	56 to 81 years
-33-74 years	9606	Homo sapiens (human)	4762	33-74 years
-7-8 weeks	10000601	Mus musculus HLA-DR1 Tg	4763	7-8 weeks
-48- 74 years	9606	Homo sapiens (human)	4764	48- 74 years
-1 month	9823	Sus scrofa (pig)	4765	1 month
-23-40 years	9606	Homo sapiens (human)	4766	23-40 years
-83-86	9606	Homo sapiens (human)	4767	83-86
-23 to 39 years	9606	Homo sapiens (human)	4768	23 to 39 years
-NULL	10002819	Rattus norvegicus HLA-B27 Tg	4769	null
-6-8 weels	10000000	Mus musculus BALB/c	4770	6-8 weeks
-9 years	9606	Homo sapiens (human)	4771	9 years
-4-18+ years	9606	Homo sapiens (human)	4772	4-18+ years
-23 to 26 years	9606	Homo sapiens (human)	4773	23 to 26 years
-83	9606	Homo sapiens (human)	4774	83
-19- 95 years	9606	Homo sapiens (human)	4775	19- 95 years
-55 years (mean)	9606	Homo sapiens (human)	4776	55 years (mean)
-6 to 8 weeks	10001217	Mus musculus pmel-1 TCR Tg	4777	6 to 8 weeks
-31 to 59 years	9606	Homo sapiens (human)	4778	31 to 59 years
-5 weeks	9823	Sus scrofa (pig)	4779	5 weeks
-8 to 12 weeks	10002848	Mus musculus HLA-DPw4 Tg	4780	8 to 12 weeks
-4-5  weeks	10002763	Mus musculus HLA-A*11:01 Tg	4781	4-5  weeks
-44 to 74 years	9606	Homo sapiens (human)	4782	44 to 74 years
-8 to 12 weeks	10000610	Mus musculus HLA-DR4 Tg	4783	8 to 12 weeks
-NULL	10002843	Mus musculus HLA-DRA*01:01/DRB1*15:01 Tg	4784	null
-24-70 years	9606	Homo sapiens (human)	4785	24-70 years
-50-70 years	9606	Homo sapiens (human)	4786	50-70 years
-5 days	9823	Sus scrofa (pig)	4787	5 days
-40-49 years	9606	Homo sapiens (human)	4788	40-49 years
-NULL	10002279	mus musculus VelocImmune	4789	null
-40-81 years	9606	Homo sapiens (human)	4790	40-81 years
-24 to 75 years	9606	Homo sapiens (human)	4791	24 to 75 years
-35- 70 years	9606	Homo sapiens (human)	4792	35- 70 years
-54-79 years	9606	Homo sapiens (human)	4793	54-79 years
-29 to 65 years	9606	Homo sapiens (human)	4794	29 to 65 years
-30 to 67 years	9606	Homo sapiens (human)	4795	30 to 67 years
-8 to 9 weeks	10000067	Mus musculus C57BL/6	4796	8 to 9 weeks
-mean 56 years	9606	Homo sapiens (human)	4797	mean 56 years
-32-66 years	9606	Homo sapiens (human)	4798	32-66 years
-49-88 years	9606	Homo sapiens (human)	4799	49-88 years
-24 - 46 years	9606	Homo sapiens (human)	4800	24 - 46 years
-47-88 years	9606	Homo sapiens (human)	4801	47-88 years
-8 week old	10000610	Mus musculus HLA-DR4 Tg	4802	8 week old
-30-39 years	9606	Homo sapiens (human)	4803	30-39 years
-59 to 64 years	9606	Homo sapiens (human)	4804	59 to 64 years
-NULL	10002292	Mus musculus BoyJ	4805	null
-30 to 79 years	9606	Homo sapiens (human)	4806	30 to 79 years
-65-70 years	9606	Homo sapiens (human)	4807	65-70 years
-57 years	9606	Homo sapiens	4808	57 years
-43 years	9606	Homo sapiens	4809	43 years
-28-64 years	9606	Homo sapiens (human)	4810	28-64 years
-27-75 years	9606	Homo sapiens (human)	4811	27-75 years
-53 years	9606	Homo sapiens	4812	53 years
-NULL	10001625	Mus musculus BALB/c HA(110-120)-specific TCR Tg/ Flu  HA Tg	4813	null
-37-90 years	9606	Homo sapiens (human)	4814	37-90 years
-51 to 84 years	9606	Homo sapiens (human)	4815	51 to 84 years
-55 to 87 years	9606	Homo sapiens (human)	4816	55 to 87 years
-31 to 83 years	9606	Homo sapiens (human)	4817	31 to 83 years
-41-86 years	9606	Homo sapiens (human)	4818	41-86 years
-7-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4819	7-12 weeks
-NULL	10002847	Mus musculus HLA-DPA1*01:03/DPB1*04:01 Tg	4820	null
-16-21 years	9606	Homo sapiens (human)	4821	16-21 years
-44 to 66 years	9606	Homo sapiens (human)	4822	44 to 66 years
-45-82 years	9606	Homo sapiens (human)	4823	45-82 years
-37- 88 years	9606	Homo sapiens (human)	4824	37- 88 years
-30-85 years	9606	Homo sapiens (human)	4825	30-85 years
-51-85 years	9606	Homo sapiens (human)	4826	51-85 years
-1-75 years	9606	Homo sapiens (human)	4827	1-75 years
-6-8 week-old	10000047	Mus musculus C57BL/10	4828	6-8 week-old
-NULL	10000207	Oryctolagus cuniculus Sandy Half-Lop	4829	null
-1-5 years old	9606	Homo sapiens (human)	4830	1-5 years old
-average age 54	9606	Homo sapiens (human)	4831	average age 54
-16-Feb	9606	Homo sapiens (human)	4832	16-feb
-7-9 wks	10000649	Mus musculus SJL	4833	7-9 weeks
-4-10 weeks	447135	Myodes glareolus (bank vole)	4834	4-10 weeks
-2-3 weeks	9823	Sus scrofa (pig)	4835	2-3 weeks
-90 days	10000000	Mus musculus BALB/c	4836	90 days
-6-12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	4837	6-12 weeks
-4-10 weeks	10000263	Mus musculus B10.BR	4838	4-10 weeks
-14 and younger	9606	Homo sapiens (human)	4839	14 and younger
-2-6 years	9606	Homo sapiens (human)	4840	2-6 years
-8-10 weeks	9823	Sus scrofa (pig)	4841	8-10 weeks
-12-24 month old	10000193	Bos taurus Holstein	4842	12-24 month old
-Ponies	9796	Equus caballus (domestic horse)	4843	ponies
-1-84 years old	9606	Homo sapiens (human)	4844	1-84 years old
-6 months	10000203	Oryctolagus cuniculus Groot Chinchilla	4845	6 months
-1-17 years	9606	Homo sapiens (human)	4846	1-17 years
-4-6 weeks	10000647	Mus musculus Quackenbush	4847	4-6 weeks
-NULL	10001673	Homo sapiens Australian Aboriginal	4848	null
-4 to 7 week-old	10000000	Mus musculus BALB/c	4849	4 to 7 week-old
-8 wekks-old	10000000	Mus musculus BALB/c	4850	8 weeks-old
-NULL	447135	Myodes glareolus (bank vole)	4851	null
-4-8-week-old	10000253	Mus musculus A/J	4852	4-8-week-old
-2-month-old	10000201	Oryctolagus cuniculus Fauve de Bourgogne	4853	2-month-old
-4-10 weeks	10000051	Mus musculus C57BL/10 X DBA/2	4854	4-10 weeks
-7-9 wks	10000000	Mus musculus BALB/c	4855	7-9 weeks
-More than 15 years	9606	Homo sapiens (human)	4856	more than 15 years
-20-31 years	9606	Homo sapiens (human)	4857	20-31 years
-4-10 weeks old	447135	Myodes glareolus (bank vole)	4858	4-10 weeks old
-6 weeks old	10000206	Oryctolagus cuniculus New Zealand White	4859	6 weeks old
-5-6 weeks-old	10000000	Mus musculus BALB/c	4860	5-6 weeks-old
-2-4 years-old	9544	Macaca mulatta (rhesus macaque)	4861	2-4 years-old
-Adutls	9606	Homo sapiens (human)	4862	adults
-3 weeks old	10000920	Gallus gallus Leghorn	4863	3 weeks old
-6-7 weeks-old	10000000	Mus musculus BALB/c	4864	6-7 weeks-old
-One week	10000654	Mus musculus Swiss albino	4865	1 week
-6-7-week-old	10000000	Mus musculus BALB/c	4866	6-7-week-old
-6 month	10000206	Oryctolagus cuniculus New Zealand White	4867	6 month
-28-92 years	9606	Homo sapiens (human)	4868	28-92 years
-6-8 weeks-old	10000038	Mus musculus C3H/He	4869	6-8 weeks-old
-2-day to 6-week old	10000000	Mus musculus BALB/c	4870	2-day to 6-week old
-8-12 weeks old	10000263	Mus musculus B10.BR	4871	8-12 weeks old
-NULL	10000630	Mus musculus NHI Swiss	4872	null
-3 days	8839	Anas platyrhynchos (duck)	4873	3 days
-6-7 wks	10090	Mus musculus (mouse)	4874	6-7 weeks
-NULL	10000200	Oryctolagus cuniculus Chinchilla	4875	null
-6-24 mo of age	9606	Homo sapiens (human)	4876	6-24 month of age
-Adults	10000119	Homo sapiens Caucasian	4877	adults
-7 weeks old	10000028	Mus musculus C3H	4878	7 weeks old
-6-7 weeks	10000647	Mus musculus Quackenbush	4879	6-7 weeks
-6-8 weeks	10000023	Mus musculus BDF1	4880	6-8 weeks
-4-6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4881	4-6 weeks
-NULL	10000023	Mus musculus BDF1	4882	null
-NULL	9505	Aotus trivirgatus (night monkey)	4883	null
-3 month old	9986	Oryctolagus cuniculus (rabbit)	4884	3 month old
-8-10 wo	10000000	Mus musculus BALB/c	4885	8-10 week
-5-7 months old	10000206	Oryctolagus cuniculus New Zealand White	4886	5-7 months old
-5 weeks	10000618	Mus musculus ICR	4887	5 weeks
-8-16 week	10000067	Mus musculus C57BL/6	4888	8-16 week
-6-10 weeks-old	10000019	Mus musculus BALB/cByJ	4889	6-10 weeks-old
-3.5-15 years	9606	Homo sapiens (human)	4890	3.5-15 years
-NULL	10000186	Mustela vison Black	4891	null
-0-12 months	9606	Homo sapiens (human)	4892	0-12 months
-6-8 months	9915	Bos indicus (Indicine cattle)	4893	6-8 months
-56.3 +/- 12.8 years	9606	Homo sapiens (human)	4894	56.3 ± 12.8 years
-6 - 8 mo	9913	Bos taurus (bovine)	4895	6 - 8 month
-6-15 weeks	10090	Mus musculus (mouse)	4896	6-15 weeks
-9 weeks	8839	Anas platyrhynchos (duck)	4897	9 weeks
-6-8 weeks old	10000271	Mus musculus B10.M	4898	6-8 weeks old
-5-8 weeks	10000187	Sus scrofa Landrace X Large White	4899	5-8 weeks
-10 to 65 years	9606	Homo sapiens (human)	4900	10 to 65 years
-2 to >20 years	9606	Homo sapiens (human)	4901	2 to >20 years
-22-41 years	9606	Homo sapiens (human)	4902	22-41 years
-53-63 years	9606	Homo sapiens (human)	4903	53-63 years
-6 months old	10000206	Oryctolagus cuniculus New Zealand White	4904	6 months old
-8 weeks old	10000209	Mesocricetus auratus HsdHan:Aura	4905	8 weeks old
-4 to 70 years old	9606	Homo sapiens (human)	4906	4 to 70 years old
-1 to 6 years	9606	Homo sapiens (human)	4907	1 to 6 years
-NULL	9844	Lama glama (llama)	4908	null
-15-72	9606	Homo sapiens (human)	4909	15-72
-12-44 years	9606	Homo sapiens (human)	4910	12-44 years
-25-43 years	9606	Homo sapiens (human)	4911	25-43 years
-adult	10000206	Oryctolagus cuniculus New Zealand White	4912	adult
-NULL	10000197	Oryctolagus cuniculus albino	4913	null
-14-85 years	9606	Homo sapiens (human)	4914	14-85 years
-12 weeks	9823	Sus scrofa (pig)	4915	12 weeks
-NULL	10114	Rattus (rat)	4916	null
-4 to 45 years-old	9606	Homo sapiens (human)	4917	4 to 45 years-old
-4-60 years old	9606	Homo sapiens (human)	4918	4-60 years old
-6 to 24 months	10000195	Capra hircus Saanen	4919	6 to 24 months
-NULL	10000657	Mus musculus Xenomouse	4920	null
-6 weeks	9823	Sus scrofa (pig)	4921	6 weeks
-8 to 9 weeks	10000000	Mus musculus BALB/c	4922	8 to 9 weeks
-16-70 years	9606	Homo sapiens (human)	4923	16-70 years
-12 weeks	10141	Cavia porcellus (guinea pig)	4924	12 weeks
-17-81 years	9606	Homo sapiens (human)	4925	17-81 years
-12-54 years	9606	Homo sapiens (human)	4926	12-54 years
-4 weeks	9031	Gallus gallus (chicken)	4927	4 weeks
-8-9 weeks	10000047	Mus musculus C57BL/10	4928	8-9 weeks
-NULL	10000920	Gallus gallus Leghorn	4929	null
-2 months	10000024	Mus musculus Biozzi	4930	2 months
-4 month old	9685	Felis catus (cat)	4931	4 month old
-35-40 days	10000669	Cavia porcellus Hartley	4932	35-40 days
-5 weeks old	10000662	Rattus norvegicus Lewis	4933	5 weeks old
-22 wk	10000639	Mus musculus NZB	4934	22 week
-608 weeks	10000000	Mus musculus BALB/c	4935	608 weeks
-NULL	10001151	Oryctolagus cuniculus Chinchilla Bastard	4936	null
-14-57	9606	Homo sapiens (human)	4937	14-57
-NULL	10000239	Mus musculus CF-1 X BALB/c	4938	null
-NULL	10001117	Oryctolagus cuniculus Blanc de Bouscat	4939	null
-17-42 years-old	9606	Homo sapiens (human)	4940	17-42 years-old
-NULL	74940	Oncorhynchus tshawytscha (king salmon)	4941	null
-6 weeks	10000919	Gallus gallus White Leghorn	4942	6 weeks
-6 weeks old	10000228	Mus musculus CBA	4943	6 weeks old
-2-65 years-old	9606	Homo sapiens (human)	4944	2-65 years-old
-43 days	10000667	Rattus norvegicus Sprague-Dawley	4945	43 days
-3-4 weeks	10000618	Mus musculus ICR	4946	3-4 weeks
-8-16 week	10000051	Mus musculus C57BL/10 X DBA/2	4947	8-16 week
-6 week-old	10000000	Mus musculus BALB/c	4948	6 week-old
-4-6 months	9669	Mustela putorius furo (black ferret)	4949	4-6 months
-6 weeks	10114	Rattus (rat)	4950	6 weeks
-6-12 months	9940	Ovis aries (domestic sheep)	4951	6-12 months
-6 weeks	10000019	Mus musculus BALB/cByJ	4952	6 weeks
-Adult	10000019	Mus musculus BALB/cByJ	4953	adult
-NULL	10000204	Oryctolagus cuniculus Japanese white	4954	null
-NULL	10000093	Mus musculus C57BL/6 human IgCkappa Tg	4955	null
-NULL	34839	Chinchilla lanigera (long-tailed chinchilla)	4956	null
-8-week old	10000000	Mus musculus BALB/c	4957	8-week old
-45 day	10116	Rattus norvegicus (brown rat)	4958	45 day
-10 weeks	9031	Gallus gallus (chicken)	4959	10 weeks
-45 to 55 years	9606	Homo sapiens (human)	4960	45 to 55 years
-7-10 years	9606	Homo sapiens (human)	4961	7-10 years
-NULL	10000647	Mus musculus Quackenbush	4962	null
-12 weeks	10000617	Mus musculus HuMAb (Medarex)	4963	12 weeks
-8-74 years	9606	Homo sapiens (human)	4964	8-74 years
-3 months to 7 years	9606	Homo sapiens (human)	4965	3 months to 7 years
-12 to 55 years	9606	Homo sapiens (human)	4966	12 to 55 years
-NULL	10000026	Mus musculus BP2	4967	null
-8-9-weeks-old	10000629	Mus musculus ND4 Swiss Webster	4968	8-9-weeks-old
-3 months	10000631	Mus musculus NMRI	4969	3 months
-18 to 66 years	9606	Homo sapiens (human)	4970	18 to 66 years
-up to 12 weeks old	10000047	Mus musculus C57BL/10	4971	up to 12 weeks old
-36-55	9606	Homo sapiens (human)	4972	36-55
-5-6 weeks	10000655	Mus musculus Swiss Webster	4973	5-6 weeks
-4 months	10000206	Oryctolagus cuniculus New Zealand White	4974	4 months
-Younger than 35 years	9606	Homo sapiens (human)	4975	younger than 35 years
-8 weeks-old	10090	Mus musculus (mouse)	4976	8 weeks-old
-NULL	10000248	Mus musculus 129 GIX+	4977	null
-45 days	10116	Rattus norvegicus (brown rat)	4978	45 days
-8 to 12-week-old	10000067	Mus musculus C57BL/6	4979	8 to 12-week-old
-18-20 years-old	9606	Homo sapiens (human)	4980	18-20 years-old
-6-8 weeks	10001998	Mus musculus CD1	4981	6-8 weeks
-3 weeks	10000187	Sus scrofa Landrace X Large White	4982	3 weeks
-Adult	34839	Chinchilla lanigera (long-tailed chinchilla)	4983	adult
-3 months	9823	Sus scrofa (pig)	4984	3 months
-5-8 weeks	10000653	Mus musculus Swiss	4985	5-8 weeks
-8-10 weeks old	10000655	Mus musculus Swiss Webster	4986	8-10 weeks old
-NULL	45352	Morone chrysops x Morone saxatilis (white bass x striped sea-bass)	4987	null
-6 - 9 months	9913	Bos taurus (bovine)	4988	6 - 9 months
-6-9 months	9913	Bos taurus (bovine)	4989	6-9 months
-NULL	10001756	Mus musculus B10.MBR X B10.D2	4990	null
-NULL	9542	Macaca fuscata (Japanese monkey)	4991	null
-8 weeks	10000023	Mus musculus BDF1	4992	8 weeks
-6 weeks	9031	Gallus gallus (chicken)	4993	6 weeks
-Children <5 years old	9606	Homo sapiens (human)	4994	children <5 years old
-91-101 years	9606	Homo sapiens (human)	4995	91-101 years
-NULL	13489	Dicentrarchus labrax (European sea bass)	4996	null
-4 - 6 weeks	10001998	Mus musculus CD1	4997	4 - 6 weeks
-8 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	4998	8 weeks
-4-5 weeks	10001022	Mus musculus A.BY/SnJ	4999	4-5 weeks
-1-64 years	9606	Homo sapiens (human)	5000	1-64 years
-8 weeks	10000268	Mus musculus B10.D2-Hc1 H2d H2-T18c/nSn	5001	8 weeks
-6 weeks	10000206	Oryctolagus cuniculus New Zealand White	5002	6 weeks
-1-6 months	9606	Homo sapiens (human)	5003	1-6 months
-24-34 years	9606	Homo sapiens (human)	5004	24-34 years
-2 - 3 months	10000000	Mus musculus BALB/c	5005	2 - 3 months
-10 weeks-old	9823	Sus scrofa (pig)	5006	10 weeks-old
-3.5 month	10000206	Oryctolagus cuniculus New Zealand White	5007	3.5 month
-16 to 60 years	9606	Homo sapiens (human)	5008	16 to 60 years
-2 month	10000000	Mus musculus BALB/c	5009	2 month
-8-10 weeks	10116	Rattus norvegicus (brown rat)	5010	8-10 weeks
-8 weeks or 12 months	10000000	Mus musculus BALB/c	5011	8 weeks or 12 months
-NULL	9838	Camelus dromedarius (camel)	5012	null
-12 weeks	10000668	Cavia porcellus Duncan-Hartley	5013	12 weeks
-8 weeks	10000206	Oryctolagus cuniculus New Zealand White	5014	8 weeks
-4 weeks	10000914	Mus musculus TO	5015	4 weeks
-12 months old	10000191	Bos taurus Hereford	5016	12 months old
-4-8 weeks	10001998	Mus musculus CD1	5017	4-8 weeks
-3 weeks	10090	Mus musculus (mouse)	5018	3 weeks
-6-7 weeks old	10000067	Mus musculus C57BL/6	5019	6-7 weeks old
-6-7 weeks old	10000000	Mus musculus BALB/c	5020	6-7 weeks old
-8 weeks old	10000662	Rattus norvegicus Lewis	5021	8 weeks old
-10 weeks	10000206	Oryctolagus cuniculus New Zealand White	5022	10 weeks
-6-7 months	10000194	Bos taurus Holstein-Friesian	5023	6-7 months
-Infants	9606	Homo sapiens (human)	5024	infants
-6-8 weeks-old	10000228	Mus musculus CBA	5025	6-8 weeks-old
-42 days	10000667	Rattus norvegicus Sprague-Dawley	5026	42 days
-14 weeks old	9825	Sus scrofa domesticus (domestic pig)	5027	14 weeks old
-NULL	10000990	Ovis aries Romanov	5028	null
-12-14 weeks	10000000	Mus musculus BALB/c	5029	12-14 weeks
-2 months	10000206	Oryctolagus cuniculus New Zealand White	5030	2 months
-12 weeks old	10000668	Cavia porcellus Duncan-Hartley	5031	12 weeks old
-4-8 months	10000194	Bos taurus Holstein-Friesian	5032	4-8 months
-2 and 64 years	9606	Homo sapiens (human)	5033	2 and 64 years
-16-79 years	9606	Homo sapiens (human)	5034	16-79 years
-12 weeks	10000206	Oryctolagus cuniculus New Zealand White	5035	12 weeks
-8 weeks	10000618	Mus musculus ICR	5036	8 weeks
-38-69 years	9606	Homo sapiens (human)	5037	38-69 years
-NULL	9479	Platyrrhini (New World monkey)	5038	null
-3 to 16 years	9796	Equus caballus (domestic horse)	5039	3 to 16 years
-16 weeks-40 years	9606	Homo sapiens (human)	5040	16 weeks-40 years
-25-week-old	10000919	Gallus gallus White Leghorn	5041	25-week-old
-7-8 weeks-old	10000661	Rattus norvegicus Fischer 344	5042	7-8 weeks-old
-60-90 days old	10000000	Mus musculus BALB/c	5043	60-90 days old
-7 weeks	10000653	Mus musculus Swiss	5044	7 weeks
-NULL	9554	Papio (baboon)	5045	null
-3-4 weeks-old	10000000	Mus musculus BALB/c	5046	3-4 weeks-old
-6 weeks	10000645	Mus musculus PrP null	5047	6 weeks
-12 to 66 years-old	9606	Homo sapiens (human)	5048	12 to 66 years-old
-3.6-18.6 years	9606	Homo sapiens (human)	5049	3.6-18.6 years
-NULL	10001097	Sus scrofa Yorkshire	5050	null
-4-6 weeks old	10141	Cavia porcellus (guinea pig)	5051	4-6 weeks old
-8-12 weeks old	10000038	Mus musculus C3H/He	5052	8-12 weeks old
-2-3 months	10000013	Mus musculus BALB/c X A/J	5053	2-3 months
-NULL	10001099	Mus musculus CF-1	5054	null
-NULL	10000659	Rattus norvegicus CD Charles River	5055	null
-2-18 years	9606	Homo sapiens (human)	5056	2-18 years
-6-8 weeks	10000914	Mus musculus TO	5057	6-8 weeks
-7 weeks old	10000000	Mus musculus BALB/c	5058	7 weeks old
-6 weeks	10000187	Sus scrofa Landrace X Large White	5059	6 weeks
-4-36 month-old	9606	Homo sapiens (human)	5060	4-36 month-old
-6-8 weeks	10000062	Mus musculus FVB/J	5061	6-8 weeks
-1-90 years	9606	Homo sapiens (human)	5062	1-90 years
-14-88 years	9606	Homo sapiens (human)	5063	14-88 years
-10-12 weeks	10001998	Mus musculus CD1	5064	10-12 weeks
-7-weeks-old	10000000	Mus musculus BALB/c	5065	7-weeks-old
-6 - 8 wo	10000006	Mus musculus BALB/c GalNAc Transferase null	5066	6 - 8 week
-8-12 weeks	10000653	Mus musculus Swiss	5067	8-12 weeks
-8-12 wk	10090	Mus musculus (mouse)	5068	8-12 week
-5 months	9823	Sus scrofa (pig)	5069	5 months
-4.5 months	10000666	Rattus norvegicus Rowett	5070	4.5 months
-6-10 week	10000000	Mus musculus BALB/c	5071	6-10 week
-1 month	10000241	Gallus gallus H.B15	5072	1 month
-4 weeks	8839	Anas platyrhynchos (duck)	5073	4 weeks
-8 weeks	10000266	Mus musculus B10.BR-H2k H2-T18a/SgSnJ	5074	8 weeks
-21 day old	9031	Gallus gallus (chicken)	5075	21 day old
-4 to 6 week-old	10000000	Mus musculus BALB/c	5076	4 to 6 week-old
-6 weeks-old	10000000	Mus musculus BALB/c	5077	6 weeks-old
-NULL	10042	Peromyscus maniculatus (North American deer mouse)	5078	null
-NULL	10000024	Mus musculus Biozzi	5079	null
-49-81 years	9606	Homo sapiens (human)	5080	49-81 years
-NULL	10002076	Sus scrofa Camborough 22	5081	null
-NULL	10000617	Mus musculus HuMAb (Medarex)	5082	null
-NULL	10000247	Mus musculus (CBA/J X C57BL/6J) human IgH Tg human IgL Tg	5083	null
-3-4 months-old	10000206	Oryctolagus cuniculus New Zealand White	5084	3-4 months-old
-8-16 week	10000216	Mus musculus C57BL/6 X BALB/c	5085	8-16 week
-35 years-old	9606	Homo sapiens (human)	5086	35 years-old
-NULL	168098	Orectolobus maculatus (spotted wobbegong)	5087	null
-6- week-old	10000000	Mus musculus BALB/c	5088	6- week-old
-NULL	10000235	Mus musculus CBA/CaHN-Btkxid/J	5089	null
-7 to 77 years	9606	Homo sapiens (human)	5090	7 to 77 years
-35.5 +/- 12.8 years	9606	Homo sapiens (human)	5091	35.5 ± 12.8 years
-26–71 years	9606	Homo sapiens (human)	5092	2671 years
-NULL	10000918	Oryctolagus cuniculus California x New Zealand White	5093	null
-38 to 50 years	9606	Homo sapiens (human)	5094	38 to 50 years
-5 to 7 weeks	10000000	Mus musculus BALB/c	5095	5 to 7 weeks
-5-10 weeks old	10000067	Mus musculus C57BL/6	5096	5-10 weeks old
-2-13 years	9606	Homo sapiens (human)	5097	2-13 years
-37 average	9606	Homo sapiens (human)	5098	37 average
-3 months	10000024	Mus musculus Biozzi	5099	3 months
-8-16 week	10000054	Mus musculus DBA/1	5100	8-16 week
-8 to 12 weeks	10000263	Mus musculus B10.BR	5101	8 to 12 weeks
-NULL	10000574	Mus musculus FVB/N Prp null	5102	null
-7-10 weeks	10000253	Mus musculus A/J	5103	7-10 weeks
-6-8 weeks old	10000273	Mus musculus B10.P	5104	6-8 weeks old
-20-85 years	9606	Homo sapiens (human)	5105	20-85 years
-2-week old	10000000	Mus musculus BALB/c	5106	2-week old
-7-9 weeks	10000253	Mus musculus A/J	5107	7-9 weeks
-NULL	10000240	Gallus gallus Brown leghorn Hisex	5108	null
-7 days	9825	Sus scrofa domesticus (domestic pig)	5109	7 days
-65 and 74 years old	9606	Homo sapiens (human)	5110	65 and 74 years old
-6-7 weeks	10090	Mus musculus (mouse)	5111	6-7 weeks
-1 month	9606	Homo sapiens (human)	5112	1 month
-3-4 years	9555	Papio anubis (Doguera baboon)	5113	3-4 years
-5-weeks-old	10000618	Mus musculus ICR	5114	5-weeks-old
-3 months-old	10116	Rattus norvegicus (brown rat)	5115	3 months-old
-5-6 weeks	10000047	Mus musculus C57BL/10	5116	5-6 weeks
-8-16 week	10000047	Mus musculus C57BL/10	5117	8-16 week
-4 years old	9606	Homo sapiens (human)	5118	4 years old
-8-16 week	10000055	Mus musculus DBA/2	5119	8-16 week
-4 to 6 years	9541	Macaca fascicularis (crab eating macaque)	5120	4 to 6 years
-8 to 10 weeks	10001446	Rattus norvegicus Wistar Kyoto	5121	8 to 10 weeks
-6-8 weeks old	10001998	Mus musculus CD1	5122	6-8 weeks old
-8-12 weeks	10000259	Mus musculus B10.A(3R)	5123	8-12 weeks
-19-27 years old	9606	Homo sapiens (human)	5124	19-27 years old
-up to 12 weeks old	10000263	Mus musculus B10.BR	5125	up to 12 weeks old
-NULL	30538	Vicugna pacos (alpaca)	5126	null
-NULL	10000199	Oryctolagus cuniculus Californian	5127	null
-NULL	10000923	Ovis aries Merino X Border Leiscester	5128	null
-NULL	10000202	Oryctolagus cuniculus Flemish Giant	5129	null
-up to 12 weeks old	10090	Mus musculus (mouse)	5130	up to 12 weeks old
-6-36-month-old	9606	Homo sapiens (human)	5131	6-36-month-old
-18 to 73 years	9606	Homo sapiens (human)	5132	18 to 73 years
-2-3 month old	10000206	Oryctolagus cuniculus New Zealand White	5133	2-3 month old
-12 weeks	10000055	Mus musculus DBA/2	5134	12 weeks
-3 to 5 months	10000000	Mus musculus BALB/c	5135	3 to 5 months
-6 weeks	10000655	Mus musculus Swiss Webster	5136	6 weeks
-1.5-7years	9606	Homo sapiens (human)	5137	1.5-7years
-4-7 weeks	10000000	Mus musculus BALB/c	5138	4-7 weeks
-6-8 weeks	10000669	Cavia porcellus Hartley	5139	6-8 weeks
-14-51 years	9606	Homo sapiens (human)	5140	14-51 years
-6-13 weeks	10090	Mus musculus (mouse)	5141	6-13 weeks
-18-19 years-old	9606	Homo sapiens (human)	5142	18-19 years-old
-6 weeks-old	10000618	Mus musculus ICR	5143	6 weeks-old
-6-8 weeks old	10000208	Mesocricetus auratus DSN	5144	6-8 weeks old
-6 months	9986	Oryctolagus cuniculus (rabbit)	5145	6 months
-2 months to 14 years	9606	Homo sapiens (human)	5146	2 months to 14 years
-8 wo	10000000	Mus musculus BALB/c	5147	8 week
-5 wk	10000618	Mus musculus ICR	5148	5 week
-NULL	10047	Meriones unguiculatus (Mongolian jird)	5149	null
-40-day-old	10000667	Rattus norvegicus Sprague-Dawley	5150	40-day-old
-6-8 months	9913	Bos taurus (bovine)	5151	6-8 months
-4-6 weeks old	10000028	Mus musculus C3H	5152	4-6 weeks old
-6 wk	10000000	Mus musculus BALB/c	5153	6 week
-25 weeks	10000919	Gallus gallus White Leghorn	5154	25 weeks
-47-82 years	9606	Homo sapiens (human)	5155	47-82 years
-8 weeks old	10090	Mus musculus (mouse)	5156	8 weeks old
-6 weeks old	10000062	Mus musculus FVB/J	5157	6 weeks old
-3 months	10000206	Oryctolagus cuniculus New Zealand White	5158	3 months
-4 weeks	10000915	Mus musculus Kunming	5159	4 weeks
-19-60 years	9606	Homo sapiens (human)	5160	19-60 years
-7 wk	10000000	Mus musculus BALB/c	5161	7 week
-20-35 years	9606	Homo sapiens (human)	5162	20-35 years
-7-10 days	9913	Bos taurus (bovine)	5163	7-10 days
-8 weeks	10000024	Mus musculus Biozzi	5164	8 weeks
-2 mo	10000188	Sus scrofa NIH miniature pig	5165	2 month
-2 mo	10000206	Oryctolagus cuniculus New Zealand White	5166	2 month
-> 6 months	10000193	Bos taurus Holstein	5167	> 6 months
-4 wk	10000000	Mus musculus BALB/c	5168	4 week
-8 weeks	10000231	Mus musculus CBA X BALB/c	5169	8 weeks
-5 weeks	9031	Gallus gallus (chicken)	5170	5 weeks
-25-30 grams	10000000	Mus musculus BALB/c	5171	25-30 grams
-NULL	10000035	Mus musculus C3H/DiSn	5172	null
-8-10 week	10000000	Mus musculus BALB/c	5173	8-10 week
-2 month old	10000000	Mus musculus BALB/c	5174	2 month old
-8 weeks	10000655	Mus musculus Swiss Webster	5175	8 weeks
-8 months	9913	Bos taurus (bovine)	5176	8 months
-8-10 weeks-old	9823	Sus scrofa (pig)	5177	8-10 weeks-old
-8-12 weeks old	10000233	Mus musculus CBA/Ca	5178	8-12 weeks old
-6 to 8 weeks old	10000067	Mus musculus C57BL/6	5179	6 to 8 weeks old
-6 weeks	10000050	Mus musculus C57BL/10 X C3H/HeJ	5180	6 weeks
-NULL	10000036	Mus musculus C3H/FeJ	5181	null
-3 weeks	10141	Cavia porcellus (guinea pig)	5182	3 weeks
-5-7 months-old	10000185	Canis familiaris beagle	5183	5-7 months-old
-8-12 weeks old	10000649	Mus musculus SJL	5184	8-12 weeks old
-38 days	10000659	Rattus norvegicus CD Charles River	5185	38 days
-Three-month-old	10000664	Rattus norvegicus LOU/C	5186	3-month-old
-10 weeks-old	10000206	Oryctolagus cuniculus New Zealand White	5187	10 weeks-old
-3-4 weeks old	10000067	Mus musculus C57BL/6	5188	3-4 weeks old
-23-80	9606	Homo sapiens (human)	5189	23-80
-35 to 66 years	9606	Homo sapiens (human)	5190	35 to 66 years
-NULL	10001597	Mus musculus alpha-galactosyl transferase null	5191	null
-2 months	10090	Mus musculus (mouse)	5192	2 months
-NULL	9669	Mustela putorius furo (black ferret)	5193	null
-6 to 8 -week-old	10000000	Mus musculus BALB/c	5194	6 to 8 -week-old
-21 to 59 years	9606	Homo sapiens (human)	5195	21 to 59 years
-8-12 weeks-old	10001998	Mus musculus CD1	5196	8-12 weeks-old
-Four-weeks-old	10000000	Mus musculus BALB/c	5197	4-weeks-old
-8-16 week	10000263	Mus musculus B10.BR	5198	8-16 week
-14-15 weeks	10000000	Mus musculus BALB/c	5199	14-15 weeks
-4-6 weeks old	10001998	Mus musculus CD1	5200	4-6 weeks old
-37-75 years	9606	Homo sapiens (human)	5201	37-75 years
-7-8 weeks	10000663	Rattus norvegicus LOU	5202	7-8 weeks
-4-10 weeks old	10000000	Mus musculus BALB/c	5203	4-10 weeks old
-NULL	9665	Mustela	5204	null
-Adult (pregnant)	9606	Homo sapiens (human)	5205	adult (pregnant)
-5-7 weeks	10000624	Mus musculus MF1	5206	5-7 weeks
-6-8 weeks	10032	Cricetulus migratorius (gray dwarf hamster)	5207	6-8 weeks
-8 weeks	10000202	Oryctolagus cuniculus Flemish Giant	5208	8 weeks
-<20 years	9606	Homo sapiens (human)	5209	<20 years
-9-10 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5210	9-10 weeks
-NULL	10000249	Mus musculus 129/Ola Prp null	5211	null
-8-16 week	10000038	Mus musculus C3H/He	5212	8-16 week
->15 years	9606	Homo sapiens (human)	5213	>15 years
-8-16 week	10000000	Mus musculus BALB/c	5214	8-16 week
-6 mos	10000206	Oryctolagus cuniculus New Zealand White	5215	6 months
-33-71 years	9606	Homo sapiens (human)	5216	33-71 years
-6-8 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5217	6-8 weeks
-27 to 46 years	9606	Homo sapiens (human)	5218	27 to 46 years
-6-8 weeks old	10000206	Oryctolagus cuniculus New Zealand White	5219	6-8 weeks old
-6 months to 3 years	9606	Homo sapiens (human)	5220	6 months to 3 years
-6 - 8 wo	10000000	Mus musculus BALB/c	5221	6 - 8 week
-2-5 months old	9606	Homo sapiens (human)	5222	2-5 months old
-12 weeks	10000024	Mus musculus Biozzi	5223	12 weeks
-4-6 weeks	10001998	Mus musculus CD1	5224	4-6 weeks
-NULL	10002077	Canis familiaris beagle X maltese	5225	null
-1 month-old	10000241	Gallus gallus H.B15	5226	1 month-old
-8-12 weeks	10000261	Mus musculus B10.A(5R)	5227	8-12 weeks
-NULL	9556	Papio cynocephalus (baboon)	5228	null
-51-89 years	9606	Homo sapiens (human)	5229	51-89 years
-birth - 5 years	9606	Homo sapiens (human)	5230	birth - 5 years
-5 years	9598	Pan troglodytes (chimpanzee)	5231	5 years
-3-4 days	10000653	Mus musculus Swiss	5232	3-4 days
-23 to 89 years	9606	Homo sapiens (human)	5233	23 to 89 years
-4-8-week-old	10000047	Mus musculus C57BL/10	5234	4-8-week-old
-Neonates (infected mothers or PM)	9606	Homo sapiens (human)	5235	neonates (infected mothers or pm)
-1-4 years	9606	Homo sapiens (human)	5236	1-4 years
-3-65 years-old	9606	Homo sapiens (human)	5237	3-65 years-old
-NULL	10000664	Rattus norvegicus LOU/C	5238	null
-Juvenile	30538	Vicugna pacos (alpaca)	5239	juvenile
->20 years	9606	Homo sapiens (human)	5240	>20 years
-19 to 71 years	9606	Homo sapiens (human)	5241	19 to 71 years
-NULL	9557	Papio hamadryas (baboon)	5242	null
-1 to 8 years	9606	Homo sapiens (human)	5243	1 to 8 years
-19 to 66 years	9606	Homo sapiens (human)	5244	19 to 66 years
-27 to 71 years	9606	Homo sapiens (human)	5245	27 to 71 years
-6-8 weeks-old	10000019	Mus musculus BALB/cByJ	5246	6-8 weeks-old
-8-59 years	9606	Homo sapiens (human)	5247	8-59 years
-3-23 years	9606	Homo sapiens (human)	5248	3-23 years
-18-21	9606	Homo sapiens (human)	5249	18-21
-8-12-week-old	10000275	Mus musculus B10.RIII	5250	8-12-week-old
-6 weeks-old	10000067	Mus musculus C57BL/6	5251	6 weeks-old
-6-8 weeks old	10000019	Mus musculus BALB/cByJ	5252	6-8 weeks old
-3 months old	10000206	Oryctolagus cuniculus New Zealand White	5253	3 months old
-8 to 12 weeks	10000238	Mus musculus CD1d null	5254	8 to 12 weeks
-8 to 12 weeks	10000621	Mus musculus IL-12 null	5255	8 to 12 weeks
-8 to 12-week-old	10000233	Mus musculus CBA/Ca	5256	8 to 12-week-old
-6-8 weeks	10000647	Mus musculus Quackenbush	5257	6-8 weeks
-1-1.5 years	9544	Macaca mulatta (rhesus macaque)	5258	1-1.5 years
-32-70	9606	Homo sapiens (human)	5259	32-70
-17 to 45 years	9606	Homo sapiens (human)	5260	17 to 45 years
-3-5 weeks old	10000067	Mus musculus C57BL/6	5261	3-5 weeks old
-18-21 years-old	9606	Homo sapiens (human)	5262	18-21 years-old
-3 weeks	10000649	Mus musculus SJL	5263	3 weeks
-7-9 weeks old	10090	Mus musculus (mouse)	5264	7-9 weeks old
-19-43 years	9606	Homo sapiens (human)	5265	19-43 years
-8 to 12 months	10000000	Mus musculus BALB/c	5266	8 to 12 months
-Adult (18-49)	9606	Homo sapiens (human)	5267	adult (18-49)
-19-40 years old	9606	Homo sapiens (human)	5268	19-40 years old
-12-16 weeks-old	10000065	Mus musculus C57BL/10SnJ	5269	12-16 weeks-old
-15-64 years old	9606	Homo sapiens (human)	5270	15-64 years old
-6-8 weeks	10000065	Mus musculus C57BL/10SnJ	5271	6-8 weeks
-20-25 g	10000000	Mus musculus BALB/c	5272	20-25 g
-13-66 years	9606	Homo sapiens (human)	5273	13-66 years
-16-76 years	9606	Homo sapiens (human)	5274	16-76 years
-17-71 years	9606	Homo sapiens (human)	5275	17-71 years
-Adutls	10000119	Homo sapiens Caucasian	5276	adults
-20-88 years	9606	Homo sapiens (human)	5277	20-88 years
-6-8 weeks old	10000062	Mus musculus FVB/J	5278	6-8 weeks old
-32 years	10000119	Homo sapiens Caucasian	5279	32 years
-4 weeks	10001309	Mus musculus hTNF Tg	5280	4 weeks
-4 months old	10000198	Oryctolagus cuniculus California Satin	5281	4 months old
-22-61 years	9606	Homo sapiens (human)	5282	22-61 years
-6 weeks old	10000921	Gallus gallus Cobb 500	5283	6 weeks old
-NULL	10000652	Mus musculus STU	5284	null
-19-35 years	9606	Homo sapiens (human)	5285	19-35 years
-8-12 weeks old	10000047	Mus musculus C57BL/10	5286	8-12 weeks old
-3-5 weeks	10000067	Mus musculus C57BL/6	5287	3-5 weeks
-7-9 weeks	10000263	Mus musculus B10.BR	5288	7-9 weeks
-22-24 years	9606	Homo sapiens (human)	5289	22-24 years
-15-26 years	9606	Homo sapiens (human)	5290	15-26 years
-8 to 12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	5291	8 to 12 weeks
-8 wk	10000000	Mus musculus BALB/c	5292	8 week
-6 weeks	10000102	Mus musculus C57BL/6 Prp null	5293	6 weeks
-NULL	78354	Saguinus midas midas	5294	null
-6 weeks old	10000653	Mus musculus Swiss	5295	6 weeks old
->13 years	9606	Homo sapiens (human)	5296	>13 years
-1.25-19 years	9606	Homo sapiens (human)	5297	1.25-19 years
-7 - 79 years	9606	Homo sapiens (human)	5298	7 - 79 years
-4-6 weeks	10000055	Mus musculus DBA/2	5299	4-6 weeks
-NULL	43777	Pithecia pithecia (Guianan saki)	5300	null
-12 weeks	10000618	Mus musculus ICR	5301	12 weeks
-10-week-old	9823	Sus scrofa (pig)	5302	10-week-old
-Adults	292213	Aotus griseimembra	5303	adults
-adult	292213	Aotus griseimembra	5304	adult
-8-24 weeks old	10090	Mus musculus (mouse)	5305	8-24 weeks old
-9 weeks old	10000206	Oryctolagus cuniculus New Zealand White	5306	9 weeks old
-> 20 years	9606	Homo sapiens (human)	5307	> 20 years
-NULL	10000915	Mus musculus Kunming	5308	null
-24 days	447135	Myodes glareolus (bank vole)	5309	24 days
-2-3 months old	9986	Oryctolagus cuniculus (rabbit)	5310	2-3 months old
-5-6 weeks	10000051	Mus musculus C57BL/10 X DBA/2	5311	5-6 weeks
-mean = 45 years	9606	Homo sapiens (human)	5312	mean = 45 years
-6-8 wks	10000038	Mus musculus C3H/He	5313	6-8 weeks
-8-12 weeks	10000258	Mus musculus B10.A(2R)	5314	8-12 weeks
-5-64 years	9606	Homo sapiens (human)	5315	5-64 years
-1-34 years	9606	Homo sapiens (human)	5316	1-34 years
-4-6 weeks-old	10000618	Mus musculus ICR	5317	4-6 weeks-old
-2-4 weeks	10000000	Mus musculus BALB/c	5318	2-4 weeks
-25 days	10000645	Mus musculus PrP null	5319	25 days
-8 wk	10090	Mus musculus (mouse)	5320	8 week
-4 days	8835	Anas (ducks)	5321	4 days
-15-95 years old	9606	Homo sapiens (human)	5322	15-95 years old
-9-22 months old	9606	Homo sapiens (human)	5323	9-22 months old
-39 +/- 2.4 years	9606	Homo sapiens (human)	5324	39 ± 2.4 years
-24-57 years	9606	Homo sapiens (human)	5325	24-57 years
-Child (5-11)	9606	Homo sapiens (human)	5326	child (5-11)
-18-27 years	9606	Homo sapiens (human)	5327	18-27 years
-6 months to 53 years	9606	Homo sapiens (human)	5328	6 months to 53 years
-Average age of 37 years	9606	Homo sapiens (human)	5329	average age of 37 years
-6-8 weeks	10000232	Mus musculus CBA.M523	5330	6-8 weeks
-4- to 6-week-old	10001998	Mus musculus CD1	5331	4- to 6-week-old
-11 weeks	10000067	Mus musculus C57BL/6	5332	11 weeks
-NULL	10000020	Mus musculus BALB/cByJ-Rb5Bnr	5333	null
-6-8 weeks	10000260	Mus musculus B10.A(4R)	5334	6-8 weeks
-NULL	10000619	Mus musculus ICR X Swiss	5335	null
-7 to 8 weeks	10000655	Mus musculus Swiss Webster	5336	7 to 8 weeks
-8-12-week-old	10000038	Mus musculus C3H/He	5337	8-12-week-old
-8-12 weeks old	10000665	Rattus norvegicus LOU/M	5338	8-12 weeks old
-3-15 years	9606	Homo sapiens (human)	5339	3-15 years
-0.75-15 years	9606	Homo sapiens (human)	5340	0.75-15 years
-2-4 yrs	9544	Macaca mulatta (rhesus macaque)	5341	2-4 years
-4-6 weeks	10000061	Mus musculus FVB	5342	4-6 weeks
-15-71	9606	Homo sapiens (human)	5343	15-71
-4-70 years	9606	Homo sapiens (human)	5344	4-70 years
-0.8-78 years	9606	Homo sapiens (human)	5345	0.8-78 years
-6-8 weeks old	10000647	Mus musculus Quackenbush	5346	6-8 weeks old
-8-12 weeks	10000260	Mus musculus B10.A(4R)	5347	8-12 weeks
-6-8 weeks	10000916	Mus musculus C3H/He-mg	5348	6-8 weeks
-21 days	10000000	Mus musculus BALB/c	5349	21 days
-4-8 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5350	4-8 weeks
-1.8-14.2 years	9606	Homo sapiens (human)	5351	1.8-14.2 years
-4-26 weeks	10000019	Mus musculus BALB/cByJ	5352	4-26 weeks
-14-82 years	9606	Homo sapiens (human)	5353	14-82 years
-7 weeks	10000645	Mus musculus PrP null	5354	7 weeks
-adult	9838	Camelus dromedarius (camel)	5355	adult
-21 to 45 years	9606	Homo sapiens (human)	5356	21 to 45 years
-6-8 weeks	10000574	Mus musculus FVB/N Prp null	5357	6-8 weeks
-10 to 47 years	9606	Homo sapiens (human)	5358	10 to 47 years
-3 months	10001510	Oryctolagus cuniculus Danish White	5359	3 months
-5-39 years	9606	Homo sapiens (human)	5360	5-39 years
-2-3 months	10032	Cricetulus migratorius (gray dwarf hamster)	5361	2-3 months
-26-48 years	9606	Homo sapiens (human)	5362	26-48 years
-28-68 years	9606	Homo sapiens (human)	5363	28-68 years
-25 to 46 years	9606	Homo sapiens (human)	5364	25 to 46 years
-9-12 weeks old	10001470	Mus musculus Factor VIII null	5365	9-12 weeks old
-5-80 years	9606	Homo sapiens (human)	5366	5-80 years
-8-12 weeks old	10000630	Mus musculus NHI Swiss	5367	8-12 weeks old
-10-14 years	9606	Homo sapiens (human)	5368	10-14 years
-3-11 years	9606	Homo sapiens (human)	5369	3-11 years
-10-67 years	9606	Homo sapiens (human)	5370	10-67 years
-13 to 82 years	9606	Homo sapiens (human)	5371	13 to 82 years
-16 to 20 weeks	10000625	Mus musculus MRL	5372	16 to 20 weeks
-40.0±13.7 years	9606	Homo sapiens (human)	5373	40.013.7 years
-14.4±3.8  years	9606	Homo sapiens (human)	5374	14.43.8  years
-29 to 47 years	9606	Homo sapiens (human)	5375	29 to 47 years
-6.1-36.4 years	9606	Homo sapiens (human)	5376	6.1-36.4 years
-18-35 years	9606	Homo sapiens (human)	5377	18-35 years
-12 to 13 years	9606	Homo sapiens (human)	5378	12 to 13 years
-31-49 years	9606	Homo sapiens (human)	5379	31-49 years
-39.88 ± 10.13	9606	Homo sapiens (human)	5380	39.88  10.13
-16-58 years	9606	Homo sapiens (human)	5381	16-58 years
-25 to 77	9606	Homo sapiens (human)	5382	25 to 77
-17-53 years	9606	Homo sapiens (human)	5383	17-53 years
-15-71 years	9606	Homo sapiens (human)	5384	15-71 years
-39.18 ± 6.77	9606	Homo sapiens (human)	5385	39.18  6.77
-6-8 weeks	10001512	Mus musculus C57BL/6 GalNAc Transferase null	5386	6-8 weeks
-4 to 6 weeks	10000667	Rattus norvegicus Sprague-Dawley	5387	4 to 6 weeks
-12 to 78 years	9606	Homo sapiens (human)	5388	12 to 78 years
-62 to 87 years	9606	Homo sapiens (human)	5389	62 to 87 years
-38 to 66 years	9606	Homo sapiens (human)	5390	38 to 66 years
-14 weeks	9823	Sus scrofa (pig)	5391	14 weeks
-27-51 years	9606	Homo sapiens (human)	5392	27-51 years
-67-95 years	9606	Homo sapiens (human)	5393	67-95 years
-12 to 69 years	9606	Homo sapiens (human)	5394	12 to 69 years
-13 to 29 years	9606	Homo sapiens (human)	5395	13 to 29 years
-17-80 years	9606	Homo sapiens (human)	5396	17-80 years
-2-7 months	10000067	Mus musculus C57BL/6	5397	2-7 months
-13-29 years	9606	Homo sapiens (human)	5398	13-29 years
-36-38 years	9606	Homo sapiens (human)	5399	36-38 years
-27.4 ± 16.2 years	9606	Homo sapiens (human)	5400	27.4  16.2 years
-24-83 years	9606	Homo sapiens (human)	5401	24-83 years
-27 years	9544	Macaca mulatta (rhesus macaque)	5402	27 years
-NULL	10000919	Gallus gallus White Leghorn	5403	null
-43-46 years	9606	Homo sapiens (human)	5404	43-46 years
-NULL	10001605	Oryctolagus cuniculus ELCO	5405	null
-NULL	10001664	Rattus norvegicus Albino Oxford	5406	null
-NULL	9555	Papio anubis (Doguera baboon)	5407	null
-4 to 18 years	9606	Homo sapiens (human)	5408	4 to 18 years
-NULL	10001512	Mus musculus C57BL/6 GalNAc Transferase null	5409	null
-7 to 54 years	9606	Homo sapiens (human)	5410	7 to 54 years
-6 to 69 years	9606	Homo sapiens (human)	5411	6 to 69 years
-4 to 45 years	9606	Homo sapiens (human)	5412	4 to 45 years
-77	9606	Homo sapiens (human)	5413	77
-20-22 weeks	10001405	Mus musculus NZB X NZW	5414	20-22 weeks
-9 months	10001405	Mus musculus NZB X NZW	5415	9 months
-16 to 76 years	9606	Homo sapiens (human)	5416	16 to 76 years
-8-12 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5417	8-12 weeks
-44.5-71.5 years	9606	Homo sapiens (human)	5418	44.5-71.5 years
-20 weeks	10001405	Mus musculus NZB X NZW	5419	20 weeks
-5 to 6 years	9598	Pan troglodytes (chimpanzee)	5420	5 to 6 years
-9 months	9940	Ovis aries (domestic sheep)	5421	9 months
-3 to 9 weeks	10000000	Mus musculus BALB/c	5422	3 to 9 weeks
-8-16 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5423	8-16 weeks
-6-12 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5424	6-12 weeks
-24 to 61 years	9606	Homo sapiens (human)	5425	24 to 61 years
-24 hours	10000000	Mus musculus BALB/c	5426	24 hours
-NULL	10001684	Rattus norvegicus WKAH X LEW	5427	null
-7 to 10 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5428	7 to 10 weeks
-8 mo to 35 years	9606	Homo sapiens (human)	5429	8 month to 35 years
-10-12 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5430	10-12 weeks
-4-6 months	9615	Canis lupus familiaris (dogs)	5431	4-6 months
-81 years old	9606	Homo sapiens (human)	5432	81 years old
-7 months to 14 years	9606	Homo sapiens (human)	5433	7 months to 14 years
-NULL	36229	Papio ursinus (baboon)	5434	null
-13-96 years	9606	Homo sapiens (human)	5435	13-96 years
-6-8 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5436	6-8 weeks
-8 to 10 weeks	10000233	Mus musculus CBA/Ca	5437	8 to 10 weeks
-8 to 48 years	9606	Homo sapiens (human)	5438	8 to 48 years
-15-69 years	9606	Homo sapiens (human)	5439	15-69 years
-6 to 28 years	9606	Homo sapiens (human)	5440	6 to 28 years
-8 to 53 years	9606	Homo sapiens (human)	5441	8 to 53 years
-10 to 53 years	9606	Homo sapiens (human)	5442	10 to 53 years
-NULL	10001602	Mus musculus RBF	5443	null
-18-79 years	9606	Homo sapiens (human)	5444	18-79 years
-10-66 yr	9606	Homo sapiens (human)	5445	10-66 year
-24-55 years	9606	Homo sapiens (human)	5446	24-55 years
-3-4 months	10001221	Mus musculus C57BL/6 x SJL	5447	3-4 months
-3 to 4 months	10001532	Mus musculus NZW X BXSB	5448	3 to 4 months
-33 to 61 years	9606	Homo sapiens (human)	5449	33 to 61 years
-4-6 weeks	10000276	Mus musculus B10.S	5450	4-6 weeks
-12-16 weeks old	10000000	Mus musculus BALB/c	5451	12-16 weeks old
-6 weeks	10001487	Mus musculus Apolipoprotein E null	5452	6 weeks
-2 to 3 weeks	9823	Sus scrofa (pig)	5453	2 to 3 weeks
-14 +/- 3 years	10000195	Capra hircus Saanen	5454	14 ± 3 years
-NULL	10001574	Mus musculus C57BL/6 CMAH null	5455	null
->/= 18 years	9606	Homo sapiens (human)	5456	>/= 18 years
-9 months	10001487	Mus musculus Apolipoprotein E null	5457	9 months
-adult	10001605	Oryctolagus cuniculus ELCO	5458	adult
-36 to 75 years	9606	Homo sapiens (human)	5459	36 to 75 years
-62.8 ± 10 years	9606	Homo sapiens (human)	5460	62.8  10 years
-2 months-12 years	9606	Homo sapiens (human)	5461	2 months-12 years
-20-42 years	9606	Homo sapiens (human)	5462	20-42 years
-18-42 years	9606	Homo sapiens (human)	5463	18-42 years
-37 years	10000119	Homo sapiens Caucasian	5464	37 years
-mean = 34 years	9606	Homo sapiens (human)	5465	mean = 34 years
-20-74 years	9606	Homo sapiens (human)	5466	20-74 years
-13 to 79 years	9606	Homo sapiens (human)	5467	13 to 79 years
-< 40 years	9606	Homo sapiens (human)	5468	< 40 years
-19-80 years	9606	Homo sapiens (human)	5469	19-80 years
-80-84 years	10000119	Homo sapiens Caucasian	5470	80-84 years
-21-33 years	9606	Homo sapiens (human)	5471	21-33 years
-69 ± 15 years	9606	Homo sapiens (human)	5472	69  15 years
-60 ± 15 years	9606	Homo sapiens (human)	5473	60  15 years
-37 ± 14 years	9606	Homo sapiens (human)	5474	37  14 years
-11-58 years	9606	Homo sapiens (human)	5475	11-58 years
-35 years mean age	9606	Homo sapiens (human)	5476	35 years mean age
-32-58 years	9606	Homo sapiens (human)	5477	32-58 years
-mean = 71.2 years	9606	Homo sapiens (human)	5478	mean = 71.2 years
-17-84 years	9606	Homo sapiens (human)	5479	17-84 years
-1 to 11 months	10000639	Mus musculus NZB	5480	1 to 11 months
-mean = 65.04 years	9606	Homo sapiens (human)	5481	mean = 65.04 years
-17-31 years	9606	Homo sapiens (human)	5482	17-31 years
-62 ± 12 years	9606	Homo sapiens (human)	5483	62  12 years
-18 to 67 years	9606	Homo sapiens (human)	5484	18 to 67 years
-mean = 72.4 years	9606	Homo sapiens (human)	5485	mean = 72.4 years
-21 to 43 years	9606	Homo sapiens (human)	5486	21 to 43 years
-55 ± 12 years	9606	Homo sapiens (human)	5487	55  12 years
-29-68 years	9606	Homo sapiens (human)	5488	29-68 years
-10-71 years	9606	Homo sapiens (human)	5489	10-71 years
-32 to 72 years	9606	Homo sapiens (human)	5490	32 to 72 years
-38.15 ± 6.5	9606	Homo sapiens (human)	5491	38.15  6.5
-> 20 weeks	10001406	Mus musculus MLR/lpr	5492	> 20 weeks
-14.4±3.8 years	9606	Homo sapiens (human)	5493	14.43.8 years
-6 to 8 weeks	10001405	Mus musculus NZB X NZW	5494	6 to 8 weeks
-34 to 37 years	9606	Homo sapiens (human)	5495	34 to 37 years
-3-4 months	10001532	Mus musculus NZW X BXSB	5496	3-4 months
-17-69 years	9606	Homo sapiens (human)	5497	17-69 years
-25-46 years	9606	Homo sapiens (human)	5498	25-46 years
-6-9 weeks	10001406	Mus musculus MLR/lpr	5499	6-9 weeks
-12-55 years	9606	Homo sapiens (human)	5500	12-55 years
-15-33 years	9606	Homo sapiens (human)	5501	15-33 years
-26 to 52 years	9606	Homo sapiens (human)	5502	26 to 52 years
-17-61 years	9606	Homo sapiens (human)	5503	17-61 years
-20-44 years	9606	Homo sapiens (human)	5504	20-44 years
-18-47 years	9606	Homo sapiens (human)	5505	18-47 years
-22-41	9606	Homo sapiens (human)	5506	22-41
-39 ± 15	9606	Homo sapiens (human)	5507	39  15
-14-62 years	9606	Homo sapiens (human)	5508	14-62 years
-8 weeks	10001406	Mus musculus MLR/lpr	5509	8 weeks
-21 to 47 years	9606	Homo sapiens (human)	5510	21 to 47 years
-21 to 38 years	9606	Homo sapiens (human)	5511	21 to 38 years
-Mean age = 41.7 ± 15.1 years	9606	Homo sapiens (human)	5512	mean age = 41.7  15.1 years
-5 to 10 weeks	10000000	Mus musculus BALB/c	5513	5 to 10 weeks
-17-19 years	9606	Homo sapiens (human)	5514	17-19 years
-<16 years	9606	Homo sapiens (human)	5515	<16 years
-12 to 16 weeks	10001406	Mus musculus MLR/lpr	5516	12 to 16 weeks
-19-52 years	9606	Homo sapiens (human)	5517	19-52 years
-5 to 8 weeks	10001405	Mus musculus NZB X NZW	5518	5 to 8 weeks
-Mean age = 39.8 ± 13.3 years	9606	Homo sapiens (human)	5519	mean age = 39.8  13.3 years
-subadult	10000193	Bos taurus Holstein	5520	subadult
-33.7±4.6 years	9606	Homo sapiens (human)	5521	33.74.6 years
-39 to 51 years	9606	Homo sapiens (human)	5522	39 to 51 years
-19-45 years	9606	Homo sapiens (human)	5523	19-45 years
-12-68 years	9606	Homo sapiens (human)	5524	12-68 years
-31-47 years	9606	Homo sapiens (human)	5525	31-47 years
-26-49 years	9606	Homo sapiens (human)	5526	26-49 years
-42.3 ± 16.4 years	9606	Homo sapiens (human)	5527	42.3  16.4 years
-18 to 41 years	9606	Homo sapiens (human)	5528	18 to 41 years
-33.4±6 years	9606	Homo sapiens (human)	5529	33.46 years
-6 months - 47 years	9606	Homo sapiens (human)	5530	6 months - 47 years
-8 to 12 weeks	10000033	Mus musculus C3H.SW	5531	8 to 12 weeks
-8-79 years	9606	Homo sapiens (human)	5532	8-79 years
-18-39 years	9606	Homo sapiens (human)	5533	18-39 years
-39-67 years	9606	Homo sapiens (human)	5534	39-67 years
-35.5±8.1 years	9606	Homo sapiens (human)	5535	35.58.1 years
-15-82 years	9606	Homo sapiens (human)	5536	15-82 years
-13-69 years	9606	Homo sapiens (human)	5537	13-69 years
-37-44 years	9606	Homo sapiens (human)	5538	37-44 years
-14-76 years	9606	Homo sapiens (human)	5539	14-76 years
-16-94 years	9606	Homo sapiens (human)	5540	16-94 years
-11-60 years	9606	Homo sapiens (human)	5541	11-60 years
-29-44 years	9606	Homo sapiens (human)	5542	29-44 years
-12-53 years	9606	Homo sapiens (human)	5543	12-53 years
-73 years	10000119	Homo sapiens Caucasian	5544	73 years
-37.4-47 years	9606	Homo sapiens (human)	5545	37.4-47 years
-40.7-59.3 years	9606	Homo sapiens (human)	5546	40.7-59.3 years
-8-16 weeks old	10000067	Mus musculus C57BL/6	5547	8-16 weeks old
-6 week old	10000000	Mus musculus BALB/c	5548	6 week old
-NULL	10001532	Mus musculus NZW X BXSB	5549	null
-15-70 years	9606	Homo sapiens (human)	5550	15-70 years
-mean age of 39.9 years	9606	Homo sapiens (human)	5551	mean age of 39.9 years
-20-43 years	9606	Homo sapiens (human)	5552	20-43 years
-13 to 83 years	9606	Homo sapiens (human)	5553	13 to 83 years
-20 to 57 years	9606	Homo sapiens (human)	5554	20 to 57 years
-17-49 years	9606	Homo sapiens (human)	5555	17-49 years
-17-62 years	9606	Homo sapiens (human)	5556	17-62 years
-28-85 years	9606	Homo sapiens (human)	5557	28-85 years
-6 to 12 weeks	10001998	Mus musculus CD1	5558	6 to 12 weeks
-16-85 years	9606	Homo sapiens (human)	5559	16-85 years
-10-12 weeks old	10001575	Mus musculus C57BL/6 alpha1,3GT null	5560	10-12 weeks old
-six weeks	10000000	Mus musculus BALB/c	5561	6 weeks
-45-85 years	9606	Homo sapiens (human)	5562	45-85 years
-27 to 65 years	9606	Homo sapiens (human)	5563	27 to 65 years
-8.5 +/- 3.3 years	9606	Homo sapiens (human)	5564	8.5 ± 3.3 years
-mean age = 38.7 years	9606	Homo sapiens (human)	5565	mean age = 38.7 years
-22-79 years	9606	Homo sapiens (human)	5566	22-79 years
-mean age = 48.94 years	9606	Homo sapiens (human)	5567	mean age = 48.94 years
-19 months	30538	Vicugna pacos (alpaca)	5568	19 months
-7-63 years	9606	Homo sapiens (human)	5569	7-63 years
-adult	9555	Papio anubis (Doguera baboon)	5570	adult
-18 +/- 11 years	9606	Homo sapiens (human)	5571	18 ± 11 years
-46-96 years	9606	Homo sapiens (human)	5572	46-96 years
-48 hours	10001041	Rattus norvegicus Wistar	5573	48 hours
-16-20 weeks	10000625	Mus musculus MRL	5574	16-20 weeks
-12-14 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5575	12-14 weeks
-5 to 64 years	9606	Homo sapiens (human)	5576	5 to 64 years
-4 weeks	10000662	Rattus norvegicus Lewis	5577	4 weeks
-6 to 12 weeks	10000253	Mus musculus A/J	5578	6 to 12 weeks
-2 to 39 years	9606	Homo sapiens (human)	5579	2 to 39 years
-16 to 87 years	9606	Homo sapiens (human)	5580	16 to 87 years
-NULL	7801	Ginglymostoma cirratum (nurse shark)	5581	null
-10 weeks	10001487	Mus musculus Apolipoprotein E null	5582	10 weeks
-5 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5583	5 weeks
-10 weeks	10000655	Mus musculus Swiss Webster	5584	10 weeks
-12 weeks	10000190	Bos taurus Friesian	5585	12 weeks
-29 to 77 years	9606	Homo sapiens (human)	5586	29 to 77 years
-Young	9925	Capra hircus (domestic goat)	5587	young
-3-4 months	10001268	Mus musculus 3xTg-AD	5588	3-4 months
-5-81 years	9606	Homo sapiens (human)	5589	5-81 years
-26-43 years	9606	Homo sapiens (human)	5590	26-43 years
-NULL	10032	Cricetulus migratorius (gray dwarf hamster)	5591	null
-1-10 years	9606	Homo sapiens (human)	5592	1-10 years
-12 months	9913	Bos taurus (bovine)	5593	12 months
-19-62 years	9606	Homo sapiens (human)	5594	19-62 years
-2-3 years	9913	Bos taurus (bovine)	5595	2-3 years
-5-6 weeks	10001446	Rattus norvegicus Wistar Kyoto	5596	5-6 weeks
->65 years	9606	Homo sapiens (human)	5597	>65 years
-2.8 to 4.2	10001584	Sus scrofa alpha1,3GALT null	5598	2.8 to 4.2
-55 to 90 years	10000119	Homo sapiens Caucasian	5599	55 to 90 years
-39-44 years	9606	Homo sapiens (human)	5600	39-44 years
-14 to 65 years	9606	Homo sapiens (human)	5601	14 to 65 years
-29 to 59 years	9606	Homo sapiens (human)	5602	29 to 59 years
-4 weeks	10000625	Mus musculus MRL	5603	4 weeks
-36-66 years	9606	Homo sapiens (human)	5604	36-66 years
-4 to 6 week	10000000	Mus musculus BALB/c	5605	4 to 6 week
-21 to 91 years	9606	Homo sapiens (human)	5606	21 to 91 years
-2 to 58 years	9606	Homo sapiens (human)	5607	2 to 58 years
-4 months	10001406	Mus musculus MLR/lpr	5608	4 months
-5-6 weeks	10000618	Mus musculus ICR	5609	5-6 weeks
-24 to 55 years	9606	Homo sapiens (human)	5610	24 to 55 years
-22 weeks	10000639	Mus musculus NZB	5611	22 weeks
-24 to 87 years	9606	Homo sapiens (human)	5612	24 to 87 years
-12-66 years	9606	Homo sapiens (human)	5613	12-66 years
-Mean age = 58±12 years	9606	Homo sapiens (human)	5614	mean age = 5812 years
-17-56 years	9606	Homo sapiens (human)	5615	17-56 years
-31 to 67 years	9606	Homo sapiens (human)	5616	31 to 67 years
-6 to 8 weeks	10001099	Mus musculus CF-1	5617	6 to 8 weeks
-Adult	9534	Chlorocebus aethiops (African green monkey)	5618	adult
-2-3 years old	9544	Macaca mulatta (rhesus macaque)	5619	2-3 years old
-NULL	9835	Camelid	5620	null
-1.5 month	10001241	Mus musculus APP	5621	1.5 month
-2-3 months	10000218	Mus musculus C57BL/6 X C3H	5622	2-3 months
-8 to 10 weeks	10001601	Mus musculus C57BL/6 X 129	5623	8 to 10 weeks
-7 to 8 weeks	10000017	Mus musculus BALB/c X DBA/2	5624	7 to 8 weeks
-35-43 years	9606	Homo sapiens (human)	5625	35-43 years
-18-67 years	9606	Homo sapiens (human)	5626	18-67 years
-24-49	9606	Homo sapiens (human)	5627	24-49
-6 to 15 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5628	6 to 15 weeks
-40 to 44 years	9606	Homo sapiens (human)	5629	40 to 44 years
-3-5 months	10001575	Mus musculus C57BL/6 alpha1,3GT null	5630	3-5 months
-4 to 60 months	9606	Homo sapiens (human)	5631	4 to 60 months
-8 days	10000220	Mus musculus C57BL/6 X DBA/2	5632	8 days
-19 weeks	10001657	Mus musculus NZW X BALB/c	5633	19 weeks
-60 to 74 years	9606	Homo sapiens (human)	5634	60 to 74 years
-3-5 months	10000067	Mus musculus C57BL/6	5635	3-5 months
-8 to 10 weeks	10001626	Mus musculus beta2m null	5636	8 to 10 weeks
-newborns - 29 years	9606	Homo sapiens (human)	5637	newborns - 29 years
-23 to 82 years	10000119	Homo sapiens Caucasian	5638	23 to 82 years
-1 year 5 months to 15 years 8 months	9606	Homo sapiens (human)	5639	1 year 5 months to 15 years 8 months
-6-8 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5640	6-8 weeks
->24 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5641	>24 weeks
->22 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5642	>22 weeks
-8-20 weeks	10000228	Mus musculus CBA	5643	8-20 weeks
-NULL	10001661	Mus musculus alphaGal IgM H Tg	5644	null
-33 to 60 years	9606	Homo sapiens (human)	5645	33 to 60 years
-16 months	10001240	Mus musculus APPsw	5646	16 months
-12-15 weeks	10001405	Mus musculus NZB X NZW	5647	12-15 weeks
-27-55 years	9606	Homo sapiens (human)	5648	27-55 years
-> 65 years	9606	Homo sapiens (human)	5649	> 65 years
-21-78 years	9606	Homo sapiens (human)	5650	21-78 years
-23-79 years	9606	Homo sapiens (human)	5651	23-79 years
-62	10090	Mus musculus (mouse)	5652	62
-29-56 years	9606	Homo sapiens (human)	5653	29-56 years
-6 days to 7  months	10000639	Mus musculus NZB	5654	6 days to 7  months
-8 weeks	10001041	Rattus norvegicus Wistar	5655	8 weeks
-average= 34.6 years	10000119	Homo sapiens Caucasian	5656	average= 34.6 years
-NULL	9612	Canis lupus (wolf or dog)	5657	null
-average= 53.4  years	10000119	Homo sapiens Caucasian	5658	average= 53.4  years
-average= 56.4  years	10000119	Homo sapiens Caucasian	5659	average= 56.4  years
-8 weeks	9031	Gallus gallus (chicken)	5660	8 weeks
-70 days	10114	Rattus (rat)	5661	70 days
-12-80 years	9606	Homo sapiens (human)	5662	12-80 years
-22 years	10000119	Homo sapiens Caucasian	5663	22 years
-13 years	10000119	Homo sapiens Caucasian	5664	13 years
-5-59 years	9606	Homo sapiens (human)	5665	5-59 years
-17-132 days	9823	Sus scrofa (pig)	5666	17-132 days
-College age	9606	Homo sapiens (human)	5667	college age
-2 months old	10000024	Mus musculus Biozzi	5668	2 months old
-NULL	10001124	Mus musculus Porton	5669	null
-12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	5670	12 weeks
-3 weeks - 6 months	9796	Equus caballus (domestic horse)	5671	3 weeks - 6 months
-5-6 years	9544	Macaca mulatta (rhesus macaque)	5672	5-6 years
-60-90-days-old	10000000	Mus musculus BALB/c	5673	60-90-days-old
-4-5 weeks	10000631	Mus musculus NMRI	5674	4-5 weeks
-31–83 years	9606	Homo sapiens (human)	5675	3183 years
-3-week old	9940	Ovis aries (domestic sheep)	5676	3-week old
-15 weeks old	10000000	Mus musculus BALB/c	5677	15 weeks old
-Adults	34839	Chinchilla lanigera (long-tailed chinchilla)	5678	adults
-3 months to 11 years	9606	Homo sapiens (human)	5679	3 months to 11 years
-8-12 weeks	10000652	Mus musculus STU	5680	8-12 weeks
-0.9 to 3.7 years	10000195	Capra hircus Saanen	5681	0.9 to 3.7 years
-22–59 years	9606	Homo sapiens (human)	5682	2259 years
-4-5 weeks	10000289	Mus musculus BALB.B	5683	4-5 weeks
-4-5 weeks	10000028	Mus musculus C3H	5684	4-5 weeks
-6 months	9606	Homo sapiens (human)	5685	6 months
-22–59	9606	Homo sapiens (human)	5686	2259
-> 18 years old	9606	Homo sapiens (human)	5687	> 18 years old
-6 weeks	10000017	Mus musculus BALB/c X DBA/2	5688	6 weeks
-22-70 years	9606	Homo sapiens (human)	5689	22-70 years
-8 weeks	10000652	Mus musculus STU	5690	8 weeks
-4-115 months	9606	Homo sapiens (human)	5691	4-115 months
-46-79 years	9606	Homo sapiens (human)	5692	46-79 years
-4-5 weeks	10001537	Mus musculus PL	5693	4-5 weeks
-5 weeks	10000038	Mus musculus C3H/He	5694	5 weeks
-NULL	10001333	Rattus norvegicus LEW.1N	5695	null
-NULL	10001337	Rattus norvegicus LEWIS.1W	5696	null
-4-5 months	10000000	Mus musculus BALB/c	5697	4-5 months
-3 weeks	10000919	Gallus gallus White Leghorn	5698	3 weeks
-1-35 years	9606	Homo sapiens (human)	5699	1-35 years
-8-10 weeks	10000638	Mus musculus Nude	5700	8-10 weeks
-NULL	10000921	Gallus gallus Cobb 500	5701	null
-7 to 8 weeks	10000642	Mus musculus Outbred	5702	7 to 8 weeks
-10-20 weeks	10114	Rattus (rat)	5703	10-20 weeks
-adult, >32 years	9606	Homo sapiens (human)	5704	adult, >32 years
-7 to 11 years	9544	Macaca mulatta (rhesus macaque)	5705	7 to 11 years
-8-13 years	9606	Homo sapiens (human)	5706	8-13 years
-NULL	8187	Lates calcarifer (Asian seabass)	5707	null
-11-72 years	9606	Homo sapiens (human)	5708	11-72 years
-NULL	10001332	Rattus norvegicus LEW.1AV1	5709	null
-median 4 years	9606	Homo sapiens (human)	5710	median 4 years
-8-15 weeks old	10000000	Mus musculus BALB/c	5711	8-15 weeks old
-8-12 weeks	10000281	Mus musculus B10.WB	5712	8-12 weeks
-3-15 years old	9606	Homo sapiens (human)	5713	3-15 years old
-Young	9823	Sus scrofa (pig)	5714	young
-6 weeks	10000630	Mus musculus NHI Swiss	5715	6 weeks
-6-9 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	5716	6-9 weeks
-40 to 50 days	10000662	Rattus norvegicus Lewis	5717	40 to 50 days
-50-85 years	9606	Homo sapiens (human)	5718	50-85 years
-8-14 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5719	8-14 weeks
-0.1-11 years	9606	Homo sapiens (human)	5720	0.1-11 years
-8.9-13.8 years	9615	Canis lupus familiaris (dogs)	5721	8.9-13.8 years
-Foals	9796	Equus caballus (domestic horse)	5722	foals
-40-75 years	9606	Homo sapiens (human)	5723	40-75 years
-5 to 26	9606	Homo sapiens (human)	5724	5 to 26
-9-81 years	9606	Homo sapiens (human)	5725	9-81 years
-48.6 +/- 13.5 years	9606	Homo sapiens (human)	5726	48.6 ± 13.5 years
-NULL	38020	marmosets	5727	null
-3-4 months	10000653	Mus musculus Swiss	5728	3-4 months
-2 years	9615	Canis lupus familiaris (dogs)	5729	2 years
-NULL	10001442	Rattus norvegicus Copenhagen	5730	null
-1-40 years	9606	Homo sapiens (human)	5731	1-40 years
-18 month old	10000191	Bos taurus Hereford	5732	18 month old
-37-43 years	9606	Homo sapiens (human)	5733	37-43 years
-14 weeks	10000000	Mus musculus BALB/c	5734	14 weeks
-44-86 years	9606	Homo sapiens (human)	5735	44-86 years
-14	9606	Homo sapiens (human)	5736	14
-4 to 6 weeks old	10001998	Mus musculus CD1	5737	4 to 6 weeks old
-38 weeks	10000000	Mus musculus BALB/c	5738	38 weeks
-10-39 years	9606	Homo sapiens (human)	5739	10-39 years
-20-30 years	9606	Homo sapiens (human)	5740	20-30 years
-6-8 weeks	10001241	Mus musculus APP	5741	6-8 weeks
-3-4 weeks	10001247	Oryctolagus cuniculus Dutch Half Lop	5742	3-4 weeks
-NULL	10000006	Mus musculus BALB/c GalNAc Transferase null	5743	null
-34-70 years	9606	Homo sapiens (human)	5744	34-70 years
-6 to 8 week	10000054	Mus musculus DBA/1	5745	6 to 8 week
-26-30 weeks	10000635	Mus musculus NOD/Lt	5746	26-30 weeks
-1-31 years	9606	Homo sapiens (human)	5747	1-31 years
-NULL	10001249	Mus musculus B10.A x BALB/c	5748	null
-7-14 months	10001240	Mus musculus APPsw	5749	7-14 months
-30 days	9823	Sus scrofa (pig)	5750	30 days
-55-89 years	9606	Homo sapiens (human)	5751	55-89 years
-0-84 years	9606	Homo sapiens (human)	5752	0-84 years
-9-10 months	10001240	Mus musculus APPsw	5753	9-10 months
-6-8 weeks	10000639	Mus musculus NZB	5754	6-8 weeks
-3 weeks-15 years	9606	Homo sapiens (human)	5755	3 weeks-15 years
-8 weeks	10001240	Mus musculus APPsw	5756	8 weeks
-5-7 weeks	10000635	Mus musculus NOD/Lt	5757	5-7 weeks
-Mean=8.4 ± 4.3	9606	Homo sapiens (human)	5758	mean=8.4  4.3
-24-33 years	9606	Homo sapiens (human)	5759	24-33 years
-7-58 years	9606	Homo sapiens (human)	5760	7-58 years
-26-67 yrs	9606	Homo sapiens (human)	5761	26-67 years
-4-35 years	9606	Homo sapiens (human)	5762	4-35 years
-12-13 months	10001241	Mus musculus APP	5763	12-13 months
-8 to 10 weeks old	10000000	Mus musculus BALB/c	5764	8 to 10 weeks old
-65 days	9606	Homo sapiens (human)	5765	65 days
-2 months	10001241	Mus musculus APP	5766	2 months
-5-8 years	9544	Macaca mulatta (rhesus macaque)	5767	5-8 years
-NULL	135760	Maccullochella macquariensis (trout cod)	5768	null
-2 months	10001240	Mus musculus APPsw	5769	2 months
-12 weeks	10000015	Mus musculus BALB/c X C3H	5770	12 weeks
-30 to 67	9606	Homo sapiens (human)	5771	30 to 67
-6-11 months	10001240	Mus musculus APPsw	5772	6-11 months
-6 months - 9 years	9606	Homo sapiens (human)	5773	6 months - 9 years
-6 to 84	9606	Homo sapiens (human)	5774	6 to 84
-5 weeks	10000108	Mus musculus C57BL/6 X B10.D2	5775	5 weeks
-39-59 years old	9606	Homo sapiens (human)	5776	39-59 years old
-16 months	10001241	Mus musculus APP	5777	16 months
-32 to 78	9606	Homo sapiens (human)	5778	32 to 78
-6-22.8 years	9606	Homo sapiens (human)	5779	6-22.8 years
-2-50 years	9606	Homo sapiens (human)	5780	2-50 years
-6-22.8	9606	Homo sapiens (human)	5781	6-22.8
->69 years	9606	Homo sapiens (human)	5782	>69 years
-33-88 years	9606	Homo sapiens (human)	5783	33-88 years
-8.6-22.8 years	9606	Homo sapiens (human)	5784	8.6-22.8 years
-18 months	10001268	Mus musculus 3xTg-AD	5785	18 months
-49.3-69.9 years	9606	Homo sapiens (human)	5786	49.3-69.9 years
-2 months	10001286	Mus musculus APPswe/PSEN1	5787	2 months
-9-10 months	10001278	Mus musculus APP751	5788	9-10 months
-4.5-26 years	9606	Homo sapiens (human)	5789	4.5-26 years
-8-16 weeks	10001309	Mus musculus hTNF Tg	5790	8-16 weeks
-adults, >32 years	9606	Homo sapiens (human)	5791	adults, >32 years
-19.8 to 38.8	9606	Homo sapiens (human)	5792	19.8 to 38.8
-15-77 years	9606	Homo sapiens (human)	5793	15-77 years
-elderly > 70 years	9606	Homo sapiens (human)	5794	elderly > 70 years
-27-74 years	9606	Homo sapiens (human)	5795	27-74 years
-14 days	10000187	Sus scrofa Landrace X Large White	5796	14 days
-3 months to 64 years	9606	Homo sapiens (human)	5797	3 months to 64 years
-8 to 12 weeks old	10000064	Mus musculus C57BL/10.Q	5798	8 to 12 weeks old
-16-72 years	9606	Homo sapiens (human)	5799	16-72 years
-8 months	9838	Camelus dromedarius (camel)	5800	8 months
-18-78 years	9606	Homo sapiens (human)	5801	18-78 years
-6 weeks	10000638	Mus musculus Nude	5802	6 weeks
-56.3 years	9606	Homo sapiens (human)	5803	56.3 years
-7 months - 9 years	9606	Homo sapiens (human)	5804	7 months - 9 years
-12-week-old	10000000	Mus musculus BALB/c	5805	12-week-old
-3 months to 2 years	9606	Homo sapiens (human)	5806	3 months to 2 years
-6 to 8 months	10000000	Mus musculus BALB/c	5807	6 to 8 months
-19-49	9606	Homo sapiens (human)	5808	19-49
-6-57 years	9606	Homo sapiens (human)	5809	6-57 years
-18-53	9606	Homo sapiens (human)	5810	18-53
-NULL	10026	Cricetinae (hamsters)	5811	null
-1 to 3 years	9606	Homo sapiens (human)	5812	1 to 3 years
-16-54 years	9606	Homo sapiens (human)	5813	16-54 years
-5 months	9031	Gallus gallus (chicken)	5814	5 months
-17-81	9606	Homo sapiens (human)	5815	17-81
-6 to 8 weeks	10001314	Mus musculus HPV 16 E7 Tg	5816	6 to 8 weeks
-7–8 weeks	10000658	Rattus norvegicus Brown Norway	5817	78 weeks
-7–8 weeks	10001041	Rattus norvegicus Wistar	5818	78 weeks
-20-82	9606	Homo sapiens (human)	5819	20-82
-3 months	10001286	Mus musculus APPswe/PSEN1	5820	3 months
-8 to 24 weeks	10000000	Mus musculus BALB/c	5821	8 to 24 weeks
-10-75 years	9606	Homo sapiens (human)	5822	10-75 years
-4 to 8 weeks	10000000	Mus musculus BALB/c	5823	4 to 8 weeks
-4 to 8 weeks	10001998	Mus musculus CD1	5824	4 to 8 weeks
-8-12 months	9913	Bos taurus (bovine)	5825	8-12 months
-NULL	10000629	Mus musculus ND4 Swiss Webster	5826	null
-6 to 8 weeks	10000061	Mus musculus FVB	5827	6 to 8 weeks
-10-week-old	10000000	Mus musculus BALB/c	5828	10-week-old
-26 to 52 weeks	10001314	Mus musculus HPV 16 E7 Tg	5829	26 to 52 weeks
-8-12 weeks	10000013	Mus musculus BALB/c X A/J	5830	8-12 weeks
-19-43	9606	Homo sapiens (human)	5831	19-43
-14 to 41 years	9606	Homo sapiens (human)	5832	14 to 41 years
-6-8 weeks	10001537	Mus musculus PL	5833	6-8 weeks
-2.5-16 years	9606	Homo sapiens (human)	5834	2.5-16 years
-6-10 weeks	9544	Macaca mulatta (rhesus macaque)	5835	6-10 weeks
-4 months-30 years	9606	Homo sapiens (human)	5836	4 months-30 years
-3 months	10001272	Cavia porcellus Strain 2	5837	3 months
-3 months	10001274	Cavia porcellus Strain (2 X 13)	5838	3 months
-16-44 years	9606	Homo sapiens (human)	5839	16-44 years
-4 months-15 years	9606	Homo sapiens (human)	5840	4 months-15 years
-21-86 years	9606	Homo sapiens (human)	5841	21-86 years
-33-66 years old	9606	Homo sapiens (human)	5842	33-66 years old
-27 to 45 years	9606	Homo sapiens (human)	5843	27 to 45 years
-21-47 years	9606	Homo sapiens (human)	5844	21-47 years
-6-8 weeks	9986	Oryctolagus cuniculus (rabbit)	5845	6-8 weeks
-36-43 days	10000667	Rattus norvegicus Sprague-Dawley	5846	36-43 days
-30-89 years old	9606	Homo sapiens (human)	5847	30-89 years old
-18-47 years old	9606	Homo sapiens (human)	5848	18-47 years old
-6-9 months	10001405	Mus musculus NZB X NZW	5849	6-9 months
-11 weeks	10000206	Oryctolagus cuniculus New Zealand White	5850	11 weeks
-5 weeks	10000667	Rattus norvegicus Sprague-Dawley	5851	5 weeks
-11 months	10001279	Mus musculus APP Tg-SwDI	5852	11 months
-4-18 years	9606	Homo sapiens (human)	5853	4-18 years
-8-12 weeks	10000028	Mus musculus C3H	5854	8-12 weeks
-2-54 years-old	9606	Homo sapiens (human)	5855	2-54 years-old
-5-11 years	9606	Homo sapiens (human)	5856	5-11 years
-32-60	9606	Homo sapiens (human)	5857	32-60
-9-10 weeks	10000054	Mus musculus DBA/1	5858	9-10 weeks
-8-12 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5859	8-12 weeks
-5-49 years	9606	Homo sapiens (human)	5860	5-49 years
-3-4 months	10001019	Mus musculus B10.D2	5861	3-4 months
-8 weeks	10116	Rattus norvegicus (brown rat)	5862	8 weeks
-3-4 months	10000228	Mus musculus CBA	5863	3-4 months
-NULL	10001296	Mus musculus A.SW/SN	5864	null
-8-14 weeks	10000228	Mus musculus CBA	5865	8-14 weeks
-46-70 years	9606	Homo sapiens (human)	5866	46-70 years
-49-56 years	9606	Homo sapiens (human)	5867	49-56 years
-28 to 57 years	9606	Homo sapiens (human)	5868	28 to 57 years
-3-4 months	10001241	Mus musculus APP	5869	3-4 months
-4-6 weeks	10116	Rattus norvegicus (brown rat)	5870	4-6 weeks
-2 months old	10000206	Oryctolagus cuniculus New Zealand White	5871	2 months old
-13-72 years	9606	Homo sapiens (human)	5872	13-72 years
-8 to 12 weeks old	10000000	Mus musculus BALB/c	5873	8 to 12 weeks old
-8 weeks old	10000054	Mus musculus DBA/1	5874	8 weeks old
-12-16 weeks	10000054	Mus musculus DBA/1	5875	12-16 weeks
-6.5 to 11 years	9606	Homo sapiens (human)	5876	6.5 to 11 years
-6-8 weeks	10001395	Mus musculus BUB/Bn	5877	6-8 weeks
-4 to 6 weeks	10001041	Rattus norvegicus Wistar	5878	4 to 6 weeks
-54-74 years	9606	Homo sapiens (human)	5879	54-74 years
-mean age 45 years	9606	Homo sapiens (human)	5880	mean age 45 years
-3.5 months	10001279	Mus musculus APP Tg-SwDI	5881	3.5 months
-11-15 months	10001279	Mus musculus APP Tg-SwDI	5882	11-15 months
-10 months	10090	Mus musculus (mouse)	5883	10 months
-0.3-56 years	9606	Homo sapiens (human)	5884	0.3-56 years
-0.5-36 years	9606	Homo sapiens (human)	5885	0.5-36 years
-46-66 years	9606	Homo sapiens (human)	5886	46-66 years
-NULL	10001279	Mus musculus APP Tg-SwDI	5887	null
-0.3-45 years	9606	Homo sapiens (human)	5888	0.3-45 years
-18-87 years	9606	Homo sapiens (human)	5889	18-87 years
-mean age 59.8 years	9606	Homo sapiens (human)	5890	mean age 59.8 years
-2-12 years	9606	Homo sapiens (human)	5891	2-12 years
-14-64 years	9606	Homo sapiens (human)	5892	14-64 years
-21-74 years	9606	Homo sapiens (human)	5893	21-74 years
-32-46 years	9606	Homo sapiens (human)	5894	32-46 years
-6 to 8 weeks	10000255	Mus musculus AKR	5895	6 to 8 weeks
-5 to 6 weeks	10001406	Mus musculus MLR/lpr	5896	5 to 6 weeks
-Adult	9031	Gallus gallus (chicken)	5897	adult
-6-8 weeks	10000600	Mus musculus HLA-DR Transgenic	5898	6-8 weeks
-7 to 12 weeks	10000662	Rattus norvegicus Lewis	5899	7 to 12 weeks
-21-77 years old	9606	Homo sapiens (human)	5900	21-77 years old
-8-12 weeks	10000023	Mus musculus BDF1	5901	8-12 weeks
-2 months	10000625	Mus musculus MRL	5902	2 months
-18-37 years	9606	Homo sapiens (human)	5903	18-37 years
-15-83 years	9606	Homo sapiens (human)	5904	15-83 years
-10-98 years	9606	Homo sapiens (human)	5905	10-98 years
-15 to 71 years	9606	Homo sapiens (human)	5906	15 to 71 years
-19-56 years	9606	Homo sapiens (human)	5907	19-56 years
-18 months	9940	Ovis aries (domestic sheep)	5908	18 months
-6 to 8 weeks	10001537	Mus musculus PL	5909	6 to 8 weeks
-14-42 years	9606	Homo sapiens (human)	5910	14-42 years
-NULL	10001507	Rattus norvegicus BioBreeding	5911	null
-2 months	10001268	Mus musculus 3xTg-AD	5912	2 months
-16 to 72 years	9606	Homo sapiens (human)	5913	16 to 72 years
-13-59 years	9606	Homo sapiens (human)	5914	13-59 years
-36-38 weeks	10001405	Mus musculus NZB X NZW	5915	36-38 weeks
-36-38 weeks	10000000	Mus musculus BALB/c	5916	36-38 weeks
-7-month-old	10001406	Mus musculus MLR/lpr	5917	7-month-old
-6-8 weeks	10001406	Mus musculus MLR/lpr	5918	6-8 weeks
-5 months	10001406	Mus musculus MLR/lpr	5919	5 months
-21, 27 and 36 weeks	10001405	Mus musculus NZB X NZW	5920	21, 27 and 36 weeks
-10 to 12 weeks	10000625	Mus musculus MRL	5921	10 to 12 weeks
-52-84 years	9606	Homo sapiens (human)	5922	52-84 years
-22-72 years	9606	Homo sapiens (human)	5923	22-72 years
-45 days	10001041	Rattus norvegicus Wistar	5924	45 days
-6-10 weeks	10001406	Mus musculus MLR/lpr	5925	6-10 weeks
-6 to 8 weeks	10000625	Mus musculus MRL	5926	6 to 8 weeks
-17 months	10000625	Mus musculus MRL	5927	17 months
-12-20 weeks	10001406	Mus musculus MLR/lpr	5928	12-20 weeks
-12 - 20 weeks	10001406	Mus musculus MLR/lpr	5929	12 - 20 weeks
-14-22 weeks	10001406	Mus musculus MLR/lpr	5930	14-22 weeks
-50 to 68	9606	Homo sapiens (human)	5931	50 to 68
-Within 1 week after birth	9606	Homo sapiens (human)	5932	within 1 week after birth
-17-58 years	9606	Homo sapiens (human)	5933	17-58 years
-49-71 years	9606	Homo sapiens (human)	5934	49-71 years
-47-62 years	9606	Homo sapiens (human)	5935	47-62 years
-14-67 years	9606	Homo sapiens (human)	5936	14-67 years
-50-74 years	9606	Homo sapiens (human)	5937	50-74 years
-0.3-5.7 years	9606	Homo sapiens (human)	5938	0.3-5.7 years
-10-12 weeks	10000625	Mus musculus MRL	5939	10-12 weeks
-16-17 years	9606	Homo sapiens (human)	5940	16-17 years
-10-12 weeks	10001406	Mus musculus MLR/lpr	5941	10-12 weeks
-6 weeks	10001133	Rattus norvegicus DA	5942	6 weeks
-15-73 years	9606	Homo sapiens (human)	5943	15-73 years
-26-47 years	9606	Homo sapiens (human)	5944	26-47 years
-32 to 66 years	9606	Homo sapiens (human)	5945	32 to 66 years
-48-51	9606	Homo sapiens (human)	5946	48-51
-40.8-69.4 years	9606	Homo sapiens (human)	5947	40.8-69.4 years
-21 days	10001427	Mus musculus viable motheaten	5948	21 days
-Young adult	10000000	Mus musculus BALB/c	5949	young adult
-23-66 years old	9606	Homo sapiens (human)	5950	23-66 years old
-6-62 years-old	9606	Homo sapiens (human)	5951	6-62 years-old
-13-68	9606	Homo sapiens (human)	5952	13-68
-12-20 weeks	9986	Oryctolagus cuniculus (rabbit)	5953	12-20 weeks
-12-18 months	10000194	Bos taurus Holstein-Friesian	5954	12-18 months
-23-38 years	9606	Homo sapiens (human)	5955	23-38 years
-4-6 months	9534	Chlorocebus aethiops (African green monkey)	5956	4-6 months
-7 weeks	10000618	Mus musculus ICR	5957	7 weeks
-21-57 years	9606	Homo sapiens (human)	5958	21-57 years
-7 months old	10000206	Oryctolagus cuniculus New Zealand White	5959	7 months old
-68 to 77 years	9606	Homo sapiens (human)	5960	68 to 77 years
-16 to 65 years	9606	Homo sapiens (human)	5961	16 to 65 years
-6-7 months	10001405	Mus musculus NZB X NZW	5962	6-7 months
-22-80 years	9606	Homo sapiens (human)	5963	22-80 years
-23.6-53.8	9606	Homo sapiens (human)	5964	23.6-53.8
-21-49 years	9606	Homo sapiens (human)	5965	21-49 years
->10 weeks	10000662	Rattus norvegicus Lewis	5966	>10 weeks
-5 months	10000662	Rattus norvegicus Lewis	5967	5 months
-28-70 years	9606	Homo sapiens (human)	5968	28-70 years
-40.6 +/- 11.4 years	9606	Homo sapiens (human)	5969	40.6 ± 11.4 years
-Adult	10000660	Rattus norvegicus Fischer	5970	adult
-Adult	10000658	Rattus norvegicus Brown Norway	5971	adult
-12-18 weeks	10000067	Mus musculus C57BL/6	5972	12-18 weeks
-under 7 years	9606	Homo sapiens (human)	5973	under 7 years
-NULL	9548	Macaca radiata (bonnet macaque)	5974	null
-66 to 70 years	9606	Homo sapiens (human)	5975	66 to 70 years
-14 to 45	9606	Homo sapiens (human)	5976	14 to 45
-7 to 9 weeks	10000000	Mus musculus BALB/c	5977	7 to 9 weeks
-24 to 35 years	9606	Homo sapiens (human)	5978	24 to 35 years
-6 months	10001247	Oryctolagus cuniculus Dutch Half Lop	5979	6 months
-calves	10000193	Bos taurus Holstein	5980	calves
-Steer	10000193	Bos taurus Holstein	5981	steer
-33 to 53 years	9606	Homo sapiens (human)	5982	33 to 53 years
-4-6 months	10000206	Oryctolagus cuniculus New Zealand White	5983	4-6 months
-26 to 37 years	9606	Homo sapiens (human)	5984	26 to 37 years
-28–36 years	9606	Homo sapiens (human)	5985	2836 years
-24 weeks	10000662	Rattus norvegicus Lewis	5986	24 weeks
-3 months	10000204	Oryctolagus cuniculus Japanese white	5987	3 months
-6 weeks	10000631	Mus musculus NMRI	5988	6 weeks
-20 weeks	10000662	Rattus norvegicus Lewis	5989	20 weeks
-adult	9337	Trichosurus vulpecula (common brush-tailed possum)	5990	adult
-5 years	9606	Homo sapiens (human)	5991	5 years
-8 to 10 weeks	10000062	Mus musculus FVB/J	5992	8 to 10 weeks
-7-13 years	9606	Homo sapiens (human)	5993	7-13 years
-53-75 years	9606	Homo sapiens (human)	5994	53-75 years
-59-100 years	9606	Homo sapiens (human)	5995	59-100 years
-49-57 years	9606	Homo sapiens (human)	5996	49-57 years
-adult	9986	Oryctolagus cuniculus (rabbit)	5997	adult
-5-13 years	9606	Homo sapiens (human)	5998	5-13 years
-17-57 years	9606	Homo sapiens (human)	5999	17-57 years
-16-24 years	9534	Chlorocebus aethiops (African green monkey)	6000	16-24 years
-6-12 months	10001241	Mus musculus APP	6001	6-12 months
-30 to 77 years	9606	Homo sapiens (human)	6002	30 to 77 years
-13 years	9548	Macaca radiata (bonnet macaque)	6003	13 years
-5-6 months	9986	Oryctolagus cuniculus (rabbit)	6004	5-6 months
-26-84 years	9606	Homo sapiens (human)	6005	26-84 years
-5 to 6 weeks	10000019	Mus musculus BALB/cByJ	6006	5 to 6 weeks
-17 to 82 years	9606	Homo sapiens (human)	6007	17 to 82 years
-59-84 years old	9606	Homo sapiens (human)	6008	59-84 years old
-37-69 years	9606	Homo sapiens (human)	6009	37-69 years
-7 months	10000206	Oryctolagus cuniculus New Zealand White	6010	7 months
-26-61 years	9606	Homo sapiens (human)	6011	26-61 years
-6 to 8 weeks	10000055	Mus musculus DBA/2	6012	6 to 8 weeks
-75.9 +/- 7.5 years	9606	Homo sapiens (human)	6013	75.9 ± 7.5 years
-5-17 years	9606	Homo sapiens (human)	6014	5-17 years
-Elderly	9606	Homo sapiens (human)	6015	elderly
-3.1-18 years	9606	Homo sapiens (human)	6016	3.1-18 years
-19-55 years	9606	Homo sapiens (human)	6017	19-55 years
-14-79 years	9606	Homo sapiens (human)	6018	14-79 years
-17 months	10000627	Mus musculus MRL/MpJ	6019	17 months
-5 to 7 years	9548	Macaca radiata (bonnet macaque)	6020	5 to 7 years
-1-38 years	9606	Homo sapiens (human)	6021	1-38 years
-5 to 6 weeks	10001998	Mus musculus CD1	6022	5 to 6 weeks
-10 weeks	9823	Sus scrofa (pig)	6023	10 weeks
-38-68 years	9606	Homo sapiens (human)	6024	38-68 years
-27-47 years	9606	Homo sapiens (human)	6025	27-47 years
-31and 73 years	9606	Homo sapiens (human)	6026	31and 73 years
-32 to 97 years	9606	Homo sapiens (human)	6027	32 to 97 years
-6 to 8 weeks	10000638	Mus musculus Nude	6028	6 to 8 weeks
-33 to 81 years	9606	Homo sapiens (human)	6029	33 to 81 years
-29 to 75 years	9606	Homo sapiens (human)	6030	29 to 75 years
-49-66 years	9606	Homo sapiens (human)	6031	49-66 years
-adult	10001211	Mus musculus (C57BL/6 X A/J)	6032	adult
-11 to 82	9606	Homo sapiens (human)	6033	11 to 82
-7-30 years	9606	Homo sapiens (human)	6034	7-30 years
-17 to 84 years	9606	Homo sapiens (human)	6035	17 to 84 years
-17 to 84	9606	Homo sapiens (human)	6036	17 to 84
-38-72 years	9606	Homo sapiens (human)	6037	38-72 years
-6 to 10 weeks	10000236	Mus musculus CBA/J	6038	6 to 10 weeks
-6 to 10 weeks	10000206	Oryctolagus cuniculus New Zealand White	6039	6 to 10 weeks
-10-14 weeks	10001332	Rattus norvegicus LEW.1AV1	6040	10-14 weeks
-20 to 75	9606	Homo sapiens (human)	6041	20 to 75
-54-71 years	9606	Homo sapiens (human)	6042	54-71 years
-30-82 years old	9606	Homo sapiens (human)	6043	30-82 years old
-15 to 78 years	9606	Homo sapiens (human)	6044	15 to 78 years
-NULL	9337	Trichosurus vulpecula (common brush-tailed possum)	6045	null
-Less than 20 years	9606	Homo sapiens (human)	6046	less than 20 years
-mature	9554	Papio (baboon)	6047	mature
-NULL	10001354	Mus musculus SJL X BALB/c	6048	null
-20-95 years old	9606	Homo sapiens (human)	6049	20-95 years old
-18–73	9606	Homo sapiens (human)	6050	1873
-17-74 years	9606	Homo sapiens (human)	6051	17-74 years
-middle aged	9606	Homo sapiens (human)	6052	middle aged
-38-73	9606	Homo sapiens (human)	6053	38-73
-2-14 years	9606	Homo sapiens (human)	6054	2-14 years
-NULL	9493	Cebuella pygmaea (pygmy marmoset)	6055	null
-2 and 6 years	9615	Canis lupus familiaris (dogs)	6056	2 and 6 years
-40 to 66 years	9606	Homo sapiens (human)	6057	40 to 66 years
-43 to 83 years	9606	Homo sapiens (human)	6058	43 to 83 years
-23-47 years	9606	Homo sapiens (human)	6059	23-47 years
-8 to 10 weeks	10001471	Mus musculus NOD.Idd3/5	6060	8 to 10 weeks
-21-90 years old	9606	Homo sapiens (human)	6061	21-90 years old
-63 years	10000119	Homo sapiens Caucasian	6062	63 years
-NULL	10001473	Mus musculus 1H3.1 TCR Tg	6063	null
-21 months-45 years	9606	Homo sapiens (human)	6064	21 months-45 years
-19 to 79 years	9606	Homo sapiens (human)	6065	19 to 79 years
-16-66 years	9606	Homo sapiens (human)	6066	16-66 years
-22 to 55 years	9606	Homo sapiens (human)	6067	22 to 55 years
-Median age 33 years	9606	Homo sapiens (human)	6068	median age 33 years
-NULL	10000639	Mus musculus NZB	6069	null
-49-76 years	9606	Homo sapiens (human)	6070	49-76 years
-32-79 years	9606	Homo sapiens (human)	6071	32-79 years
-54 to 70 years	9606	Homo sapiens (human)	6072	54 to 70 years
-25-75 years	9606	Homo sapiens (human)	6073	25-75 years
-40-84 years	9606	Homo sapiens (human)	6074	40-84 years
-19-75 years	9606	Homo sapiens (human)	6075	19-75 years
-34-61 years old	9606	Homo sapiens (human)	6076	34-61 years old
-37 to 78 years	9606	Homo sapiens (human)	6077	37 to 78 years
-30-63 years	9606	Homo sapiens (human)	6078	30-63 years
-8-9 weeks	10001427	Mus musculus viable motheaten	6079	8-9 weeks
-29-71 years	9606	Homo sapiens (human)	6080	29-71 years
-average age = 12.32 years	9606	Homo sapiens (human)	6081	average age = 12.32 years
-7 month	9940	Ovis aries (domestic sheep)	6082	7 month
-35-70 years	9606	Homo sapiens (human)	6083	35-70 years
-5 to 6 weeks	10000655	Mus musculus Swiss Webster	6084	5 to 6 weeks
-18-35	9606	Homo sapiens (human)	6085	18-35
-6-14 years	9606	Homo sapiens (human)	6086	6-14 years
-adult	10001099	Mus musculus CF-1	6087	adult
-18 months	9913	Bos taurus (bovine)	6088	18 months
-mean age = 30.4 years	9606	Homo sapiens (human)	6089	mean age = 30.4 years
-2-19 years	9606	Homo sapiens (human)	6090	2-19 years
-8-31 weeks	9823	Sus scrofa (pig)	6091	8-31 weeks
-3-4 months	10000000	Mus musculus BALB/c	6092	3-4 months
-19-83 years	9606	Homo sapiens (human)	6093	19-83 years
-11-12 weeks	10000000	Mus musculus BALB/c	6094	11-12 weeks
-0.8-18.7 years	9606	Homo sapiens (human)	6095	0.8-18.7 years
-52.7 +/- 10 years	9606	Homo sapiens (human)	6096	52.7 ± 10 years
-32-72 years	9606	Homo sapiens (human)	6097	32-72 years
-48 +/- 12 years	9606	Homo sapiens (human)	6098	48 ± 12 years
-24-54 years	9606	Homo sapiens (human)	6099	24-54 years
-2-11 years	9606	Homo sapiens (human)	6100	2-11 years
-2.5-22 years	9606	Homo sapiens (human)	6101	2.5-22 years
-6 to 8 weeks	10000642	Mus musculus Outbred	6102	6 to 8 weeks
-22 to 31 years	9606	Homo sapiens (human)	6103	22 to 31 years
-23-71 years	9606	Homo sapiens (human)	6104	23-71 years
-66.6 +/- 7.4 years	9606	Homo sapiens (human)	6105	66.6 ± 7.4 years
-18-63 years	9606	Homo sapiens (human)	6106	18-63 years
-6-8 weeks	10001041	Rattus norvegicus Wistar	6107	6-8 weeks
-14-68 years	9606	Homo sapiens (human)	6108	14-68 years
-15-86 years	9606	Homo sapiens (human)	6109	15-86 years
-> 12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6110	> 12 weeks
-8 to 12 weeks	10001283	Mus musculus BALB/c X B10.Q	6111	8 to 12 weeks
-9 to 12 weeks	10001470	Mus musculus Factor VIII null	6112	9 to 12 weeks
-> 1.5 years	9483	Callithrix jacchus (common marmoset)	6113	> 1.5 years
-> 4 years	9544	Macaca mulatta (rhesus macaque)	6114	> 4 years
-21 to 86 years	9606	Homo sapiens (human)	6115	21 to 86 years
-3 to 14 years	9606	Homo sapiens (human)	6116	3 to 14 years
-20-59 years	9606	Homo sapiens (human)	6117	20-59 years
-31.63 +/- 1.37 years	9606	Homo sapiens (human)	6118	31.63 ± 1.37 years
-36.1 years (mean)	9606	Homo sapiens (human)	6119	36.1 years (mean)
-55 ± 27 years	9606	Homo sapiens (human)	6120	55  27 years
-24.92 +/- 0.84	9606	Homo sapiens (human)	6121	24.92 ± 0.84
-NULL	10001717	Mus musculus A.TH	6122	null
-8- to 10-week-old	10000000	Mus musculus BALB/c	6123	8- to 10-week-old
-3 years	9606	Homo sapiens (human)	6124	3 years
-<6 months	10000000	Mus musculus BALB/c	6125	<6 months
-NULL	10001719	Mesocricetus auratus LVG	6126	null
-5 weeks.	10090	Mus musculus (mouse)	6127	5 weeks.
-mean age = 46 years	9606	Homo sapiens (human)	6128	mean age = 46 years
-43.62 +/- 1.07 years	9606	Homo sapiens (human)	6129	43.62 ± 1.07 years
-young	10000000	Mus musculus BALB/c	6130	young
-100 day fetus	10001726	Sus scrofa Miniature Minnesota	6131	100 day fetus
-4-6 weeks	10000915	Mus musculus Kunming	6132	4-6 weeks
-23 to 27 weeks	10001728	Mus musculus PBL-SCID-bo	6133	23 to 27 weeks
-23 to 27 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	6134	23 to 27 weeks
-35 to 65 years	9606	Homo sapiens (human)	6135	35 to 65 years
-9 weeks	9823	Sus scrofa (pig)	6136	9 weeks
-12-14 weeks old	10000000	Mus musculus BALB/c	6137	12-14 weeks old
-4 weeks	10000919	Gallus gallus White Leghorn	6138	4 weeks
-NULL	10000201	Oryctolagus cuniculus Fauve de Bourgogne	6139	null
-24-75 years	9606	Homo sapiens (human)	6140	24-75 years
-7-9 weeks	10000618	Mus musculus ICR	6141	7-9 weeks
-26 weeks	10000625	Mus musculus MRL	6142	26 weeks
-NULL	10001743	Mus musculus BW	6143	null
-< 30 years	9606	Homo sapiens (human)	6144	< 30 years
-2 to 65 years	9606	Homo sapiens (human)	6145	2 to 65 years
-30-52 years	9606	Homo sapiens (human)	6146	30-52 years
-NULL	10001744	Mus musculus B10.STC77	6147	null
-Adult	10001749	Rattus norvegicus KGH	6148	adult
-18–55 years	9606	Homo sapiens (human)	6149	1855 years
-NULL	198115	Alouatta macconnelli	6150	null
-16-77 years	9606	Homo sapiens (human)	6151	16-77 years
-48 ± 8 years	9606	Homo sapiens (human)	6152	48  8 years
-51.4 +/- 18 years	9606	Homo sapiens (human)	6153	51.4 ± 18 years
-29 +/- 9 days	9913	Bos taurus (bovine)	6154	29 ± 9 days
-3 to 4 months	9823	Sus scrofa (pig)	6155	3 to 4 months
-2-49 years	9606	Homo sapiens (human)	6156	2-49 years
-20 to 34 years	9606	Homo sapiens (human)	6157	20 to 34 years
-6-10 weeks	10000010	Mus musculus BALB/c LACK TCR Tg	6158	6-10 weeks
-6-7 weeks	10000915	Mus musculus Kunming	6159	6-7 weeks
-Mean age of 54. 04	9606	Homo sapiens (human)	6160	mean age of 54. 04
-6 weeks	10001717	Mus musculus A.TH	6161	6 weeks
-22 to 34 years	9606	Homo sapiens (human)	6162	22 to 34 years
-7.5 months	9606	Homo sapiens (human)	6163	7.5 months
-10-15 years	9544	Macaca mulatta (rhesus macaque)	6164	10-15 years
-6-7 weeks	10000019	Mus musculus BALB/cByJ	6165	6-7 weeks
-> 2 months	9823	Sus scrofa (pig)	6166	> 2 months
-72.5±5.2 years	9606	Homo sapiens (human)	6167	72.55.2 years
-72.3±6.7 years	9606	Homo sapiens (human)	6168	72.36.7 years
-mean age = 38.6 years	9606	Homo sapiens (human)	6169	mean age = 38.6 years
-5-59 years old	9606	Homo sapiens (human)	6170	5-59 years old
-6–8weeks old	10000000	Mus musculus BALB/c	6171	68weeks old
-10 weeks	10000667	Rattus norvegicus Sprague-Dawley	6172	10 weeks
-32-68 years old	9606	Homo sapiens (human)	6173	32-68 years old
->55 years	9606	Homo sapiens (human)	6174	>55 years
-5-6 weeks old	10000654	Mus musculus Swiss albino	6175	5-6 weeks old
-NULL	100937	Papio papio (baboon)	6176	null
-4 weeks	10000017	Mus musculus BALB/c X DBA/2	6177	4 weeks
-36.47 +/- 12.46 years	9606	Homo sapiens (human)	6178	36.47 ± 12.46 years
-40.15 +/- 8.8 years	9606	Homo sapiens (human)	6179	40.15 ± 8.8 years
-Infants and adults	9606	Homo sapiens (human)	6180	infants and adults
-2 weeks	9103	Meleagris gallopavo (common turkey)	6181	2 weeks
-5 weeks	9103	Meleagris gallopavo (common turkey)	6182	5 weeks
-4 months	9925	Capra hircus (domestic goat)	6183	4 months
-10-62 years	9606	Homo sapiens (human)	6184	10-62 years
-4 to 6 weeks	10000655	Mus musculus Swiss Webster	6185	4 to 6 weeks
-53 +/- 11 years	9606	Homo sapiens (human)	6186	53 ± 11 years
-21-85 years	9606	Homo sapiens (human)	6187	21-85 years
-mean age=53.7 years	9606	Homo sapiens (human)	6188	mean age=53.7 years
-16-22 years	9534	Chlorocebus aethiops (African green monkey)	6189	16-22 years
-5-10 weeks	10000038	Mus musculus C3H/He	6190	5-10 weeks
-2 weeks	10000668	Cavia porcellus Duncan-Hartley	6191	2 weeks
-17-50 years	9606	Homo sapiens (human)	6192	17-50 years
-NULL	10001790	Mus musculus alpha1KI	6193	null
-6 weeks	10000641	Mus musculus OF1	6194	6 weeks
-NULL	10002851	Mus musculus HLA-B*13:02 Tg	6195	null
-4-8 years	9606	Homo sapiens (human)	6196	4-8 years
-16 weeks	9986	Oryctolagus cuniculus (rabbit)	6197	16 weeks
-8 - 10 weeks	10000000	Mus musculus BALB/c	6198	8 - 10 weeks
-11-78 years	9606	Homo sapiens (human)	6199	11-78 years
-57-59	9606	Homo sapiens (human)	6200	57-59
-23-66	9606	Homo sapiens (human)	6201	23-66
-26-48	9606	Homo sapiens (human)	6202	26-48
-19-66	9606	Homo sapiens (human)	6203	19-66
-40-42	9606	Homo sapiens (human)	6204	40-42
-44-47	9606	Homo sapiens (human)	6205	44-47
-63-64	9606	Homo sapiens (human)	6206	63-64
-31-32	9606	Homo sapiens (human)	6207	31-32
-3-25 years	9606	Homo sapiens (human)	6208	3-25 years
-8 weeks	10000627	Mus musculus MRL/MpJ	6209	8 weeks
-6 months	10000206	Oryctolagus cuniculus New Zealand White	6210	6 months
-17-73 years	9606	Homo sapiens (human)	6211	17-73 years
-6-40 years	9606	Homo sapiens (human)	6212	6-40 years
-4 weeks	10000206	Oryctolagus cuniculus New Zealand White	6213	4 weeks
-18-28 years old	9606	Homo sapiens (human)	6214	18-28 years old
-18-41 years old	9606	Homo sapiens (human)	6215	18-41 years old
-4 to 6 weeks	10000253	Mus musculus A/J	6216	4 to 6 weeks
-60-80 years	9606	Homo sapiens (human)	6217	60-80 years
-4 to 6 weeks	10001998	Mus musculus CD1	6218	4 to 6 weeks
-6 to 7 weeks	10000973	Mus musculus 129	6219	6 to 7 weeks
-15 months	10000667	Rattus norvegicus Sprague-Dawley	6220	15 months
-66 weeks	10000000	Mus musculus BALB/c	6221	66 weeks
-10–14-week old	10000000	Mus musculus BALB/c	6222	1014-week old
-25 years mean age	9606	Homo sapiens (human)	6223	25 years mean age
-mean age = 65.6 years	9606	Homo sapiens (human)	6224	mean age = 65.6 years
-3 weeks	10000275	Mus musculus B10.RIII	6225	3 weeks
-3 weeks	10000269	Mus musculus B10.G	6226	3 weeks
-3 weeks	10000276	Mus musculus B10.S	6227	3 weeks
-5 weeks	8839	Anas platyrhynchos (duck)	6228	5 weeks
-22-42 years	9606	Homo sapiens (human)	6229	22-42 years
-< 3 years	9606	Homo sapiens (human)	6230	< 3 years
-5 years	9541	Macaca fascicularis (crab eating macaque)	6231	5 years
-11-77 years	9606	Homo sapiens (human)	6232	11-77 years
-35-75 years old	9606	Homo sapiens (human)	6233	35-75 years old
-Mean age: 32.56 years	9606	Homo sapiens (human)	6234	mean age: 32.56 years
-Mean age: 34 years	9606	Homo sapiens (human)	6235	mean age: 34 years
-4 to 6 week old	10000263	Mus musculus B10.BR	6236	4 to 6 week old
-28-74 years	9606	Homo sapiens (human)	6237	28-74 years
-1.1–69 years	9606	Homo sapiens (human)	6238	1.169 years
-0.9-78 years	9606	Homo sapiens (human)	6239	0.9-78 years
-4 weeks old	9031	Gallus gallus (chicken)	6240	4 weeks old
-4 weeks old	8782	Ave (bird)	6241	4 weeks old
-Young adult	10000206	Oryctolagus cuniculus New Zealand White	6242	young adult
-3 months	8847	Anser sp. (goose)	6243	3 months
-4 weeks old	8847	Anser sp. (goose)	6244	4 weeks old
-4 weeks old	8839	Anas platyrhynchos (duck)	6245	4 weeks old
-30-58 years	9606	Homo sapiens (human)	6246	30-58 years
-23-64 years	9606	Homo sapiens (human)	6247	23-64 years
-8 weeks	10000248	Mus musculus 129 GIX+	6248	8 weeks
-12-14 weeks	10000199	Oryctolagus cuniculus Californian	6249	12-14 weeks
-7-8 weeks old	10000663	Rattus norvegicus LOU	6250	7-8 weeks old
-12-74 years	9606	Homo sapiens (human)	6251	12-74 years
-15 months	10001268	Mus musculus 3xTg-AD	6252	15 months
-36-63 years	9606	Homo sapiens (human)	6253	36-63 years
-49-72 years	9606	Homo sapiens (human)	6254	49-72 years
-NULL	10001976	Bos taurus Santa Gertrudis	6255	null
-8-46 years	9606	Homo sapiens (human)	6256	8-46 years
-12-15 months	10001268	Mus musculus 3xTg-AD	6257	12-15 months
-20-84 years	9606	Homo sapiens (human)	6258	20-84 years
-39.0 +/- 13.8 years	9606	Homo sapiens (human)	6259	39.0 ± 13.8 years
-60 days	10000038	Mus musculus C3H/He	6260	60 days
-27 to 60 years	9606	Homo sapiens (human)	6261	27 to 60 years
-NULL	7962	Cyprinus carpio (carp)	6262	null
-27 to 77 years	9606	Homo sapiens (human)	6263	27 to 77 years
-33 to 84 years	9606	Homo sapiens (human)	6264	33 to 84 years
-13-34 years	9606	Homo sapiens (human)	6265	13-34 years
-6 to 38 years	9606	Homo sapiens (human)	6266	6 to 38 years
-35 to 56 years	9606	Homo sapiens (human)	6267	35 to 56 years
-2 weeks	10001436	Gallus gallus P2a	6268	2 weeks
-44.1 +/- 13.2 years	9606	Homo sapiens (human)	6269	44.1 ± 13.2 years
-41.5 +/- 9.8 years	9606	Homo sapiens (human)	6270	41.5 ± 9.8 years
-31.7+/-4.5	9606	Homo sapiens (human)	6271	31.7±4.5
-7.5 to 16.5 years	9606	Homo sapiens (human)	6272	7.5 to 16.5 years
-37.0 +/- 12.6 years	9606	Homo sapiens (human)	6273	37.0 ± 12.6 years
-31.6+/-5.4	9606	Homo sapiens (human)	6274	31.6±5.4
-22-85 years	9606	Homo sapiens (human)	6275	22-85 years
-3 months	10001240	Mus musculus APPsw	6276	3 months
-4-6 weeks old	10000645	Mus musculus PrP null	6277	4-6 weeks old
-6 weeks old	10000645	Mus musculus PrP null	6278	6 weeks old
-37-57 years	9606	Homo sapiens (human)	6279	37-57 years
-5 to 38 years	9606	Homo sapiens (human)	6280	5 to 38 years
-2 to 15 years	9606	Homo sapiens (human)	6281	2 to 15 years
-8 +/- 3 years	9606	Homo sapiens (human)	6282	8 ± 3 years
-5 week old	10000645	Mus musculus PrP null	6283	5 week old
-60 to 77 years	9606	Homo sapiens (human)	6284	60 to 77 years
-27 to 37 years	9606	Homo sapiens (human)	6285	27 to 37 years
-28 to 39 years	9606	Homo sapiens (human)	6286	28 to 39 years
-8 to 10 weeks	10000668	Cavia porcellus Duncan-Hartley	6287	8 to 10 weeks
-38+/- 11 years	9606	Homo sapiens (human)	6288	38± 11 years
-3 years	9541	Macaca fascicularis (crab eating macaque)	6289	3 years
-2 to 73 years	9606	Homo sapiens (human)	6290	2 to 73 years
-median age 21 years	9606	Homo sapiens (human)	6291	median age 21 years
-43-70 years	9606	Homo sapiens (human)	6292	43-70 years
-36 to 47 years	9606	Homo sapiens (human)	6293	36 to 47 years
-34-48 years	9606	Homo sapiens (human)	6294	34-48 years
-70 +/- 9 years	9606	Homo sapiens (human)	6295	70 ± 9 years
-8 weeks	10000653	Mus musculus Swiss	6296	8 weeks
-64 to 76 years	9606	Homo sapiens (human)	6297	64 to 76 years
-6 - 8 weeks	10000253	Mus musculus A/J	6298	6 - 8 weeks
-3-48 years old	9606	Homo sapiens (human)	6299	3-48 years old
-1 year 8 months to 68 years	9606	Homo sapiens (human)	6300	1 year 8 months to 68 years
-31 to 49 years	9606	Homo sapiens (human)	6301	31 to 49 years
-15 to 67 years	9606	Homo sapiens (human)	6302	15 to 67 years
-21 to 84 years	9606	Homo sapiens (human)	6303	21 to 84 years
-16 to 84 years	9606	Homo sapiens (human)	6304	16 to 84 years
-mean age = 40.3 years	9606	Homo sapiens (human)	6305	mean age = 40.3 years
-10 to 801 days	10001584	Sus scrofa alpha1,3GALT null	6306	10 to 801 days
-Four-week-old	10000919	Gallus gallus White Leghorn	6307	4-week-old
-8-week-old	10000000	Mus musculus BALB/c	6308	8-week-old
-NULL	7797	Squalus acanthias (spiny dogfish)	6309	null
-8 to 9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6310	8 to 9 weeks
-NULL	9872	Odocoileus hemionus (mule deer)	6311	null
-3-70 years old	9606	Homo sapiens (human)	6312	3-70 years old
-3 to 56 years	9606	Homo sapiens (human)	6313	3 to 56 years
-2 to 47 years	9606	Homo sapiens (human)	6314	2 to 47 years
-3 years	9534	Chlorocebus aethiops (African green monkey)	6315	3 years
-Adult	10000920	Gallus gallus Leghorn	6316	adult
-8-9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6317	8-9 weeks
-48 months	9913	Bos taurus (bovine)	6318	48 months
-mean age = 63 years	9606	Homo sapiens (human)	6319	mean age = 63 years
-mean age = 57 years	9606	Homo sapiens (human)	6320	mean age = 57 years
-9 to 53 years	9606	Homo sapiens (human)	6321	9 to 53 years
-5-13 weeks	10000000	Mus musculus BALB/c	6322	5-13 weeks
-4 weeks	10090	Mus musculus (mouse)	6323	4 weeks
-mean 53.8 years	9606	Homo sapiens (human)	6324	mean 53.8 years
-24 weeks	10000000	Mus musculus BALB/c	6325	24 weeks
-6 - 8 weeks	10001487	Mus musculus Apolipoprotein E null	6326	6 - 8 weeks
-25 to 45 years	9606	Homo sapiens (human)	6327	25 to 45 years
-0.7 to 20.9 years (median = 11.0)	9606	Homo sapiens (human)	6328	0.7 to 20.9 years (median = 11.0)
-2 to 67 years	9606	Homo sapiens (human)	6329	2 to 67 years
-2 to 53 years	9606	Homo sapiens (human)	6330	2 to 53 years
-4-6 weeks	10000218	Mus musculus C57BL/6 X C3H	6331	4-6 weeks
-36.2 +/- 8.9 years	9606	Homo sapiens (human)	6332	36.2 ± 8.9 years
-7 to 8 weeks	10000019	Mus musculus BALB/cByJ	6333	7 to 8 weeks
-6 to 12 months	9669	Mustela putorius furo (black ferret)	6334	6 to 12 months
-20-24 weeks	10001406	Mus musculus MLR/lpr	6335	20-24 weeks
-3 years	10090	Mus musculus (mouse)	6336	3 years
-1-2 years	9940	Ovis aries (domestic sheep)	6337	1-2 years
-4-6 weeks	10001221	Mus musculus C57BL/6 x SJL	6338	4-6 weeks
-13 weeks	10000000	Mus musculus BALB/c	6339	13 weeks
-0.5 - 3 years	9606	Homo sapiens (human)	6340	0.5 - 3 years
-2-65 years	9606	Homo sapiens (human)	6341	2-65 years
-3 weeks	10000639	Mus musculus NZB	6342	3 weeks
-26 weeks	10001406	Mus musculus MLR/lpr	6343	26 weeks
-59 to 80 years	9606	Homo sapiens (human)	6344	59 to 80 years
-9 to 12 weeks	10090	Mus musculus (mouse)	6345	9 to 12 weeks
-10-64 years	9606	Homo sapiens (human)	6346	10-64 years
-6 weeks	8835	Anas (ducks)	6347	6 weeks
-24 to 59 years	9606	Homo sapiens (human)	6348	24 to 59 years
-10 weeks	10000194	Bos taurus Holstein-Friesian	6349	10 weeks
-27 to 55 years	9606	Homo sapiens (human)	6350	27 to 55 years
-19 to 64 years	9606	Homo sapiens (human)	6351	19 to 64 years
-9 to 10 weeks	10000067	Mus musculus C57BL/6	6352	9 to 10 weeks
-3-4 weeks	9823	Sus scrofa (pig)	6353	3-4 weeks
-10 weeks	10000653	Mus musculus Swiss	6354	10 weeks
-NULL	8847	Anser sp. (goose)	6355	null
-NULL	8835	Anas (ducks)	6356	null
-58.4 +/- 14.3 years	9606	Homo sapiens (human)	6357	58.4 ± 14.3 years
-NULL	40674	Mammal	6358	null
-<42-79 years	9606	Homo sapiens (human)	6359	<42-79 years
-24-61 years	9606	Homo sapiens (human)	6360	24-61 years
-2 to 4 weeks	10000067	Mus musculus C57BL/6	6361	2 to 4 weeks
-1 month - 13 years	9606	Homo sapiens (human)	6362	1 month - 13 years
-18-74 years	9606	Homo sapiens (human)	6363	18-74 years
-26-96 years	9606	Homo sapiens (human)	6364	26-96 years
-9-12 weeks	10001926	Mus musculus FVIII null	6365	9-12 weeks
-2-3 months	10001406	Mus musculus MLR/lpr	6366	2-3 months
-6 months	10000185	Canis familiaris beagle	6367	6 months
-15 months	10001286	Mus musculus APPswe/PSEN1	6368	15 months
-38-55  years	9606	Homo sapiens (human)	6369	38-55  years
-8 to 10 years	9541	Macaca fascicularis (crab eating macaque)	6370	8 to 10 years
-54-64 years	10000119	Homo sapiens Caucasian	6371	54-64 years
-60 years	10000119	Homo sapiens Caucasian	6372	60 years
-1 year	9986	Oryctolagus cuniculus (rabbit)	6373	1 year
-6 or 12 months	10001286	Mus musculus APPswe/PSEN1	6374	6 or 12 months
-7 weeks	10000915	Mus musculus Kunming	6375	7 weeks
-55-79 years	9606	Homo sapiens (human)	6376	55-79 years
-7 to 78 years	9606	Homo sapiens (human)	6377	7 to 78 years
-5 to 80 years	9606	Homo sapiens (human)	6378	5 to 80 years
-4 months	10000000	Mus musculus BALB/c	6379	4 months
-3 to 5 years	9541	Macaca fascicularis (crab eating macaque)	6380	3 to 5 years
-51-74 years	9606	Homo sapiens (human)	6381	51-74 years
-27 weeks	10001406	Mus musculus MLR/lpr	6382	27 weeks
-42.18+/-13.23	9606	Homo sapiens (human)	6383	42.18±13.23
-44.94+/-15.65	9606	Homo sapiens (human)	6384	44.94±15.65
-20 weeks	10001406	Mus musculus MLR/lpr	6385	20 weeks
-> 2 months	10000067	Mus musculus C57BL/6	6386	> 2 months
-4 years	9544	Macaca mulatta (rhesus macaque)	6387	4 years
-1 to 5 years	9606	Homo sapiens (human)	6388	1 to 5 years
-8 weeks	10000204	Oryctolagus cuniculus Japanese white	6389	8 weeks
-5 to 7 weeks	10000038	Mus musculus C3H/He	6390	5 to 7 weeks
-10 to 73 years	9606	Homo sapiens (human)	6391	10 to 73 years
-34-71 years	9606	Homo sapiens (human)	6392	34-71 years
-5-12 months	10001286	Mus musculus APPswe/PSEN1	6393	5-12 months
-34-68 years	9606	Homo sapiens (human)	6394	34-68 years
-NULL	10001598	Mus musculus human duffy Fyb protein Tg	6395	null
-8 to 12 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6396	8 to 12 weeks
-NULL	10001599	Mus musculus duffy Fy null	6397	null
-6 to 8 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6398	6 to 8 weeks
-8.4 to 12.4 years	10000185	Canis familiaris beagle	6399	8.4 to 12.4 years
-44-74 years	9606	Homo sapiens (human)	6400	44-74 years
-28-82	9606	Homo sapiens (human)	6401	28-82
-34-82 years	9606	Homo sapiens (human)	6402	34-82 years
-3.4-86 years	9606	Homo sapiens (human)	6403	3.4-86 years
-5 to 14 years	9606	Homo sapiens (human)	6404	5 to 14 years
-18 months	10000627	Mus musculus MRL/MpJ	6405	18 months
-> 12 years old	9606	Homo sapiens (human)	6406	> 12 years old
-2 to 16 years	9606	Homo sapiens (human)	6407	2 to 16 years
-1 day to 103 years	9606	Homo sapiens (human)	6408	1 day to 103 years
-6-8 weeks	10000631	Mus musculus NMRI	6409	6-8 weeks
-4 months	9986	Oryctolagus cuniculus (rabbit)	6410	4 months
-38-54 weeks	10000627	Mus musculus MRL/MpJ	6411	38-54 weeks
-4-43 years	9606	Homo sapiens (human)	6412	4-43 years
-2 years	9481	Callithrix (marmoset)	6413	2 years
-23.2 +/- 5.7 years	9606	Homo sapiens (human)	6414	23.2 ± 5.7 years
-1 year	10002168	Oryctolagus cuniculus Belgian White	6415	1 year
-8 to 10 months	10000220	Mus musculus C57BL/6 X DBA/2	6416	8 to 10 months
-13-22 years	9606	Homo sapiens (human)	6417	13-22 years
-60.9 +/- 11 years	9606	Homo sapiens (human)	6418	60.9 ± 11 years
-59.4 +/- 5.4 years	9606	Homo sapiens (human)	6419	59.4 ± 5.4 years
-0-96 years	9606	Homo sapiens (human)	6420	0-96 years
-38-79 years	9606	Homo sapiens (human)	6421	38-79 years
-6-7 weks	10000662	Rattus norvegicus Lewis	6422	6-7 weeks
-22 weeks	10000919	Gallus gallus White Leghorn	6423	22 weeks
-10-77 years	9606	Homo sapiens (human)	6424	10-77 years
-4.5-12.1 years	9541	Macaca fascicularis (crab eating macaque)	6425	4.5-12.1 years
-12-30	9606	Homo sapiens (human)	6426	12-30
-43 t0 53 months	9483	Callithrix jacchus (common marmoset)	6427	43 t0 53 months
-98 to 140 days	9031	Gallus gallus (chicken)	6428	98 to 140 days
-28 to 54 years	9606	Homo sapiens (human)	6429	28 to 54 years
-8-10 weeks	10000062	Mus musculus FVB/J	6430	8-10 weeks
-8 weeks	10001446	Rattus norvegicus Wistar Kyoto	6431	8 weeks
-35-84 years	9606	Homo sapiens (human)	6432	35-84 years
-35-85 years	9606	Homo sapiens (human)	6433	35-85 years
-2 to 6 years	9606	Homo sapiens (human)	6434	2 to 6 years
-18-33 years	9606	Homo sapiens (human)	6435	18-33 years
-19 to 85 years	9606	Homo sapiens (human)	6436	19 to 85 years
-2 months	42414	Sigmodon (cotton rat)	6437	2 months
-1 to 5 years or > 15 years	9606	Homo sapiens (human)	6438	1 to 5 years or > 15 years
-adult	10001041	Rattus norvegicus Wistar	6439	adult
-NULL	10001247	Oryctolagus cuniculus Dutch Half Lop	6440	null
-mean age = 4.4 years	9544	Macaca mulatta (rhesus macaque)	6441	mean age = 4.4 years
-NULL	10000641	Mus musculus OF1	6442	null
-mean age 3-4 years	9606	Homo sapiens (human)	6443	mean age 3-4 years
-4 to 80 years	9606	Homo sapiens (human)	6444	4 to 80 years
-4 weeks	10000618	Mus musculus ICR	6445	4 weeks
-median age 63 years	9606	Homo sapiens (human)	6446	median age 63 years
-adult	10001001	Rattus norvegicus WKAH	6447	adult
-31-66 years	9606	Homo sapiens (human)	6448	31-66 years
-22-63 years	9606	Homo sapiens (human)	6449	22-63 years
-27-105 years	9606	Homo sapiens (human)	6450	27-105 years
-9.42 +/- 3.84 years	9606	Homo sapiens (human)	6451	9.42 ± 3.84 years
-6.94 +/- 3.58 years	9606	Homo sapiens (human)	6452	6.94 ± 3.58 years
-9 weeks	10000024	Mus musculus Biozzi	6453	9 weeks
-15 to 92 years	9606	Homo sapiens (human)	6454	15 to 92 years
-11 +/- 7 years	9606	Homo sapiens (human)	6455	11 ± 7 years
-12.9 +/- 7.7 years	9606	Homo sapiens (human)	6456	12.9 ± 7.7 years
-12.8 +/- 8 years	9606	Homo sapiens (human)	6457	12.8 ± 8 years
-13.6 +/- 6.8 years	9606	Homo sapiens (human)	6458	13.6 ± 6.8 years
-22.7 +/- 14 years	9606	Homo sapiens (human)	6459	22.7 ± 14 years
-14.1 +/- 12 years	9606	Homo sapiens (human)	6460	14.1 ± 12 years
-9.6 +/- 3.1 years	9606	Homo sapiens (human)	6461	9.6 ± 3.1 years
-14.3 +/- 5.7 years	9606	Homo sapiens (human)	6462	14.3 ± 5.7 years
-23.8 +/- 2.3 years	9606	Homo sapiens (human)	6463	23.8 ± 2.3 years
-4-9 years	9606	Homo sapiens (human)	6464	4-9 years
-34-75 years	9606	Homo sapiens (human)	6465	34-75 years
-12 to 54 years	9606	Homo sapiens (human)	6466	12 to 54 years
-1 to 66 years	9606	Homo sapiens (human)	6467	1 to 66 years
-4 to 54 years	9606	Homo sapiens (human)	6468	4 to 54 years
-4 to 28 years	9606	Homo sapiens (human)	6469	4 to 28 years
-50.3 years median age	9606	Homo sapiens (human)	6470	50.3 years median age
-56.5 years median age	9606	Homo sapiens (human)	6471	56.5 years median age
-6-12 weeks	9669	Mustela putorius furo (black ferret)	6472	6-12 weeks
-17-95 years	9606	Homo sapiens (human)	6473	17-95 years
-13-81 years	9606	Homo sapiens (human)	6474	13-81 years
-9 weeks	10090	Mus musculus (mouse)	6475	9 weeks
-55.9 +/- 19.2 years	9606	Homo sapiens (human)	6476	55.9 ± 19.2 years
-8-10 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	6477	8-10 weeks
-piglet	9823	Sus scrofa (pig)	6478	piglet
-1-60 years	9606	Homo sapiens (human)	6479	1-60 years
-3 months	1240228	Cairina moschata domestica (Muscovy Duck (domestic type))	6480	3 months
-37.9 +/- 6.5 years	9606	Homo sapiens (human)	6481	37.9 ± 6.5 years
-37.6 +/- 11.0 years	9606	Homo sapiens (human)	6482	37.6 ± 11.0 years
-3-41 years	9606	Homo sapiens (human)	6483	3-41 years
-6 to 8 weeks	10002050	Mus musculus HLA-DQB1*03:02 Tg	6484	6 to 8 weeks
-6 to 8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	6485	6 to 8 weeks
-6 to 8 weeks	10001377	Mus musculus HLA-DQB1*06:01 Tg	6486	6 to 8 weeks
-6-8 weeks	9031	Gallus gallus (chicken)	6487	6-8 weeks
-12-73 years	9606	Homo sapiens (human)	6488	12-73 years
-23-59 years	9606	Homo sapiens (human)	6489	23-59 years
-3 to 4 months	10000206	Oryctolagus cuniculus New Zealand White	6490	3 to 4 months
-2 to 3 weeks	10000000	Mus musculus BALB/c	6491	2 to 3 weeks
-1-10 years old	9606	Homo sapiens (human)	6492	1-10 years old
-23.9 to 53.9 years	9606	Homo sapiens (human)	6493	23.9 to 53.9 years
-40.7 to 73.3 years	9606	Homo sapiens (human)	6494	40.7 to 73.3 years
-3 to 4 months	10000000	Mus musculus BALB/c	6495	3 to 4 months
-20-85	9606	Homo sapiens (human)	6496	20-85
-6 weeks and 18 months	10000000	Mus musculus BALB/c	6497	6 weeks and 18 months
-6 -12 weeks	10000000	Mus musculus BALB/c	6498	6 -12 weeks
-7- 32 years	9606	Homo sapiens (human)	6499	7- 32 years
-8 to 10 weeks	10000054	Mus musculus DBA/1	6500	8 to 10 weeks
-53.7 +/- 11.2	9606	Homo sapiens (human)	6501	53.7 ± 11.2
-58.8 +/- 8.7	9606	Homo sapiens (human)	6502	58.8 ± 8.7
-15-50 years	9606	Homo sapiens (human)	6503	15-50 years
-1-24 years	9606	Homo sapiens (human)	6504	1-24 years
-2.2-47.9 years	9606	Homo sapiens (human)	6505	2.2-47.9 years
-48-93 years	9606	Homo sapiens (human)	6506	48-93 years
-adult	10090	Mus musculus (mouse)	6507	adult
-7 weeks	9031	Gallus gallus (chicken)	6508	7 weeks
-4 to 9 years	9606	Homo sapiens (human)	6509	4 to 9 years
-mean age = 9.3 years	9606	Homo sapiens (human)	6510	mean age = 9.3 years
-17 to 56 years	9606	Homo sapiens (human)	6511	17 to 56 years
-NULL	10002063	Ovis aries Merino	6512	null
-10 years	9544	Macaca mulatta (rhesus macaque)	6513	10 years
-55.7 +/- 5.7	9606	Homo sapiens (human)	6514	55.7 ± 5.7
-49.5 +/- 7.5	9606	Homo sapiens (human)	6515	49.5 ± 7.5
-NULL	1240228	Cairina moschata domestica (Muscovy Duck (domestic type))	6516	null
-mean age = 38 years	9606	Homo sapiens (human)	6517	mean age = 38 years
-45 days	9823	Sus scrofa (pig)	6518	45 days
-19-66 years	9606	Homo sapiens (human)	6519	19-66 years
-1 to 268 days	9606	Homo sapiens (human)	6520	1 to 268 days
-3 days	10000067	Mus musculus C57BL/6	6521	3 days
-NULL	42414	Sigmodon (cotton rat)	6522	null
-8 weeks	10000019	Mus musculus BALB/cByJ	6523	8 weeks
-3 years	30538	Vicugna pacos (alpaca)	6524	3 years
-1.1-20 years	9606	Homo sapiens (human)	6525	1.1-20 years
-7-20 weeks	10001487	Mus musculus Apolipoprotein E null	6526	7-20 weeks
-18 to 47 years	9606	Homo sapiens (human)	6527	18 to 47 years
-22 to 58 years	9606	Homo sapiens (human)	6528	22 to 58 years
-17 to 42 years	9606	Homo sapiens (human)	6529	17 to 42 years
-22 to 62 years	9606	Homo sapiens (human)	6530	22 to 62 years
-2-8 years	9606	Homo sapiens (human)	6531	2-8 years
-4-7 years	9606	Homo sapiens (human)	6532	4-7 years
-12 weeks	10000013	Mus musculus BALB/c X A/J	6533	12 weeks
-5 week	10000067	Mus musculus C57BL/6	6534	5 week
-4-10 years	9606	Homo sapiens (human)	6535	4-10 years
-44-52 weeks	9031	Gallus gallus (chicken)	6536	44-52 weeks
-5 to 8 week	10000013	Mus musculus BALB/c X A/J	6537	5 to 8 week
-8 week	10000013	Mus musculus BALB/c X A/J	6538	8 week
-123 days	9031	Gallus gallus (chicken)	6539	123 days
-1 week	9031	Gallus gallus (chicken)	6540	1 week
-21-94 years	9606	Homo sapiens (human)	6541	21-94 years
-12-14 weeks	10000038	Mus musculus C3H/He	6542	12-14 weeks
-8-15 weeks	10000639	Mus musculus NZB	6543	8-15 weeks
-7-12 months	10000206	Oryctolagus cuniculus New Zealand White	6544	7-12 months
-10 to 89 years	9606	Homo sapiens (human)	6545	10 to 89 years
-41 to 73 years	9606	Homo sapiens (human)	6546	41 to 73 years
-56 to 72 years	9606	Homo sapiens (human)	6547	56 to 72 years
-61 to 70 years	9606	Homo sapiens (human)	6548	61 to 70 years
-4-16 years	9606	Homo sapiens (human)	6549	4-16 years
-43 to 71 years	9606	Homo sapiens (human)	6550	43 to 71 years
-8 years	9606	Homo sapiens (human)	6551	8 years
-4-54 years	9606	Homo sapiens (human)	6552	4-54 years
-27 to 85 years	9606	Homo sapiens (human)	6553	27 to 85 years
-mean 61.2 years	9606	Homo sapiens (human)	6554	mean 61.2 years
-7-8 weeks	10000019	Mus musculus BALB/cByJ	6555	7-8 weeks
-7 weeks	10000667	Rattus norvegicus Sprague-Dawley	6556	7 weeks
-12-13 weeks	10000206	Oryctolagus cuniculus New Zealand White	6557	12-13 weeks
-median 9 years	9606	Homo sapiens (human)	6558	median 9 years
-12-15 years	9606	Homo sapiens (human)	6559	12-15 years
-5-32 years	9606	Homo sapiens (human)	6560	5-32 years
-3 to 4 months	9986	Oryctolagus cuniculus (rabbit)	6561	3 to 4 months
-3-4 months	10000206	Oryctolagus cuniculus New Zealand White	6562	3-4 months
-5 weeks	10000019	Mus musculus BALB/cByJ	6563	5 weeks
-8-10 weeks	10000657	Mus musculus Xenomouse	6564	8-10 weeks
-NULL	419612	Camelus ferus (Wild Bactrian camel)	6565	null
-29-50 years	9606	Homo sapiens (human)	6566	29-50 years
-2 months	10000669	Cavia porcellus Hartley	6567	2 months
-1-23 years	9606	Homo sapiens (human)	6568	1-23 years
-2-40 years	9606	Homo sapiens (human)	6569	2-40 years
-18 to 90 years	9606	Homo sapiens (human)	6570	18 to 90 years
-8-30 years	9606	Homo sapiens (human)	6571	8-30 years
-42 days	9823	Sus scrofa (pig)	6572	42 days
-4 years	9796	Equus caballus (domestic horse)	6573	4 years
-85 days	9031	Gallus gallus (chicken)	6574	85 days
-2 days	9031	Gallus gallus (chicken)	6575	2 days
-49 to 62 years	9606	Homo sapiens (human)	6576	49 to 62 years
-39 to 54 years	9606	Homo sapiens (human)	6577	39 to 54 years
-59 to 65 years	9606	Homo sapiens (human)	6578	59 to 65 years
-NULL	452646	Neogale vison (mink)	6579	null
-NULL	381198	Anser cygnoides domesticus	6580	null
-8 to 74 years	9606	Homo sapiens (human)	6581	8 to 74 years
-6 weeks	9874	Odocoileus virginianus (white-tailed deer)	6582	6 weeks
-43 +/- 12 years	9606	Homo sapiens (human)	6583	43 ± 12 years
-8-12 weeks	10001601	Mus musculus C57BL/6 X 129	6584	8-12 weeks
-1 to 7 years	9606	Homo sapiens (human)	6585	1 to 7 years
-0.8 to 81 years	9606	Homo sapiens (human)	6586	0.8 to 81 years
-2 to 36 months	9606	Homo sapiens (human)	6587	2 to 36 months
-36 +/- 10 years	9606	Homo sapiens (human)	6588	36 ± 10 years
-4 to 25 years	9606	Homo sapiens (human)	6589	4 to 25 years
-54.8 to 72.4 years	9606	Homo sapiens (human)	6590	54.8 to 72.4 years
-9 to 36 months	9606	Homo sapiens (human)	6591	9 to 36 months
-22.4 to 58.8 years	9606	Homo sapiens (human)	6592	22.4 to 58.8 years
-4-8 years	9541	Macaca fascicularis (crab eating macaque)	6593	4-8 years
-12 to 192 weeks	9615	Canis lupus familiaris (dogs)	6594	12 to 192 weeks
-median age: 7.5 years	9606	Homo sapiens (human)	6595	median age: 7.5 years
-11 to 66 months	9615	Canis lupus familiaris (dogs)	6596	11 to 66 months
-40-67 years	9606	Homo sapiens (human)	6597	40-67 years
-9-12 weeks	10090	Mus musculus (mouse)	6598	9-12 weeks
-26-72 years	9606	Homo sapiens (human)	6599	26-72 years
-7 weeks	10000973	Mus musculus 129	6600	7 weeks
-15 weeks	10000206	Oryctolagus cuniculus New Zealand White	6601	15 weeks
-NULL	10117	Rattus rattus (house rat)	6602	null
-3 to 4 months	10000653	Mus musculus Swiss	6603	3 to 4 months
-51-70 years	9606	Homo sapiens (human)	6604	51-70 years
-9-51 years	9606	Homo sapiens (human)	6605	9-51 years
-NULL	9666	Mustela lutreola (mink)	6606	null
-21-25 years	9606	Homo sapiens (human)	6607	21-25 years
-8-10 weeks	10000206	Oryctolagus cuniculus New Zealand White	6608	8-10 weeks
-38 to 81 years	9606	Homo sapiens (human)	6609	38 to 81 years
-3 months	10141	Cavia porcellus (guinea pig)	6610	3 months
-60-83 years	9606	Homo sapiens (human)	6611	60-83 years
-adult	10141	Cavia porcellus (guinea pig)	6612	adult
-10-70 years	9606	Homo sapiens (human)	6613	10-70 years
-56-64 years	9606	Homo sapiens (human)	6614	56-64 years
-over 18 years	10000119	Homo sapiens Caucasian	6615	over 18 years
-10 to 100 years	9606	Homo sapiens (human)	6616	10 to 100 years
-4 weeks	10000667	Rattus norvegicus Sprague-Dawley	6617	4 weeks
-6 to 8 months	10000206	Oryctolagus cuniculus New Zealand White	6618	6 to 8 months
-17 to 24 years	9606	Homo sapiens (human)	6619	17 to 24 years
-19.9 to 60.5 years	9606	Homo sapiens (human)	6620	19.9 to 60.5 years
-< 5 years	9606	Homo sapiens (human)	6621	< 5 years
-9-61 years	9606	Homo sapiens (human)	6622	9-61 years
-5 months	10000206	Oryctolagus cuniculus New Zealand White	6623	5 months
-NULL	314147	Glire (rodent or rabbit)	6624	null
-3 months	10000664	Rattus norvegicus LOU/C	6625	3 months
-6-8 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6626	6-8 weeks
-12-16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6627	12-16 weeks
-51-81 years	9606	Homo sapiens (human)	6628	51-81 years
-12-35 years	9606	Homo sapiens (human)	6629	12-35 years
-5 week	10000000	Mus musculus BALB/c	6630	5 week
-19 to 47 years	9606	Homo sapiens (human)	6631	19 to 47 years
-31 to 73 years	9606	Homo sapiens (human)	6632	31 to 73 years
-13 to 31 years	9606	Homo sapiens (human)	6633	13 to 31 years
-46.7 yeas (mean)	9606	Homo sapiens (human)	6634	46.7 yeas (mean)
-25.8 to 53.2 years	9606	Homo sapiens (human)	6635	25.8 to 53.2 years
-39.6 to 63 years	9606	Homo sapiens (human)	6636	39.6 to 63 years
-23-29 years	9606	Homo sapiens (human)	6637	23-29 years
-mean age = 33.6 years	9606	Homo sapiens (human)	6638	mean age = 33.6 years
-18-66 years	9606	Homo sapiens (human)	6639	18-66 years
-6 days	10000618	Mus musculus ICR	6640	6 days
-8 to 9 weeks	10000630	Mus musculus NHI Swiss	6641	8 to 9 weeks
-43 to 88 years	9606	Homo sapiens (human)	6642	43 to 88 years
-45-62 years	9606	Homo sapiens (human)	6643	45-62 years
-5 to 6 months	9940	Ovis aries (domestic sheep)	6644	5 to 6 months
-15.8 to 51.8 years	9606	Homo sapiens (human)	6645	15.8 to 51.8 years
-28 to 49.6 years	9606	Homo sapiens (human)	6646	28 to 49.6 years
-5 to 11 months	10000194	Bos taurus Holstein-Friesian	6647	5 to 11 months
-NULL	10002278	Mus musculus Antibody Transgenic	6648	null
-1-12 years	9606	Homo sapiens (human)	6649	1-12 years
-17 to 70 years	9606	Homo sapiens (human)	6650	17 to 70 years
-21 to 83 years	9606	Homo sapiens (human)	6651	21 to 83 years
-NULL	10002257	Mus musculus Kymouse	6652	null
-> 6 weeks	10001998	Mus musculus CD1	6653	> 6 weeks
-43.9 to 71.5 years	9606	Homo sapiens (human)	6654	43.9 to 71.5 years
-2.8 months	9606	Homo sapiens (human)	6655	2.8 months
-3-6 years	9606	Homo sapiens (human)	6656	3-6 years
-10.6 months	9606	Homo sapiens (human)	6657	10.6 months
-10-12 weeks	9986	Oryctolagus cuniculus (rabbit)	6658	10-12 weeks
-10-45 years	9606	Homo sapiens (human)	6659	10-45 years
-13-48 years	9606	Homo sapiens (human)	6660	13-48 years
-6 months	9544	Macaca mulatta (rhesus macaque)	6661	6 months
-40 days	10000000	Mus musculus BALB/c	6662	40 days
-5 to 8 years	9606	Homo sapiens (human)	6663	5 to 8 years
-18 to 78 years	9606	Homo sapiens (human)	6664	18 to 78 years
-1 day to 6 months	9823	Sus scrofa (pig)	6665	1 day to 6 months
-23 to 59 years	9606	Homo sapiens (human)	6666	23 to 59 years
-2-7 years	9796	Equus caballus (domestic horse)	6667	2-7 years
-30 to 55 years	9606	Homo sapiens (human)	6668	30 to 55 years
-32 to 52 years	9606	Homo sapiens (human)	6669	32 to 52 years
-38 to 44 years	9606	Homo sapiens (human)	6670	38 to 44 years
-young	10002275	Sus scrofa Duroc X Yorkshire X Hampshire	6671	young
-19-74 years	9606	Homo sapiens (human)	6672	19-74 years
-NULL	10002262	Rattus norvegicus OmniRat5Lew x Rat4	6673	null
-2 months	10000054	Mus musculus DBA/1	6674	2 months
-mean 54.37 years	9606	Homo sapiens (human)	6675	mean 54.37 years
-mean 39 years	9606	Homo sapiens (human)	6676	mean 39 years
-46-63 years	9606	Homo sapiens (human)	6677	46-63 years
-43-65 years	9606	Homo sapiens (human)	6678	43-65 years
-mean 51.32 years	9606	Homo sapiens (human)	6679	mean 51.32 years
-24 weeks	9669	Mustela putorius furo (black ferret)	6680	24 weeks
-7 to 19 weeks	10000067	Mus musculus C57BL/6	6681	7 to 19 weeks
-9 days	8839	Anas platyrhynchos (duck)	6682	9 days
-6 weeks	10000271	Mus musculus B10.M	6683	6 weeks
-2-3 months	10000061	Mus musculus FVB	6684	2-3 months
-average 30.2 years	9606	Homo sapiens (human)	6685	average 30.2 years
-6 to 66 years	9606	Homo sapiens (human)	6686	6 to 66 years
-8 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	6687	8 weeks
-44 to 52 weeks	9031	Gallus gallus (chicken)	6688	44 to 52 weeks
-12 week	10000000	Mus musculus BALB/c	6689	12 week
-3 to 5 months	9541	Macaca fascicularis (crab eating macaque)	6690	3 to 5 months
-mean 48 years	9606	Homo sapiens (human)	6691	mean 48 years
-24-35 years	9606	Homo sapiens (human)	6692	24-35 years
-3 to 8 weeks	10001998	Mus musculus CD1	6693	3 to 8 weeks
-9 to 12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6694	9 to 12 weeks
-2-7 years	9913	Bos taurus (bovine)	6695	2-7 years
-8 to 10 weeks	10000038	Mus musculus C3H/He	6696	8 to 10 weeks
-4-6 months	9940	Ovis aries (domestic sheep)	6697	4-6 months
-40 to 78 years	9606	Homo sapiens (human)	6698	40 to 78 years
-11 to 51 years	9606	Homo sapiens (human)	6699	11 to 51 years
-2 months - 12 years	9606	Homo sapiens (human)	6700	2 months - 12 years
-juvenile	84645	Labeo rohita (Jayanti rohu)	6701	juvenile
-9 to 16 years	9606	Homo sapiens (human)	6702	9 to 16 years
-3 to 8 years	9606	Homo sapiens (human)	6703	3 to 8 years
-2 years	30538	Vicugna pacos (alpaca)	6704	2 years
-22 to 78 years	9606	Homo sapiens (human)	6705	22 to 78 years
-6 to 8 weeks	10001623	Mus musculus AG129	6706	6 to 8 weeks
-16 to 80 years	9606	Homo sapiens (human)	6707	16 to 80 years
-52 years old on average	9606	Homo sapiens (human)	6708	52 years old on average
-3 weeks	10000664	Rattus norvegicus LOU/C	6709	3 weeks
-8 weeks	9986	Oryctolagus cuniculus (rabbit)	6710	8 weeks
-31 to 61 years	9606	Homo sapiens (human)	6711	31 to 61 years
-10-19 years	9606	Homo sapiens (human)	6712	10-19 years
-10-29 years	9606	Homo sapiens (human)	6713	10-29 years
-1 months	10000632	Mus musculus NOD	6714	1 months
-7 to 65 years	9606	Homo sapiens (human)	6715	7 to 65 years
-22 to 73 years	9606	Homo sapiens (human)	6716	22 to 73 years
-16 to 68 years	9606	Homo sapiens (human)	6717	16 to 68 years
-8 to 10 weels	10000000	Mus musculus BALB/c	6718	8 to 10 weeks
-36.8 years (mean)	9606	Homo sapiens (human)	6719	36.8 years (mean)
-2 to 100 years	9606	Homo sapiens (human)	6720	2 to 100 years
-21-36 years	9606	Homo sapiens (human)	6721	21-36 years
-42-71 years	9606	Homo sapiens (human)	6722	42-71 years
-60-87 years	9606	Homo sapiens (human)	6723	60-87 years
-72-75 years	9606	Homo sapiens (human)	6724	72-75 years
-38 to 76 years	9606	Homo sapiens (human)	6725	38 to 76 years
-average 34.5 years	9606	Homo sapiens (human)	6726	average 34.5 years
-8 weeks	10001602	Mus musculus RBF	6727	8 weeks
-19.5 to 60.2 years	9606	Homo sapiens (human)	6728	19.5 to 60.2 years
-19.7 to 63.3 years	9606	Homo sapiens (human)	6729	19.7 to 63.3 years
-4 weeks old	10001406	Mus musculus MLR/lpr	6730	4 weeks old
-1-51 years	9606	Homo sapiens (human)	6731	1-51 years
-3-4 years	9554	Papio (baboon)	6732	3-4 years
-2-4 years	9544	Macaca mulatta (rhesus macaque)	6733	2-4 years
-2-5 years	9541	Macaca fascicularis (crab eating macaque)	6734	2-5 years
-1-25 years	9515	Sapajus apella (black-capped capuchin)	6735	1-25 years
-4 months	10032	Cricetulus migratorius (gray dwarf hamster)	6736	4 months
-4 months	10090	Mus musculus (mouse)	6737	4 months
-58-70 years	9606	Homo sapiens (human)	6738	58-70 years
-8 months to 54 years	9606	Homo sapiens (human)	6739	8 months to 54 years
-55.9 to 76.9 years	9606	Homo sapiens (human)	6740	55.9 to 76.9 years
-11 months - 55 years	9606	Homo sapiens (human)	6741	11 months - 55 years
-5-9 weeks	10000000	Mus musculus BALB/c	6742	5-9 weeks
-56-73 years	9606	Homo sapiens (human)	6743	56-73 years
-NULL	10002034	Fish	6744	null
-37 to 79 years	9606	Homo sapiens (human)	6745	37 to 79 years
-45 to 74 years	9606	Homo sapiens (human)	6746	45 to 74 years
-35 to 75 years	9606	Homo sapiens (human)	6747	35 to 75 years
-19 to 62 years	9606	Homo sapiens (human)	6748	19 to 62 years
-26 to 55 years	9606	Homo sapiens (human)	6749	26 to 55 years
-13 to 68 years	9606	Homo sapiens (human)	6750	13 to 68 years
-18 to 88 years	9606	Homo sapiens (human)	6751	18 to 88 years
-21 to 85 years	9606	Homo sapiens (human)	6752	21 to 85 years
-17 to 96 years	9606	Homo sapiens (human)	6753	17 to 96 years
-18-90 years	9606	Homo sapiens (human)	6754	18-90 years
-2 years	9844	Lama glama (llama)	6755	2 years
-11-68 years	9606	Homo sapiens (human)	6756	11-68 years
-12 to 88 years	9606	Homo sapiens (human)	6757	12 to 88 years
-NULL	10002138	Mus musculus B10	6758	null
-53.2 years	9606	Homo sapiens (human)	6759	53.2 years
-51.0 years	9606	Homo sapiens (human)	6760	51.0 years
-34.3 years	9606	Homo sapiens (human)	6761	34.3 years
-36.1 years	9606	Homo sapiens (human)	6762	36.1 years
-23 to 45 years	9606	Homo sapiens (human)	6763	23 to 45 years
-30 to 45 years	9606	Homo sapiens (human)	6764	30 to 45 years
-42 +/- 8.1 years	9606	Homo sapiens (human)	6765	42 ± 8.1 years
-6-37 years	9606	Homo sapiens (human)	6766	6-37 years
-18–48 years	9606	Homo sapiens (human)	6767	1848 years
-55.2 to 65.2 years	9606	Homo sapiens (human)	6768	55.2 to 65.2 years
-46-91 years	9606	Homo sapiens (human)	6769	46-91 years
-49 to 73 years	9606	Homo sapiens (human)	6770	49 to 73 years
-30 to 51 years	9606	Homo sapiens (human)	6771	30 to 51 years
-at least 2 months	10000206	Oryctolagus cuniculus New Zealand White	6772	at least 2 months
-16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6773	16 weeks
-18-38 years, with an average of 22 years	9606	Homo sapiens (human)	6774	18-38 years, with an average of 22 years
-6-8 weeks	10002278	Mus musculus Antibody Transgenic	6775	6-8 weeks
-26-51 years	9606	Homo sapiens (human)	6776	26-51 years
-29 to 71 years	9606	Homo sapiens (human)	6777	29 to 71 years
-1 to 18 years	9606	Homo sapiens (human)	6778	1 to 18 years
-10-12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6779	10-12 weeks
-14-71 years	9606	Homo sapiens (human)	6780	14-71 years
-10 days	9031	Gallus gallus (chicken)	6781	10 days
-47 +/- 4.5 years	9606	Homo sapiens (human)	6782	47 ± 4.5 years
-14 weeks	10000067	Mus musculus C57BL/6	6783	14 weeks
-7 to 41 years	9606	Homo sapiens (human)	6784	7 to 41 years
-1-39 years	9606	Homo sapiens (human)	6785	1-39 years
-15 months	9606	Homo sapiens (human)	6786	15 months
-14-50 years	9606	Homo sapiens (human)	6787	14-50 years
-20 to 66 years	9606	Homo sapiens (human)	6788	20 to 66 years
-18 to 54 years	9606	Homo sapiens (human)	6789	18 to 54 years
-49 to 63 years	9606	Homo sapiens (human)	6790	49 to 63 years
-33 to 71 years	9606	Homo sapiens (human)	6791	33 to 71 years
-29 to 73 years	9606	Homo sapiens (human)	6792	29 to 73 years
-3 to 4 weeks	10000915	Mus musculus Kunming	6793	3 to 4 weeks
-neonate	9544	Macaca mulatta (rhesus macaque)	6794	neonate
-18 months	10001406	Mus musculus MLR/lpr	6795	18 months
-adult	10000200	Oryctolagus cuniculus Chinchilla	6796	adult
-36.8 to 64 years	9606	Homo sapiens (human)	6797	36.8 to 64 years
-38.2 to 68 years	9606	Homo sapiens (human)	6798	38.2 to 68 years
-21.1 to 39.9 years	9606	Homo sapiens (human)	6799	21.1 to 39.9 years
-44.6 to 69.4 years	9606	Homo sapiens (human)	6800	44.6 to 69.4 years
-47-71 years	9606	Homo sapiens (human)	6801	47-71 years
-4 days	10090	Mus musculus (mouse)	6802	4 days
-41 to 77 years	9606	Homo sapiens (human)	6803	41 to 77 years
-54 to 74.6 years	9606	Homo sapiens (human)	6804	54 to 74.6 years
-51.6 to 77.2 years	9606	Homo sapiens (human)	6805	51.6 to 77.2 years
-28-56 years	9606	Homo sapiens (human)	6806	28-56 years
-27-56 years	9606	Homo sapiens (human)	6807	27-56 years
-10 week old	10000000	Mus musculus BALB/c	6808	10 week old
-9-10 weeks	10000629	Mus musculus ND4 Swiss Webster	6809	9-10 weeks
-10 weeks	10002257	Mus musculus Kymouse	6810	10 weeks
-32 to 69 years	9606	Homo sapiens (human)	6811	32 to 69 years
-9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6812	9 weeks
-12-58 years	9606	Homo sapiens (human)	6813	12-58 years
-16-38 years	9606	Homo sapiens (human)	6814	16-38 years
-1 year	9796	Equus caballus (domestic horse)	6815	1 year
-young	8835	Anas (ducks)	6816	young
-NULL	9837	Camelus bactrianus (camel)	6817	null
-40-48 years	9606	Homo sapiens (human)	6818	40-48 years
-21 to 30 years	9606	Homo sapiens (human)	6819	21 to 30 years
-6 - 58 years	9606	Homo sapiens (human)	6820	6 - 58 years
-15-40 years	9606	Homo sapiens (human)	6821	15-40 years
-12 to 16 weeks	10000064	Mus musculus C57BL/10.Q	6822	12 to 16 weeks
-6-8 months	10002034	Fish	6823	6-8 months
-3 months	9606	Homo sapiens (human)	6824	3 months
-14 - 66 years	9606	Homo sapiens (human)	6825	14 - 66 years
-25.4 to 52.4 years	9606	Homo sapiens (human)	6826	25.4 to 52.4 years
-51 and 66 years	9606	Homo sapiens (human)	6827	51 and 66 years
-9-90 years	9606	Homo sapiens (human)	6828	9-90 years
-adult	30538	Vicugna pacos (alpaca)	6829	adult
-21 weeks	9823	Sus scrofa (pig)	6830	21 weeks
-20 to 30 years	9606	Homo sapiens (human)	6831	20 to 30 years
-46-49 years	9606	Homo sapiens (human)	6832	46-49 years
-7 years	9844	Lama glama (llama)	6833	7 years
-32-54 years	9606	Homo sapiens (human)	6834	32-54 years
-8-15 weeks	10002378	Mus musculus SPRET/Ei	6835	8-15 weeks
-8-15 weeks	10000973	Mus musculus 129	6836	8-15 weeks
-30 to 40 years	9606	Homo sapiens (human)	6837	30 to 40 years
-1 month	10141	Cavia porcellus (guinea pig)	6838	1 month
-3.4 to 24.4 years	9606	Homo sapiens (human)	6839	3.4 to 24.4 years
-6 weeks	10000658	Rattus norvegicus Brown Norway	6840	6 weeks
-mean 6.6 years	9606	Homo sapiens (human)	6841	mean 6.6 years
-NULL	10002355	Bos taurus human immunoglobulin, bIGHMnull, bIGHML1 null, bIGL null	6842	null
-6 years	30538	Vicugna pacos (alpaca)	6843	6 years
-20 to 89 years	9606	Homo sapiens (human)	6844	20 to 89 years
-20-49 years	9606	Homo sapiens (human)	6845	20-49 years
-average age = 50 years	9606	Homo sapiens (human)	6846	average age = 50 years
-5-9 weeks	10000619	Mus musculus ICR X Swiss	6847	5-9 weeks
-born before 1968	9606	Homo sapiens (human)	6848	born before 1968
-7 days	9823	Sus scrofa (pig)	6849	7 days
-18 to 85 years	9606	Homo sapiens (human)	6850	18 to 85 years
-3-61 years	9606	Homo sapiens (human)	6851	3-61 years
-10-24 weeks	10000000	Mus musculus BALB/c	6852	10-24 weeks
-0.2 to 18 years	9685	Felis catus (cat)	6853	0.2 to 18 years
-0.3 to 12 years	9685	Felis catus (cat)	6854	0.3 to 12 years
-8-14 weeks	10000601	Mus musculus HLA-DR1 Tg	6855	8-14 weeks
-6 weeks old	10001438	Mus musculus BALB/cAnN	6856	6 weeks old
-NULL	9788	Equid (horse)	6857	null
-4-6 week	10000000	Mus musculus BALB/c	6858	4-6 week
-29-87 years	9606	Homo sapiens (human)	6859	29-87 years
-6 to 15 weeks	10000067	Mus musculus C57BL/6	6860	6 to 15 weeks
-mean age = 71.3 years	9606	Homo sapiens (human)	6861	mean age = 71.3 years
-mean age = 68.3 years	9606	Homo sapiens (human)	6862	mean age = 68.3 years
-mean age = 66.3 years	9606	Homo sapiens (human)	6863	mean age = 66.3 years
-mean age = 60.1 years	9606	Homo sapiens (human)	6864	mean age = 60.1 years
-9.9-17 years	9541	Macaca fascicularis (crab eating macaque)	6865	9.9-17 years
-4 to 6 weeks old	10000000	Mus musculus BALB/c	6866	4 to 6 weeks old
-28 weeks	10000067	Mus musculus C57BL/6	6867	28 weeks
-3 months	9031	Gallus gallus (chicken)	6868	3 months
-50-86 years	9606	Homo sapiens (human)	6869	50-86 years
-4-49 years	9606	Homo sapiens (human)	6870	4-49 years
-50-71 years	9606	Homo sapiens (human)	6871	50-71 years
-26-54 years	9606	Homo sapiens (human)	6872	26-54 years
->56 years	9606	Homo sapiens (human)	6873	>56 years
-10 weeks	10001998	Mus musculus CD1	6874	10 weeks
-7-9 weeks	10001998	Mus musculus CD1	6875	7-9 weeks
-28-91 years	9606	Homo sapiens (human)	6876	28-91 years
-mean = 48 years	9606	Homo sapiens (human)	6877	mean = 48 years
-68.5 +/- 16.4 years	9606	Homo sapiens (human)	6878	68.5 ± 16.4 years
-53-85 years	9606	Homo sapiens (human)	6879	53-85 years
-10 to 72 years	9606	Homo sapiens (human)	6880	10 to 72 years
-6 months	9823	Sus scrofa (pig)	6881	6 months
-Mean age = 47.1 years	9606	Homo sapiens (human)	6882	mean age = 47.1 years
-34-79 years	9606	Homo sapiens (human)	6883	34-79 years
-38-60 years	9606	Homo sapiens (human)	6884	38-60 years
-22-87 years	9606	Homo sapiens (human)	6885	22-87 years
-28-75 years	9606	Homo sapiens (human)	6886	28-75 years
-62-91 years	9606	Homo sapiens (human)	6887	62-91 years
-2-23 years	9606	Homo sapiens (human)	6888	2-23 years
-10 to 66 years	9606	Homo sapiens (human)	6889	10 to 66 years
-NULL	70699	unidentified monkey	6890	null
-3-4 years	9534	Chlorocebus aethiops (African green monkey)	6891	3-4 years
-6 months	10000067	Mus musculus C57BL/6	6892	6 months
-6 weeks	10000629	Mus musculus ND4 Swiss Webster	6893	6 weeks
-27-77 years	9606	Homo sapiens (human)	6894	27-77 years
-28 to 53 years	9606	Homo sapiens (human)	6895	28 to 53 years
-7-9weeks	10000067	Mus musculus C57BL/6	6896	7-9weeks
-5 weeks	10000206	Oryctolagus cuniculus New Zealand White	6897	5 weeks
-1-9 years	9606	Homo sapiens (human)	6898	1-9 years
-2-7 years	9606	Homo sapiens (human)	6899	2-7 years
-72-86 years	9606	Homo sapiens (human)	6900	72-86 years
-71-87 years	9606	Homo sapiens (human)	6901	71-87 years
-8-18 years	9606	Homo sapiens (human)	6902	8-18 years
-1-6 years	9606	Homo sapiens (human)	6903	1-6 years
-9 months	10000193	Bos taurus Holstein	6904	9 months
-Over 50 years	9606	Homo sapiens (human)	6905	over 50 years
-17 to 39 years	9606	Homo sapiens (human)	6906	17 to 39 years
-1.5 months to 40 years	9606	Homo sapiens (human)	6907	1.5 months to 40 years
-12 to 60 months	9606	Homo sapiens (human)	6908	12 to 60 months
-17 to 30 years	9606	Homo sapiens (human)	6909	17 to 30 years
-17 months - 4 years	9606	Homo sapiens (human)	6910	17 months - 4 years
-22 to 81 years	9606	Homo sapiens (human)	6911	22 to 81 years
-0-9 years	9606	Homo sapiens (human)	6912	0-9 years
-6-15 years	9541	Macaca fascicularis (crab eating macaque)	6913	6-15 years
-10-weeks	10000000	Mus musculus BALB/c	6914	10-weeks
-6 weeks	10001406	Mus musculus MLR/lpr	6915	6 weeks
-NULL	10001601	Mus musculus C57BL/6 X 129	6916	null
-4 to 8 weeks	10000067	Mus musculus C57BL/6	6917	4 to 8 weeks
-31 to 48 years	9606	Homo sapiens (human)	6918	31 to 48 years
-5-6 weeks	10001438	Mus musculus BALB/cAnN	6919	5-6 weeks
-40-63 years	9606	Homo sapiens (human)	6920	40-63 years
-22 to 69 years	9606	Homo sapiens (human)	6921	22 to 69 years
-6-46 years	9606	Homo sapiens (human)	6922	6-46 years
-14-54 years	9606	Homo sapiens (human)	6923	14-54 years
-39-77 years	9606	Homo sapiens (human)	6924	39-77 years
-16 to 18 years	9606	Homo sapiens (human)	6925	16 to 18 years
-3 years	9837	Camelus bactrianus (camel)	6926	3 years
-30-68 years	9606	Homo sapiens (human)	6927	30-68 years
-50 to 71 years	9606	Homo sapiens (human)	6928	50 to 71 years
-3 months to 15 years	9606	Homo sapiens (human)	6929	3 months to 15 years
-5 to 9 months	9606	Homo sapiens (human)	6930	5 to 9 months
-7 months to 10 years	9606	Homo sapiens (human)	6931	7 months to 10 years
-8 weeks	10000002	Mus musculus BALB/c beta2m null	6932	8 weeks
-23-84 years	9606	Homo sapiens (human)	6933	23-84 years
-NULL	10002275	Sus scrofa Duroc X Yorkshire X Hampshire	6934	null
-16 to 41 years	9606	Homo sapiens (human)	6935	16 to 41 years
-Young adult	9606	Homo sapiens (human)	6936	young adult
-34-96 years	9606	Homo sapiens (human)	6937	34-96 years
-NULL	36176	Chiloscyllium plagiosum (whitespotted bambooshark)	6938	null
-29-96 years	9606	Homo sapiens (human)	6939	29-96 years
-15-48 years	9606	Homo sapiens (human)	6940	15-48 years
-18 to 55 years	9544	Macaca mulatta (rhesus macaque)	6941	18 to 55 years
-7-39 years	9606	Homo sapiens (human)	6942	7-39 years
-21 to 72 years	9606	Homo sapiens (human)	6943	21 to 72 years
-4-11 months	9606	Homo sapiens (human)	6944	4-11 months
-NULL	30522	Bos indicus x Bos taurus (hybrid cow)	6945	null
-NULL	9915	Bos indicus (Indicine cattle)	6946	null
-<5 years	9606	Homo sapiens (human)	6947	<5 years
-40 to 41 years	9606	Homo sapiens (human)	6948	40 to 41 years
-13-84 years	9606	Homo sapiens (human)	6949	13-84 years
-76.9-80.3 years	9606	Homo sapiens (human)	6950	76.9-80.3 years
-49- 55.6 years	9606	Homo sapiens (human)	6951	49- 55.6 years
-25 weeks	10000920	Gallus gallus Leghorn	6952	25 weeks
-mean 38 years	9606	Homo sapiens (human)	6953	mean 38 years
-9-44 years	9606	Homo sapiens (human)	6954	9-44 years
-mean 11 years	9606	Homo sapiens (human)	6955	mean 11 years
-mean 13. 8 years	9606	Homo sapiens (human)	6956	mean 13. 8 years
-30-66 years	9606	Homo sapiens (human)	6957	30-66 years
-31-59 years	9606	Homo sapiens (human)	6958	31-59 years
-21-61 years	9606	Homo sapiens (human)	6959	21-61 years
-28-60 years	9606	Homo sapiens (human)	6960	28-60 years
-17 to 71 years	9606	Homo sapiens (human)	6961	17 to 71 years
-24 to 65 yesrs	9606	Homo sapiens (human)	6962	24 to 65 years
-mean 30 years	9606	Homo sapiens (human)	6963	mean 30 years
-26-85 years	9606	Homo sapiens (human)	6964	26-85 years
-31-45 years	9606	Homo sapiens (human)	6965	31-45 years
-7 - 8 weeks	10000067	Mus musculus C57BL/6	6966	7 - 8 weeks
-NULL	10002503	Sus scrofa Duroc X Large White X Landrace	6967	null
-6 to 16 years	9606	Homo sapiens (human)	6968	6 to 16 years
-12 months	9940	Ovis aries (domestic sheep)	6969	12 months
-35 to 52 years	9606	Homo sapiens (human)	6970	35 to 52 years
-29-63 years	9606	Homo sapiens (human)	6971	29-63 years
-25 to 70 years	9606	Homo sapiens (human)	6972	25 to 70 years
-35-72 years	9606	Homo sapiens (human)	6973	35-72 years
-4-6 months	9913	Bos taurus (bovine)	6974	4-6 months
-29 to 81 years	9606	Homo sapiens (human)	6975	29 to 81 years
-59 to 72 years	9606	Homo sapiens (human)	6976	59 to 72 years
-8 months	10000206	Oryctolagus cuniculus New Zealand White	6977	8 months
-10-16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6978	10-16 weeks
-18-83 years	9606	Homo sapiens (human)	6979	18-83 years
-8-12 weeks	10114	Rattus (rat)	6980	8-12 weeks
-NULL	8128	Oreochromis niloticus (Nile tilapia)	6981	null
-35-87 years	9606	Homo sapiens (human)	6982	35-87 years
-5 to 6 weeks	10000667	Rattus norvegicus Sprague-Dawley	6983	5 to 6 weeks
-22-34.5 years	9606	Homo sapiens (human)	6984	22-34.5 years
-23-37.5 years	9606	Homo sapiens (human)	6985	23-37.5 years
-4-78 years	9606	Homo sapiens (human)	6986	4-78 years
-15 to 76 years	9606	Homo sapiens (human)	6987	15 to 76 years
-31-65 years	9606	Homo sapiens (human)	6988	31-65 years
-2-3 months	10000206	Oryctolagus cuniculus New Zealand White	6989	2-3 months
-average age = 43.6 years	9606	Homo sapiens (human)	6990	average age = 43.6 years
-average age = 44.8 years	9606	Homo sapiens (human)	6991	average age = 44.8 years
-8 to 10 weeks	10001306	Mus musculus KRN TCR Tg	6992	8 to 10 weeks
-NULL	42716	Didelphis albiventris (white-eared opossum)	6993	null
-6 weeks	10002278	Mus musculus Antibody Transgenic	6994	6 weeks
-NULL	10041	Peromyscus leucopus (white-footed mouse)	6995	null
-17-68 years	9606	Homo sapiens (human)	6996	17-68 years
-19 to 45 years	9606	Homo sapiens (human)	6997	19 to 45 years
-36- 57 years	9606	Homo sapiens (human)	6998	36- 57 years
-32 to 73 years	9606	Homo sapiens (human)	6999	32 to 73 years
-13 week	9823	Sus scrofa (pig)	7000	13 week
-55-86 years	9606	Homo sapiens (human)	7001	55-86 years
-1 month - 4 years	9606	Homo sapiens (human)	7002	1 month - 4 years
-20-89 years	9606	Homo sapiens (human)	7003	20-89 years
-<21 years	9606	Homo sapiens (human)	7004	<21 years
-median 54 years	9606	Homo sapiens (human)	7005	median 54 years
-median 55 years	9606	Homo sapiens (human)	7006	median 55 years
-6-17 years	9606	Homo sapiens (human)	7007	6-17 years
-NULL	10002411	Gallus gallus SynVH	7008	null
-7-8 weeks	10001487	Mus musculus Apolipoprotein E null	7009	7-8 weeks
-0-77 years	9606	Homo sapiens (human)	7010	0-77 years
-9-17 years	9606	Homo sapiens (human)	7011	9-17 years
-6-18 years	9606	Homo sapiens (human)	7012	6-18 years
-NULL	10088	Mus <genus> (mice)	7013	null
-31 to 32 years	9606	Homo sapiens (human)	7014	31 to 32 years
-3 months to 25 years	9606	Homo sapiens (human)	7015	3 months to 25 years
->/= 15 years	9606	Homo sapiens (human)	7016	>/= 15 years
-49-80.3 years	9606	Homo sapiens (human)	7017	49-80.3 years
-6-10 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	7018	6-10 weeks
-1.5 years	9837	Camelus bactrianus (camel)	7019	1.5 years
-8-16 years	9606	Homo sapiens (human)	7020	8-16 years
-9 months	9925	Capra hircus (domestic goat)	7021	9 months
-median 48 years	9606	Homo sapiens (human)	7022	median 48 years
-median 50 years	9606	Homo sapiens (human)	7023	median 50 years
-6-weeks	10000000	Mus musculus BALB/c	7024	6-weeks
-35.3 to 54.3 years	9606	Homo sapiens (human)	7025	35.3 to 54.3 years
-48.5 to 61.2 years	9606	Homo sapiens (human)	7026	48.5 to 61.2 years
-NULL	9845	Ruminant	7027	null
-25-76 years	9606	Homo sapiens (human)	7028	25-76 years
-4-6 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	7029	4-6 weeks
-55-70 years	9606	Homo sapiens (human)	7030	55-70 years
-4 to 6 weeks	10000206	Oryctolagus cuniculus New Zealand White	7031	4 to 6 weeks
-21 to 76 years	9606	Homo sapiens (human)	7032	21 to 76 years
-4-6 weeks	10000206	Oryctolagus cuniculus New Zealand White	7033	4-6 weeks
-6-8 weeks	10000624	Mus musculus MF1	7034	6-8 weeks
-16-83 years	9606	Homo sapiens (human)	7035	16-83 years
-33 to 83 years	9606	Homo sapiens (human)	7036	33 to 83 years
-24 to 28 years	9606	Homo sapiens (human)	7037	24 to 28 years
-0- 59 years	9606	Homo sapiens (human)	7038	0- 59 years
-40-70 years	9606	Homo sapiens (human)	7039	40-70 years
-4-86 years	9606	Homo sapiens (human)	7040	4-86 years
-3-5 years	9544	Macaca mulatta (rhesus macaque)	7041	3-5 years
-36 to 70 years	9606	Homo sapiens (human)	7042	36 to 70 years
-15-42 years	9606	Homo sapiens (human)	7043	15-42 years
-5-37 years	9606	Homo sapiens (human)	7044	5-37 years
-44-83 years	9606	Homo sapiens (human)	7045	44-83 years
-22-74 years	9606	Homo sapiens (human)	7046	22-74 years
-mean 63.87 years	9606	Homo sapiens (human)	7047	mean 63.87 years
-1-3 years	9685	Felis catus (cat)	7048	1-3 years
-3-9 years	9544	Macaca mulatta (rhesus macaque)	7049	3-9 years
-8-9 years	9606	Homo sapiens (human)	7050	8-9 years
-38 to 64 years	9606	Homo sapiens (human)	7051	38 to 64 years
-5 weeks	10001998	Mus musculus CD1	7052	5 weeks
-2-45 years	9606	Homo sapiens (human)	7053	2-45 years
-5-6 weeks	10000667	Rattus norvegicus Sprague-Dawley	7054	5-6 weeks
-10-13 years	9606	Homo sapiens (human)	7055	10-13 years
-mean 55.4 years	9606	Homo sapiens (human)	7056	mean 55.4 years
-3-9 years	9606	Homo sapiens (human)	7057	3-9 years
-5 years	9544	Macaca mulatta (rhesus macaque)	7058	5 years
-mean 53.4 years	9606	Homo sapiens (human)	7059	mean 53.4 years
-9-49 years	9606	Homo sapiens (human)	7060	9-49 years
-mean 59 years	9606	Homo sapiens (human)	7061	mean 59 years
-8 weeks	10000218	Mus musculus C57BL/6 X C3H	7062	8 weeks
-6-8 weeks	10116	Rattus norvegicus (brown rat)	7063	6-8 weeks
-19-87 years	9606	Homo sapiens (human)	7064	19-87 years
-6-8 months	9825	Sus scrofa domesticus (domestic pig)	7065	6-8 months
-11 weeks	10000667	Rattus norvegicus Sprague-Dawley	7066	11 weeks
-11-83 years	9606	Homo sapiens (human)	7067	11-83 years
-1-7 years	9913	Bos taurus (bovine)	7068	1-7 years
-6 to 32 years	9606	Homo sapiens (human)	7069	6 to 32 years
-1 year old	9940	Ovis aries (domestic sheep)	7070	1 year old
-1 year old	9986	Oryctolagus cuniculus (rabbit)	7071	1 year old
-7 to 55 years	9606	Homo sapiens (human)	7072	7 to 55 years
-7 to 36 years	9606	Homo sapiens (human)	7073	7 to 36 years
-NULL	10002784	sus scrofa TLRI Black Pig No.1	7074	null
-4-5 weeks	10000019	Mus musculus BALB/cByJ	7075	4-5 weeks
-9-12 weeks	10001470	Mus musculus Factor VIII null	7076	9-12 weeks
-12-88 years	9606	Homo sapiens (human)	7077	12-88 years
-5- 55 years	9606	Homo sapiens (human)	7078	5- 55 years
-40 to 72 years	9606	Homo sapiens (human)	7079	40 to 72 years
-NULL	10001737	Mus musculus B6.P	7080	null
-12-43 years	9606	Homo sapiens (human)	7081	12-43 years
-NULL	10001678	Mus musculus B10 X 129	7082	null
-37-70 years	9606	Homo sapiens (human)	7083	37-70 years
-4 days - 9 months	9606	Homo sapiens (human)	7084	4 days - 9 months
-2 weeks	10000662	Rattus norvegicus Lewis	7085	2 weeks
-26-41 years	9606	Homo sapiens (human)	7086	26-41 years
-8-20 weeks	10002058	B6.ERAAP null	7087	8-20 weeks
-middle-aged	9606	Homo sapiens (human)	7088	middle-aged
-25-73 years	9606	Homo sapiens (human)	7089	25-73 years
-NULL	10029	Cricetulus griseus (Chinese hamsters)	7090	null
-12 to 51 years	9606	Homo sapiens (human)	7091	12 to 51 years
-37 to 70 years	9606	Homo sapiens (human)	7092	37 to 70 years
-7 months	9606	Homo sapiens (human)	7093	7 months
-6 months to 5 years	9606	Homo sapiens (human)	7094	6 months to 5 years
-60-64 years	9606	Homo sapiens (human)	7095	60-64 years
-NULL	10000034	Mus musculus C3H/An	7096	null
-NULL	9305	Sarcophilus harrisii (Tasmanian devil)	7097	null
-5 months to 5 years	9606	Homo sapiens (human)	7098	5 months to 5 years
-6 months to 15 years	9606	Homo sapiens (human)	7099	6 months to 15 years
-NULL	10002058	B6.ERAAP null	7100	null
-neonatal	9606	Homo sapiens (human)	7101	neonatal
-young and old	10116	Rattus norvegicus (brown rat)	7102	young and old
-old	10116	Rattus norvegicus (brown rat)	7103	old
-7-8 weeks	10090	Mus musculus (mouse)	7104	7-8 weeks
-NULL	10000108	Mus musculus C57BL/6 X B10.D2	7105	null
-NULL	9402	Pteropus alecto (black flying fox)	7106	null
-5-8 weeks	10000062	Mus musculus FVB/J	7107	5-8 weeks
-7-11 weeks	10000067	Mus musculus C57BL/6	7108	7-11 weeks
-10 years	9615	Canis lupus familiaris (dogs)	7109	10 years
-1 year	9606	Homo sapiens (human)	7110	1 year
-55-85 years	9606	Homo sapiens (human)	7111	55-85 years
-55-74	9606	Homo sapiens (human)	7112	55-74
-25 to 87 years	9606	Homo sapiens (human)	7113	25 to 87 years
-NULL	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	7114	null
-80 years old	9606	Homo sapiens (human)	7115	80 years old
-8 to 10 weeks	10001122	Mus musculus µMT	7116	8 to 10 weeks
-59	9606	Homo sapiens (human)	7117	59
-51 years old	9606	Homo sapiens (human)	7118	51 years old
-64 years old	9606	Homo sapiens (human)	7119	64 years old
-60 years old	9606	Homo sapiens (human)	7120	60 years old
-Fetus	9606	Homo sapiens (human)	7121	fetus
-75	9606	Homo sapiens (human)	7122	75
-76	9606	Homo sapiens (human)	7123	76
-78	9606	Homo sapiens (human)	7124	78
-80	9606	Homo sapiens (human)	7125	80
-81	9606	Homo sapiens (human)	7126	81
-82	9606	Homo sapiens (human)	7127	82
-84	9606	Homo sapiens (human)	7128	84
-85	9606	Homo sapiens (human)	7129	85
-86	9606	Homo sapiens (human)	7130	86
-87	9606	Homo sapiens (human)	7131	87
-88	9606	Homo sapiens (human)	7132	88
-89	9606	Homo sapiens (human)	7133	89
-90	9606	Homo sapiens (human)	7134	90
-91	9606	Homo sapiens (human)	7135	91
-92	9606	Homo sapiens (human)	7136	92
-93	9606	Homo sapiens (human)	7137	93
-94	9606	Homo sapiens (human)	7138	94
-95	9606	Homo sapiens (human)	7139	95
-96	9606	Homo sapiens (human)	7140	96
-97	9606	Homo sapiens (human)	7141	97
-98	9606	Homo sapiens (human)	7142	98
-99	9606	Homo sapiens (human)	7143	99
-100	9606	Homo sapiens (human)	7144	100
-101	9606	Homo sapiens (human)	7145	101
-37-91 years old	9606	Homo sapiens (human)	7146	37-91 years old
-35-87 years old	9606	Homo sapiens (human)	7147	35-87 years old
-31-88 years old	9606	Homo sapiens (human)	7148	31-88 years old
-22-49 years	9606	Homo sapiens (human)	7149	22-49 years
-8-20 weeks	10000632	Mus musculus NOD	7150	8-20 weeks
+h_age	h_organism_id	h_organism_name	index	normalized_h_age	normalized_h_age_style=age
+6-8 weeks old	10000067	Mus musculus C57BL/6	0	6-8 week old	6-8 week
+NULL	9606	Homo sapiens (human)	1	null	null
+6-8 weeks old	10000000	Mus musculus BALB/c	2	6-8 week old	6-8 week
+8 weeks	10000047	Mus musculus C57BL/10	3	8 week	8 week
+49 years old	10000119	Homo sapiens Caucasian	4	49 year old	49 year
+51 years old	10000119	Homo sapiens Caucasian	5	51 year old	51 year
+NULL	10000067	Mus musculus C57BL/6	6	null	null
+NULL	9598	Pan troglodytes (chimpanzee)	7	null	null
+8-16 weeks	10000000	Mus musculus BALB/c	8	8-16 week	8-16 week
+6-8 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	9	6-8 week old	6-8 week
+6-10 weeks old	10000000	Mus musculus BALB/c	10	6-10 week old	6-10 week
+4-16 years old	9606	Homo sapiens (human)	11	4-16 year old	4-16 year
+32-62 years	9606	Homo sapiens (human)	12	32-62 year	32-62 year
+32-38 years	9606	Homo sapiens (human)	13	32-38 year	32-38 year
+2-54 years	9606	Homo sapiens (human)	14	2-54 year	2-54 year
+3-8 years	9606	Homo sapiens (human)	15	3-8 year	3-8 year
+6-10 wk	10000047	Mus musculus C57BL/10	16	6-10 week	6-10 week
+24 years	9606	Homo sapiens (human)	17	24 year	24 year
+6-12 weeks-old	10000219	Mus musculus C57BL/6 X CBA	18	6-12 week-old	6-12 week
+29-38	9606	Homo sapiens (human)	19	29-38	29-38
+NULL	10090	Mus musculus (mouse)	20	null	null
+12-65 years old	9606	Homo sapiens (human)	21	12-65 year old	12-65 year
+6-8 weeks	10000067	Mus musculus C57BL/6	22	6-8 week	6-8 week
+6-12 weeks	10000067	Mus musculus C57BL/6	23	6-12 week	6-12 week
+8-10 weeks	10000000	Mus musculus BALB/c	24	8-10 week	8-10 week
+8-10 weeks	10000067	Mus musculus C57BL/6	25	8-10 week	8-10 week
+45 years	9606	Homo sapiens (human)	26	45 year	45 year
+10-15 weeks	10000276	Mus musculus B10.S	27	10-15 week	10-15 week
+6-10 weeks	10001019	Mus musculus B10.D2	28	6-10 week	6-10 week
+6-10 weeks	10000647	Mus musculus Quackenbush	29	6-10 week	6-10 week
+NULL	10000607	Mus musculus HLA-DR3 Tg	30	null	null
+8 weeks	10000000	Mus musculus BALB/c	31	8 week	8 week
+6-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	32	6-8 week	6-8 week
+6-8 weeks	10000271	Mus musculus B10.M	33	6-8 week	6-8 week
+Adults (pregnant)	9606	Homo sapiens (human)	34	adults (pregnant)	adults (pregnant)
+6-8 weeks	10000253	Mus musculus A/J	35	6-8 week	6-8 week
+Adults	9606	Homo sapiens (human)	36	adults	adults
+26-72 years-old	9606	Homo sapiens (human)	37	26-72 year-old	26-72 year
+4-6 weeks old	10000000	Mus musculus BALB/c	38	4-6 week old	4-6 week
+20-55 years	9606	Homo sapiens (human)	39	20-55 year	20-55 year
+55-69 years	9606	Homo sapiens (human)	40	55-69 year	55-69 year
+2-4 months old	10000000	Mus musculus BALB/c	41	2-4 month old	2-4 month
+2-4 months old	10000067	Mus musculus C57BL/6	42	2-4 month old	2-4 month
+NULL	10000601	Mus musculus HLA-DR1 Tg	43	null	null
+NULL	10000598	Mus musculus HLA-DQ8 Tg	44	null	null
+33-52 years-old	9606	Homo sapiens (human)	45	33-52 year-old	33-52 year
+26-45 years	9606	Homo sapiens (human)	46	26-45 year	26-45 year
+7-74 years old	9606	Homo sapiens (human)	47	7-74 year old	7-74 year
+6-8 weeks	10000038	Mus musculus C3H/He	48	6-8 week	6-8 week
+21-45 years old	9606	Homo sapiens (human)	49	21-45 year old	21-45 year
+8-24 weeks old	10000067	Mus musculus C57BL/6	50	8-24 week old	8-24 week
+NULL	10000047	Mus musculus C57BL/10	51	null	null
+NULL	10000094	Mus musculus C57BL/6 IAbeta null	52	null	null
+NULL	10000188	Sus scrofa NIH miniature pig	53	null	null
+average age 29.8 years	9606	Homo sapiens (human)	54	average age 29.8 year	average age 29.8 year
+18-91 years	9606	Homo sapiens (human)	55	18-91 year	18-91 year
+NULL	10000645	Mus musculus PrP null	56	null	null
+6-10 weeks	10000263	Mus musculus B10.BR	57	6-10 week	6-10 week
+6-10 weeks	10000000	Mus musculus BALB/c	58	6-10 week	6-10 week
+29-58 years	9606	Homo sapiens (human)	59	29-58 year	29-58 year
+NULL	10000000	Mus musculus BALB/c	60	null	null
+NULL	10000649	Mus musculus SJL	61	null	null
+26-38 years	9606	Homo sapiens (human)	62	26-38 year	26-38 year
+30-52 years-old	9606	Homo sapiens (human)	63	30-52 year-old	30-52 year
+32- 53.5 years	9606	Homo sapiens (human)	64	32- 53.5 year	32- 53.5 year
+NULL	9534	Chlorocebus aethiops (African green monkey)	65	null	null
+NULL	10000575	Mus musculus HBV(adr) transgenic BALB/c	66	null	null
+32-74 years old	9606	Homo sapiens (human)	67	32-74 year old	32-74 year
+6-10 weeks-old	10000038	Mus musculus C3H/He	68	6-10 week-old	6-10 week
+NULL	10000582	Mus musculus HLA-A2 Tg	69	null	null
+NULL	10000670	Cavia porcellus Ssc:AL	70	null	null
+8-week-old	10000067	Mus musculus C57BL/6	71	8-week-old	8 week
+6 weeks	10000038	Mus musculus C3H/He	72	6 week	6 week
+44 years	9606	Homo sapiens (human)	73	44 year	44 year
+8-12 weeks	10000263	Mus musculus B10.BR	74	8-12 week	8-12 week
+31-39	9606	Homo sapiens (human)	75	31-39	31-39
+7-8 weeks	10000649	Mus musculus SJL	76	7-8 week	7-8 week
+Adults (40 year-old average)	9606	Homo sapiens (human)	77	adults (40 year-old average)	adults (40 year average)
+6 weeks	10000000	Mus musculus BALB/c	78	6 week	6 week
+NULL	10000276	Mus musculus B10.S	79	null	null
+6-10 wk	10000271	Mus musculus B10.M	80	6-10 week	6-10 week
+Children and Adults	9606	Homo sapiens (human)	81	children and adults	children and adults
+6-8 weeks old	10000030	Mus musculus C3H.JK	82	6-8 week old	6-8 week
+NULL	10000119	Homo sapiens Caucasian	83	null	null
+6-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	84	6-8 week	6-8 week
+6-8 weeks	10000228	Mus musculus CBA	85	6-8 week	6-8 week
+NULL	10001537	Mus musculus PL	86	null	null
+6-10 weeks-old	10000000	Mus musculus BALB/c	87	6-10 week-old	6-10 week
+NULL	10000275	Mus musculus B10.RIII	88	null	null
+NULL	10000640	Mus musculus NZW	89	null	null
+Adults and children	9606	Homo sapiens (human)	90	adults and children	adults and children
+20 years old	9606	Homo sapiens (human)	91	20 year old	20 year
+29-41 years	9606	Homo sapiens (human)	92	29-41 year	29-41 year
+1-48 months-old	9606	Homo sapiens (human)	93	1-48 month-old	1-48 month
+8-12 weeks-old	10000067	Mus musculus C57BL/6	94	8-12 week-old	8-12 week
+6-8 weeks	10000000	Mus musculus BALB/c	95	6-8 week	6-8 week
+Adult	9606	Homo sapiens (human)	96	adult	adult
+NULL	9913	Bos taurus (bovine)	97	null	null
+15 weeks	10000600	Mus musculus HLA-DR Transgenic	98	15 week	15 week
+4-6 weeks	10000000	Mus musculus BALB/c	99	4-6 week	4-6 week
+6-10 weeks	10000067	Mus musculus C57BL/6	100	6-10 week	6-10 week
+6 to 8 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	101	6 to 8 week	6 to 8 week
+59 years	9606	Homo sapiens (human)	102	59 year	59 year
+8-12 weeks	10000236	Mus musculus CBA/J	103	8-12 week	8-12 week
+8-12 weeks	10000649	Mus musculus SJL	104	8-12 week	8-12 week
+8-12 weeks	10000000	Mus musculus BALB/c	105	8-12 week	8-12 week
+25-58 years old	9606	Homo sapiens (human)	106	25-58 year old	25-58 year
+NULL	10000233	Mus musculus CBA/Ca	107	null	null
+6 weeks-old	10000233	Mus musculus CBA/Ca	108	6 week-old	6 week
+6-8 weeks old	10000047	Mus musculus C57BL/10	109	6-8 week old	6-8 week
+14-65 years old	9606	Homo sapiens (human)	110	14-65 year old	14-65 year
+7-8 weeks	10000000	Mus musculus BALB/c	111	7-8 week	7-8 week
+31-58 years	9606	Homo sapiens (human)	112	31-58 year	31-58 year
+6-10 wk	10000273	Mus musculus B10.P	113	6-10 week	6-10 week
+6-9 weeks	10000067	Mus musculus C57BL/6	114	6-9 week	6-9 week
+36-70 years-old	9606	Homo sapiens (human)	115	36-70 year-old	36-70 year
+18-45 years	9606	Homo sapiens (human)	116	18-45 year	18-45 year
+6-10 weeks-old	10000063	Mus musculus B10.A	117	6-10 week-old	6-10 week
+8-11 wk	10000000	Mus musculus BALB/c	118	8-11 week	8-11 week
+24-75 years old	9606	Homo sapiens (human)	119	24-75 year old	24-75 year
+6-10 wk	10000066	Mus musculus C57BL/1Flu NP(328-498) Tg	120	6-10 week	6-10 week
+6-8 weeks old	10000263	Mus musculus B10.BR	121	6-8 week old	6-8 week
+2-8 months	10000067	Mus musculus C57BL/6	122	2-8 month	2-8 month
+6 to 8 weeks	10000067	Mus musculus C57BL/6	123	6 to 8 week	6 to 8 week
+5 weeks	10000000	Mus musculus BALB/c	124	5 week	5 week
+Adult	10000196	Ovis aries Finnish Landrace	125	adult	adult
+9-86 years	9606	Homo sapiens (human)	126	9-86 year	9-86 year
+19-74 years-old	9606	Homo sapiens (human)	127	19-74 year-old	19-74 year
+18-30 years old	9606	Homo sapiens (human)	128	18-30 year old	18-30 year
+NULL	10000190	Bos taurus Friesian	129	null	null
+5-6 weeks	10000067	Mus musculus C57BL/6	130	5-6 week	5-6 week
+12-16 weeks	10000021	Mus musculus BALB/c-H2dm2	131	12-16 week	12-16 week
+12-16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	132	12-16 week	12-16 week
+5-7 weeks	10000000	Mus musculus BALB/c	133	5-7 week	5-7 week
+73	9606	Homo sapiens (human)	134	73	73
+6-8 wk	10000067	Mus musculus C57BL/6	135	6-8 week	6-8 week
+NULL	10000642	Mus musculus Outbred	136	null	null
+7-10 weeks-old	10000576	Mus musculus HLA-A*02:01 Tg	137	7-10 week-old	7-10 week
+1-9 years-old	9606	Homo sapiens (human)	138	1-9 year-old	1-9 year
+18-75 years	9606	Homo sapiens (human)	139	18-75 year	18-75 year
+4-16 weeks	10000061	Mus musculus FVB	140	4-16 week	4-16 week
+11 or 18 weeks	10000025	Mus musculus Biozzi AB/H	141	11 or 18 week	11 or 18 week
+15-73 years-old	9606	Homo sapiens (human)	142	15-73 year-old	15-73 year
+8-16 wk	10000007	Mus musculus 6.5 TCR Tg	143	8-16 week	8-16 week
+6-8 weeks	10000660	Rattus norvegicus Fischer	144	6-8 week	6-8 week
+NULL	10000668	Cavia porcellus Duncan-Hartley	145	null	null
+NULL	10001980	Mus musculus Ob.1A12 TCR Tg	146	null	null
+7-79	9606	Homo sapiens (human)	147	7-79	7-79
+20-29 years	9606	Homo sapiens (human)	148	20-29 year	20-29 year
+Adult	10000119	Homo sapiens Caucasian	149	adult	adult
+NULL	10000228	Mus musculus CBA	150	null	null
+6-8 weeks	10000653	Mus musculus Swiss	151	6-8 week	6-8 week
+5, 11 or 18 weeks	10000632	Mus musculus NOD	152	5, 11 or 18 week	5, 11 or 18 week
+35 to 40 days	10000607	Mus musculus HLA-DR3 Tg	153	35 to 40 days	35 to 40 days
+8-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	154	8-12 week	8-12 week
+6-10 weeks-old	10000067	Mus musculus C57BL/6	155	6-10 week-old	6-10 week
+4-24 months	10000188	Sus scrofa NIH miniature pig	156	4-24 month	4-24 month
+NULL	10000271	Mus musculus B10.M	157	null	null
+NULL	10000263	Mus musculus B10.BR	158	null	null
+8-12 weeks	10090	Mus musculus (mouse)	159	8-12 week	8-12 week
+6-8 weeks	10000263	Mus musculus B10.BR	160	6-8 week	6-8 week
+6-8 weeks	10000051	Mus musculus C57BL/10 X DBA/2	161	6-8 week	6-8 week
+18 years	9606	Homo sapiens (human)	162	18 year	18 year
+61 years	9606	Homo sapiens (human)	163	61 year	61 year
+NULL	9504	Aotus (night monkey)	164	null	null
+18 to 65 years	9606	Homo sapiens (human)	165	18 to 65 year	18 to 65 year
+8-12 weeks	10000067	Mus musculus C57BL/6	166	8-12 week	8-12 week
+18-59 years	9606	Homo sapiens (human)	167	18-59 year	18-59 year
+6-10 weeks	10000610	Mus musculus HLA-DR4 Tg	168	6-10 week	6-10 week
+8-14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	169	8-14 week	8-14 week
+4-6 weeks-old	10000000	Mus musculus BALB/c	170	4-6 week-old	4-6 week
+> 18 years	9606	Homo sapiens (human)	171	> 18 year	> 18 year
+30-60 years	9606	Homo sapiens (human)	172	30-60 year	30-60 year
+6-12 weeks	10000028	Mus musculus C3H	173	6-12 week	6-12 week
+6 months	10001405	Mus musculus NZB X NZW	174	6 month	6 month
+6-8 wk old	10000576	Mus musculus HLA-A*02:01 Tg	175	6-8 week old	6-8 week
+8-10 weeks	10000253	Mus musculus A/J	176	8-10 week	8-10 week
+mean 54 years (range 19-68)	9606	Homo sapiens (human)	177	mean 54 year (range 19-68)	mean 54 year (range 19-68)
+6-8 weeks	10090	Mus musculus (mouse)	178	6-8 week	6-8 week
+37 years old	9606	Homo sapiens (human)	179	37 year old	37 year
+6-8 weeks	10000032	Mus musculus C3H.Q	180	6-8 week	6-8 week
+NULL	10000289	Mus musculus BALB.B	181	null	null
+NULL	10000193	Bos taurus Holstein	182	null	null
+5-14 years	9606	Homo sapiens (human)	183	5-14 year	5-14 year
+Children	9606	Homo sapiens (human)	184	children	children
+6-8 weeks old	10000038	Mus musculus C3H/He	185	6-8 week old	6-8 week
+NULL	10000220	Mus musculus C57BL/6 X DBA/2	186	null	null
+NULL	10000625	Mus musculus MRL	187	null	null
+6-8 weeks old	10000032	Mus musculus C3H.Q	188	6-8 week old	6-8 week
+NULL	10141	Cavia porcellus (guinea pig)	189	null	null
+10 months	9913	Bos taurus (bovine)	190	10 month	10 month
+4-16 weeks	10000067	Mus musculus C57BL/6	191	4-16 week	4-16 week
+6-8 weeks-old	10000047	Mus musculus C57BL/10	192	6-8 week-old	6-8 week
+4 weeks	9823	Sus scrofa (pig)	193	4 week	4 week
+8-12 weeks	10000253	Mus musculus A/J	194	8-12 week	8-12 week
+NULL	10000216	Mus musculus C57BL/6 X BALB/c	195	null	null
+NULL	10000576	Mus musculus HLA-A*02:01 Tg	196	null	null
+8-12 weeks-old	10000106	Mus musculus HY-A1 TCR beta chain Tg	197	8-12 week-old	8-12 week
+5-6 weeks	10090	Mus musculus (mouse)	198	5-6 week	5-6 week
+6-8 weeks	10000649	Mus musculus SJL	199	6-8 week	6-8 week
+42-64 years	9606	Homo sapiens (human)	200	42-64 year	42-64 year
+46-53 years	9606	Homo sapiens (human)	201	46-53 year	46-53 year
+6-12 weeks	10000000	Mus musculus BALB/c	202	6-12 week	6-12 week
+average age 29.8	9606	Homo sapiens (human)	203	average age 29.8	average age 29.8
+6-8 weeks old	10000601	Mus musculus HLA-DR1 Tg	204	6-8 week old	6-8 week
+6-8 weeks	10000027	Mus musculus C.AL-Igho/SmnJ	205	6-8 week	6-8 week
+1.5 - 10 years	9606	Homo sapiens (human)	206	1.5 - 10 year	1.5 - 10 year
+8-12 weeks old	10000000	Mus musculus BALB/c	207	8-12 week old	8-12 week
+11 or 18 weeks	10000637	Mus musculus NODasp	208	11 or 18 week	11 or 18 week
+21-34 years	9606	Homo sapiens (human)	209	21-34 year	21-34 year
+8 weeks	10000038	Mus musculus C3H/He	210	8 week	8 week
+33 years	10000119	Homo sapiens Caucasian	211	33 year	33 year
+NULL	78449	Macaca cyclopis (Taiwan macaque)	212	null	null
+8-10 weeks old	10000000	Mus musculus BALB/c	213	8-10 week old	8-10 week
+8-10 weeks old	10000233	Mus musculus CBA/Ca	214	8-10 week old	8-10 week
+4-6 weeks	10000067	Mus musculus C57BL/6	215	4-6 week	4-6 week
+NULL	10002230	Mus musculus 1807 TCR Tg	216	null	null
+8-12 weeks	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	217	8-12 week	8-12 week
+NULL	10000038	Mus musculus C3H/He	218	null	null
+6-12 weeks	10090	Mus musculus (mouse)	219	6-12 week	6-12 week
+10-12 weeks	10000067	Mus musculus C57BL/6	220	10-12 week	10-12 week
+2-18 mo	10000067	Mus musculus C57BL/6	221	2-18 month	2-18 month
+NULL	10000206	Oryctolagus cuniculus New Zealand White	222	null	null
+8-11 weeks	10000000	Mus musculus BALB/c	223	8-11 week	8-11 week
+37-61 years old	9606	Homo sapiens (human)	224	37-61 year old	37-61 year
+Mean: 29 years	9606	Homo sapiens (human)	225	mean: 29 year	mean: 29 year
+4-6 weeks	10000948	Mus musculus C3H/Ou	226	4-6 week	4-6 week
+NULL	10000287	Mus musculus P14 TCR Tg	227	null	null
+4-6 wk	10000582	Mus musculus HLA-A2 Tg	228	4-6 week	4-6 week
+8 weeks	10000636	Mus musculus NOD/Lt Ealphak Tg	229	8 week	8 week
+8-10 weeks-old	10000000	Mus musculus BALB/c	230	8-10 week-old	8-10 week
+6-10 weeks-old	10000047	Mus musculus C57BL/10	231	6-10 week-old	6-10 week
+8 weeks	10000289	Mus musculus BALB.B	232	8 week	8 week
+6 weeks old	10000000	Mus musculus BALB/c	233	6 week old	6 week
+28-55 years	9606	Homo sapiens (human)	234	28-55 year	28-55 year
+22-52 years	9606	Homo sapiens (human)	235	22-52 year	22-52 year
+NULL	10000194	Bos taurus Holstein-Friesian	236	null	null
+6-12 months	10000185	Canis familiaris beagle	237	6-12 month	6-12 month
+32	9606	Homo sapiens (human)	238	32	32
+32-42	9606	Homo sapiens (human)	239	32-42	32-42
+NULL	10000255	Mus musculus AKR	240	null	null
+6-8 weeks	10000620	Mus musculus IL-10 null	241	6-8 week	6-8 week
+4-5 weeks	10000067	Mus musculus C57BL/6	242	4-5 week	4-5 week
+5 weeks	10090	Mus musculus (mouse)	243	5 week	5 week
+2 months	10000216	Mus musculus C57BL/6 X BALB/c	244	2 month	2 month
+8-12 wks	10000067	Mus musculus C57BL/6	245	8-12 week	8-12 week
+3 months-old	10000233	Mus musculus CBA/Ca	246	3 month-old	3 month
+8 weeks	10000276	Mus musculus B10.S	247	8 week	8 week
+29-38 years	9606	Homo sapiens (human)	248	29-38 year	29-38 year
+8-10 weeks	10090	Mus musculus (mouse)	249	8-10 week	8-10 week
+8-10 weeks	10000632	Mus musculus NOD	250	8-10 week	8-10 week
+NULL	9995	Marmota monax (groundhog)	251	null	null
+7-10 weeks-old	10000067	Mus musculus C57BL/6	252	7-10 week-old	7-10 week
+6-8 weeks	10000047	Mus musculus C57BL/10	253	6-8 week	6-8 week
+NULL	10000055	Mus musculus DBA/2	254	null	null
+8-yr-old	9598	Pan troglodytes (chimpanzee)	255	8-year-old	8 year
+8-weeks-old	10000000	Mus musculus BALB/c	256	8-week-old	8 week
+38-59 years	9606	Homo sapiens (human)	257	38-59 year	38-59 year
+6-12 weeks	10000229	Mus musculus HLA-B*27:05 Tg	258	6-12 week	6-12 week
+28-42 years	9606	Homo sapiens (human)	259	28-42 year	28-42 year
+NULL	10000661	Rattus norvegicus Fischer 344	260	null	null
+6 months	10000190	Bos taurus Friesian	261	6 month	6 month
+8-12 weeks old	10000067	Mus musculus C57BL/6	262	8-12 week old	8-12 week
+8-12 wk	10000000	Mus musculus BALB/c	263	8-12 week	8-12 week
+23-55 years old	9606	Homo sapiens (human)	264	23-55 year old	23-55 year
+28-63 years	9606	Homo sapiens (human)	265	28-63 year	28-63 year
+NULL	10000070	Mus musculus C57BL/6 bg	266	null	null
+NULL	10000092	Mus musculus gBT-I TCR Tg	267	null	null
+2 months	10000236	Mus musculus CBA/J	268	2 month	2 month
+6-8 weeks old	10000276	Mus musculus B10.S	269	6-8 week old	6-8 week
+6-8 weeks	10000662	Rattus norvegicus Lewis	270	6-8 week	6-8 week
+8-14 weeks old	10000598	Mus musculus HLA-DQ8 Tg	271	8-14 week old	8-14 week
+8-12 weeks old	10000185	Canis familiaris beagle	272	8-12 week old	8-12 week
+NULL	10000610	Mus musculus HLA-DR4 Tg	273	null	null
+37-57	9606	Homo sapiens (human)	274	37-57	37-57
+NULL	10000277	Mus musculus B10.S(7R)	275	null	null
+NULL	10000051	Mus musculus C57BL/10 X DBA/2	276	null	null
+3-4 weeks	10116	Rattus norvegicus (brown rat)	277	3-4 week	3-4 week
+10-50 years	9606	Homo sapiens (human)	278	10-50 year	10-50 year
+52-68	9606	Homo sapiens (human)	279	52-68	52-68
+5-8 weeks	10000254	Mus musculus A/Sn	280	5-8 week	5-8 week
+6-12 weeks	10000038	Mus musculus C3H/He	281	6-12 week	6-12 week
+5-30 years-old	9606	Homo sapiens (human)	282	5-30 year-old	5-30 year
+8-14 wk	10000067	Mus musculus C57BL/6	283	8-14 week	8-14 week
+21-66 years old	9606	Homo sapiens (human)	284	21-66 year old	21-66 year
+12  weeks	10000000	Mus musculus BALB/c	285	12  week	12  week
+21-50 years old	10000119	Homo sapiens Caucasian	286	21-50 year old	21-50 year
+8 weeks	10000632	Mus musculus NOD	287	8 week	8 week
+NULL	10000059	Mus musculus Flu HAmemb Tg	288	null	null
+5-8 weeks	10000067	Mus musculus C57BL/6	289	5-8 week	5-8 week
+8 weeks	10000635	Mus musculus NOD/Lt	290	8 week	8 week
+NULL	9796	Equus caballus (domestic horse)	291	null	null
+10.5 years avg.	9606	Homo sapiens (human)	292	10.5 year avg.	10.5 year avg.
+NULL	10000597	Mus musculus HLA-DQ6 Tg	293	null	null
+6-8 wks	10001782	Mus musculus HLA-B*07:02 Tg	294	6-8 week	6-8 week
+4-8 weeks	10090	Mus musculus (mouse)	295	4-8 week	4-8 week
+2 months	10000000	Mus musculus BALB/c	296	2 month	2 month
+2 months	10000067	Mus musculus C57BL/6	297	2 month	2 month
+18–64 years)	9606	Homo sapiens (human)	298	1864 years)	1864 years)
+6-8 wk	10000000	Mus musculus BALB/c	299	6-8 week	6-8 week
+6-8 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	300	6-8 week old	6-8 week
+1-2 months-old	9606	Homo sapiens (human)	301	1-2 month-old	1-2 month
+6-16 wk	10000095	Mus musculus C57BL/6 IFNgamma null	302	6-16 week	6-16 week
+NULL	10000581	Mus musculus HLA-A11 Tg	303	null	null
+3.5-17 months	9796	Equus caballus (domestic horse)	304	3.5-17 month	3.5-17 month
+6-7 weeks	10000000	Mus musculus BALB/c	305	6-7 week	6-7 week
+1-1.5 years	9913	Bos taurus (bovine)	306	1-1.5 year	1-1.5 year
+At least 8 weeks old	10000000	Mus musculus BALB/c	307	at least 8 week old	at least 8 week
+8-24 weeks old	10000063	Mus musculus B10.A	308	8-24 week old	8-24 week
+7-9 weeks	10000649	Mus musculus SJL	309	7-9 week	7-9 week
+7-9 weeks	10000000	Mus musculus BALB/c	310	7-9 week	7-9 week
+12 weeks	10000067	Mus musculus C57BL/6	311	12 week	12 week
+4-5 wk	10000067	Mus musculus C57BL/6	312	4-5 week	4-5 week
+8 weeks or older	10000067	Mus musculus C57BL/6	313	8 week or older	8 week or older
+17-81 years old	9606	Homo sapiens (human)	314	17-81 year old	17-81 year
+10-12 weeks	10000000	Mus musculus BALB/c	315	10-12 week	10-12 week
+8-10 wk	10000000	Mus musculus BALB/c	316	8-10 week	8-10 week
+3 months-old	10000000	Mus musculus BALB/c	317	3 month-old	3 month
+5-6 months	10000193	Bos taurus Holstein	318	5-6 month	5-6 month
+6-10 wk	10000067	Mus musculus C57BL/6	319	6-10 week	6-10 week
+2 months or older	10000000	Mus musculus BALB/c	320	2 month or older	2 month or older
+28-65 years	9606	Homo sapiens (human)	321	28-65 year	28-65 year
+6 to 8-week old	10090	Mus musculus (mouse)	322	6 to 8-week old	6 to 8 week
+8 weeks old	10000000	Mus musculus BALB/c	323	8 week old	8 week
+5-6 weeks	10000000	Mus musculus BALB/c	324	5-6 week	5-6 week
+8-10 weeks old	10000067	Mus musculus C57BL/6	325	8-10 week old	8-10 week
+21 - 85 yo	9606	Homo sapiens (human)	326	21 - 85 year	21 - 85 year
+6-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	327	6-12 week	6-12 week
+17-57	9606	Homo sapiens (human)	328	17-57	17-57
+22-55 years	9606	Homo sapiens (human)	329	22-55 year	22-55 year
+35.4 yrs average	9606	Homo sapiens (human)	330	35.4 year average	35.4 year average
+5-8 weeks	10000000	Mus musculus BALB/c	331	5-8 week	5-8 week
+>6 wk	10000233	Mus musculus CBA/Ca	332	>6 week	>6 week
+18-72	9606	Homo sapiens (human)	333	18-72	18-72
+6 months-1.1 year	9606	Homo sapiens (human)	334	6 month-1.1 year	6 month-1.1 year
+NULL	9685	Felis catus (cat)	335	null	null
+6 weeks	10000067	Mus musculus C57BL/6	336	6 week	6 week
+4 months- 4 years	9606	Homo sapiens (human)	337	4 month- 4 year	4 month- 4 year
+10-16 weeks old	10000607	Mus musculus HLA-DR3 Tg	338	10-16 week old	10-16 week
+36-51 years old	9606	Homo sapiens (human)	339	36-51 year old	36-51 year
+15-50 years old	10000119	Homo sapiens Caucasian	340	15-50 year old	15-50 year
+16-48 years old	9606	Homo sapiens (human)	341	16-48 year old	16-48 year
+6-8 weeks	10000582	Mus musculus HLA-A2 Tg	342	6-8 week	6-8 week
+21-55 years old	9606	Homo sapiens (human)	343	21-55 year old	21-55 year
+8 to 10 weeks	10000607	Mus musculus HLA-DR3 Tg	344	8 to 10 week	8 to 10 week
+5, 8, 11 or 18 weeks	10000632	Mus musculus NOD	345	5, 8, 11 or 18 week	5, 8, 11 or 18 week
+4-6 wk	10090	Mus musculus (mouse)	346	4-6 week	4-6 week
+30-65 years	9606	Homo sapiens (human)	347	30-65 year	30-65 year
+NULL	10000065	Mus musculus C57BL/10SnJ	348	null	null
+3-5 weeks	10000000	Mus musculus BALB/c	349	3-5 week	3-5 week
+15 weeks	10000610	Mus musculus HLA-DR4 Tg	350	15 week	15 week
+NULL	43147	Aotus lemurinus (lemurine night monkey)	351	null	null
+6-8 wks	10000067	Mus musculus C57BL/6	352	6-8 week	6-8 week
+newborn	10000047	Mus musculus C57BL/10	353	newborn	newborn
+6 weeks-old	10090	Mus musculus (mouse)	354	6 week-old	6 week
+25-50 years-old	9606	Homo sapiens (human)	355	25-50 year-old	25-50 year
+6-8 week	10000000	Mus musculus BALB/c	356	6-8 week	6-8 week
+17-86 years old	10000119	Homo sapiens Caucasian	357	17-86 year old	17-86 year
+12 weeks	10000000	Mus musculus BALB/c	358	12 week	12 week
+48 years old	10000119	Homo sapiens Caucasian	359	48 year old	48 year
+18-60 years old	9606	Homo sapiens (human)	360	18-60 year old	18-60 year
+8 to 10 weeks	10000067	Mus musculus C57BL/6	361	8 to 10 week	8 to 10 week
+35	9606	Homo sapiens (human)	362	35	35
+46 years	9606	Homo sapiens (human)	363	46 year	46 year
+28 years	9606	Homo sapiens (human)	364	28 year	28 year
+6 to 10 weeks	10000047	Mus musculus C57BL/10	365	6 to 10 week	6 to 10 week
+18-61	9606	Homo sapiens (human)	366	18-61	18-61
+7-12 weeks	10000253	Mus musculus A/J	367	7-12 week	7-12 week
+6 to 10 weeks	10000263	Mus musculus B10.BR	368	6 to 10 week	6 to 10 week
+4-10 weeks	10000038	Mus musculus C3H/He	369	4-10 week	4-10 week
+4-10 weeks	10000000	Mus musculus BALB/c	370	4-10 week	4-10 week
+18-54 years	9606	Homo sapiens (human)	371	18-54 year	18-54 year
+13-133 months	9606	Homo sapiens (human)	372	13-133 month	13-133 month
+6-8 weeks old	10000649	Mus musculus SJL	373	6-8 week old	6-8 week
+8 weeks-old	10000067	Mus musculus C57BL/6	374	8 week-old	8 week
+8-12 weeks old	10000028	Mus musculus C3H	375	8-12 week old	8-12 week
+75 years	9606	Homo sapiens (human)	376	75 year	75 year
+32-51 years	9606	Homo sapiens (human)	377	32-51 year	32-51 year
+4 week	10000000	Mus musculus BALB/c	378	4 week	4 week
+7-10 weeks	10090	Mus musculus (mouse)	379	7-10 week	7-10 week
+mean age 30 years	9606	Homo sapiens (human)	380	mean age 30 year	mean age 30 year
+27 to 78 years	9606	Homo sapiens (human)	381	27 to 78 year	27 to 78 year
+8-12 weeks	10000290	Mus musculus BALB.K	382	8-12 week	8-12 week
+6-12 weeks old	10000067	Mus musculus C57BL/6	383	6-12 week old	6-12 week
+6-12 weeks	10000597	Mus musculus HLA-DQ6 Tg	384	6-12 week	6-12 week
+NULL	10000073	Mus musculus 1AD2 TCR Tg	385	null	null
+4-8 weeks-old	10000000	Mus musculus BALB/c	386	4-8 week-old	4-8 week
+6 to 10 weeks	10000256	Mus musculus B10 X B10.BR	387	6 to 10 week	6 to 10 week
+8-12 wk	10000067	Mus musculus C57BL/6	388	8-12 week	8-12 week
+NULL	9544	Macaca mulatta (rhesus macaque)	389	null	null
+18-50 years	9606	Homo sapiens (human)	390	18-50 year	18-50 year
+22-61 years-old	9606	Homo sapiens (human)	391	22-61 year-old	22-61 year
+17-88	9606	Homo sapiens (human)	392	17-88	17-88
+21-44 years	9606	Homo sapiens (human)	393	21-44 year	21-44 year
+NULL	408722	Grammomys gazellae	394	null	null
+18-30 years	9606	Homo sapiens (human)	395	18-30 year	18-30 year
+NULL	10000041	Mus musculus C3H/SnJ	396	null	null
+12 to 55 year-old	9606	Homo sapiens (human)	397	12 to 55 year-old	12 to 55 year
+6-12 weeks-old	10090	Mus musculus (mouse)	398	6-12 week-old	6-12 week
+10-79 years	9606	Homo sapiens (human)	399	10-79 year	10-79 year
+NULL	10000615	Mus musculus HLA-DRB1*01:01 Tg	400	null	null
+4-5 weeks	10000000	Mus musculus BALB/c	401	4-5 week	4-5 week
+16-87 years	9606	Homo sapiens (human)	402	16-87 year	16-87 year
+20–67 years	9606	Homo sapiens (human)	403	2067 year	2067 year
+6-8 weeks old	10000582	Mus musculus HLA-A2 Tg	404	6-8 week old	6-8 week
+8 weeks-old	10000253	Mus musculus A/J	405	8 week-old	8 week
+3-4 months	10000263	Mus musculus B10.BR	406	3-4 month	3-4 month
+6-12 weeks	10000628	Mus musculus B5 TCR Tg	407	6-12 week	6-12 week
+6-8 weeks-old	10090	Mus musculus (mouse)	408	6-8 week-old	6-8 week
+6-8 weeks	10000054	Mus musculus DBA/1	409	6-8 week	6-8 week
+2-68 years old	9606	Homo sapiens (human)	410	2-68 year old	2-68 year
+7-10 weeks	10000067	Mus musculus C57BL/6	411	7-10 week	7-10 week
+10 years and older	9606	Homo sapiens (human)	412	10 year and older	10 year and older
+NULL	10000221	Mus musculus C57BL/6-Cd28tm1Mak	413	null	null
+30	9606	Homo sapiens (human)	414	30	30
+16-45 years	9606	Homo sapiens (human)	415	16-45 year	16-45 year
+8 to 12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	416	8 to 12 week	8 to 12 week
+19-59 years	9606	Homo sapiens (human)	417	19-59 year	19-59 year
+5-6 weeks old	10000649	Mus musculus SJL	418	5-6 week old	5-6 week
+38-64 years	9606	Homo sapiens (human)	419	38-64 year	38-64 year
+6-8 weeks	10000276	Mus musculus B10.S	420	6-8 week	6-8 week
+mean age 46.5 years	9606	Homo sapiens (human)	421	mean age 46.5 year	mean age 46.5 year
+6-8 weeks-old	10000000	Mus musculus BALB/c	422	6-8 week-old	6-8 week
+23-69 years-old	9606	Homo sapiens (human)	423	23-69 year-old	23-69 year
+6-8 weeks	10000218	Mus musculus C57BL/6 X C3H	424	6-8 week	6-8 week
+NULL	10000017	Mus musculus BALB/c X DBA/2	425	null	null
+1 month-old-81 years-old	9606	Homo sapiens (human)	426	1 month-old-81 year-old	1 month-81 year
+6-12 weeks	10000598	Mus musculus HLA-DQ8 Tg	427	6-12 week	6-12 week
+6-8 weeks	10000028	Mus musculus C3H	428	6-8 week	6-8 week
+NULL	10000259	Mus musculus B10.A(3R)	429	null	null
+8-14 wk	10000576	Mus musculus HLA-A*02:01 Tg	430	8-14 week	8-14 week
+NULL	10000015	Mus musculus BALB/c X C3H	431	null	null
+4-10 weeks-old	10090	Mus musculus (mouse)	432	4-10 week-old	4-10 week
+42-70 years-old	9606	Homo sapiens (human)	433	42-70 year-old	42-70 year
+6-10 wk	10000051	Mus musculus C57BL/10 X DBA/2	434	6-10 week	6-10 week
+12-16 weeks	10000067	Mus musculus C57BL/6	435	12-16 week	12-16 week
+8-10wk	10000000	Mus musculus BALB/c	436	8-10wk	8-10wk
+12 weeks	10001407	Mus musculus SNF1	437	12 week	12 week
+8–12 weeks	10000000	Mus musculus BALB/c	438	812 week	812 week
+8-65 years	9606	Homo sapiens (human)	439	8-65 year	8-65 year
+8-16 weeks	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	440	8-16 week	8-16 week
+6-12 wk	10000067	Mus musculus C57BL/6	441	6-12 week	6-12 week
+NULL	10000063	Mus musculus B10.A	442	null	null
+8-15 weeks	10000067	Mus musculus C57BL/6	443	8-15 week	8-15 week
+NULL	10000264	Mus musculus B10.BR DM null	444	null	null
+6-8 weeks-old	10000582	Mus musculus HLA-A2 Tg	445	6-8 week-old	6-8 week
+6-16 wk	10000067	Mus musculus C57BL/6	446	6-16 week	6-16 week
+NULL	10000003	Mus musculus BALB/c DM null	447	null	null
+52 years-old	9606	Homo sapiens (human)	448	52 year-old	52 year
+8-16 weeks	10000067	Mus musculus C57BL/6	449	8-16 week	8-16 week
+16 years	9606	Homo sapiens (human)	450	16 year	16 year
+8-16 weeks	10000107	Mus musculus C57BL/6 X A/WySnJ	451	8-16 week	8-16 week
+8-12 weeks	10000043	Mus musculus C3HeB/FeJ	452	8-12 week	8-12 week
+4-6 weeks	10000649	Mus musculus SJL	453	4-6 week	4-6 week
+2-4 months old	10090	Mus musculus (mouse)	454	2-4 month old	2-4 month
+8-10 wks	10000067	Mus musculus C57BL/6	455	8-10 week	8-10 week
+8-10 wks	10000000	Mus musculus BALB/c	456	8-10 week	8-10 week
+10 weeks	10116	Rattus norvegicus (brown rat)	457	10 week	10 week
+5-65 years	9606	Homo sapiens (human)	458	5-65 year	5-65 year
+25-61 years	9606	Homo sapiens (human)	459	25-61 year	25-61 year
+1 year	10000956	Bos taurus Charolais	460	1 year	1 year
+12-57 years	9606	Homo sapiens (human)	461	12-57 year	12-57 year
+31-60 years	9606	Homo sapiens (human)	462	31-60 year	31-60 year
+9 months	10000189	Bos taurus Brahman-Angus	463	9 month	9 month
+3-10 years old	9615	Canis lupus familiaris (dogs)	464	3-10 year old	3-10 year
+NULL	8839	Anas platyrhynchos (duck)	465	null	null
+7 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	466	7 to 8 week	7 to 8 week
+Newborn	9606	Homo sapiens (human)	467	newborn	newborn
+2-80 years	9606	Homo sapiens (human)	468	2-80 year	2-80 year
+2 years	10000191	Bos taurus Hereford	469	2 year	2 year
+43-46	9606	Homo sapiens (human)	470	43-46	43-46
+8-10 wk	10000067	Mus musculus C57BL/6	471	8-10 week	8-10 week
+4-5 weeks	10000096	Mus musculus C57BL/6 IL-10 null	472	4-5 week	4-5 week
+1-4 months	10000067	Mus musculus C57BL/6	473	1-4 month	1-4 month
+8-12 wk	10000236	Mus musculus CBA/J	474	8-12 week	8-12 week
+NULL	10000253	Mus musculus A/J	475	null	null
+18-55 years	9606	Homo sapiens (human)	476	18-55 year	18-55 year
+25-53 years	9606	Homo sapiens (human)	477	25-53 year	25-53 year
+2-3 months	10000228	Mus musculus CBA	478	2-3 month	2-3 month
+NULL	10000662	Rattus norvegicus Lewis	479	null	null
+5-8 weeks	10090	Mus musculus (mouse)	480	5-8 week	5-8 week
+7-10 weeks	10000038	Mus musculus C3H/He	481	7-10 week	7-10 week
+8-12 weeks	10000245	Mus musculus (C57BL/6 X BALB/c) Tg(HBV 1.3 genome)chi32	482	8-12 week	8-12 week
+12-16 weeks old	10000067	Mus musculus C57BL/6	483	12-16 week old	12-16 week
+19-38 years old	9606	Homo sapiens (human)	484	19-38 year old	19-38 year
+5-6 weeks	10000662	Rattus norvegicus Lewis	485	5-6 week	5-6 week
+40-62 years	9606	Homo sapiens (human)	486	40-62 year	40-62 year
+2-12 months	10000067	Mus musculus C57BL/6	487	2-12 month	2-12 month
+11-32 years	9606	Homo sapiens (human)	488	11-32 year	11-32 year
+27-60	10000119	Homo sapiens Caucasian	489	27-60	27-60
+8-14 weeks	10000038	Mus musculus C3H/He	490	8-14 week	8-14 week
+8-24 weeks old	10000228	Mus musculus CBA	491	8-24 week old	8-24 week
+NULL	10000057	Mus musculus F5 TCR Tg	492	null	null
+35-50 years	9606	Homo sapiens (human)	493	35-50 year	35-50 year
+22-62 years	9606	Homo sapiens (human)	494	22-62 year	22-62 year
+8-10 weeks-old	10000047	Mus musculus C57BL/10	495	8-10 week-old	8-10 week
+8 to 12 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	496	8 to 12 week	8 to 12 week
+26-66 years	9606	Homo sapiens (human)	497	26-66 year	26-66 year
+NULL	10000274	Mus musculus B10.PL	498	null	null
+53-64 years	9606	Homo sapiens (human)	499	53-64 year	53-64 year
+6-12 weeks	10000276	Mus musculus B10.S	500	6-12 week	6-12 week
+6-8 wks	10000000	Mus musculus BALB/c	501	6-8 week	6-8 week
+6-8 weeks old	10000028	Mus musculus C3H	502	6-8 week old	6-8 week
+22-88 years	9606	Homo sapiens (human)	503	22-88 year	22-88 year
+37-41 years	9606	Homo sapiens (human)	504	37-41 year	37-41 year
+Children (mean age 7.2 years)	9606	Homo sapiens (human)	505	children (mean age 7.2 years)	children (mean age 7.2 years)
+30-86	9606	Homo sapiens (human)	506	30-86	30-86
+30 years	9606	Homo sapiens (human)	507	30 year	30 year
+8-12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	508	8-12 week	8-12 week
+40-65 years	9606	Homo sapiens (human)	509	40-65 year	40-65 year
+NULL	10000660	Rattus norvegicus Fischer	510	null	null
+NULL	10000594	Mus musculus HLA-B27 Tg	511	null	null
+14 years-old	9606	Homo sapiens (human)	512	14 year-old	14 year
+18 to 50 years	9606	Homo sapiens (human)	513	18 to 50 year	18 to 50 year
+3-4 months	10000193	Bos taurus Holstein	514	3-4 month	3-4 month
+3-4 months	9913	Bos taurus (bovine)	515	3-4 month	3-4 month
+6-10 weeks-old	10090	Mus musculus (mouse)	516	6-10 week-old	6-10 week
+5 to 19 weeks	10000000	Mus musculus BALB/c	517	5 to 19 week	5 to 19 week
+38 years-old	9606	Homo sapiens (human)	518	38 year-old	38 year
+4-16 weeks	10000000	Mus musculus BALB/c	519	4-16 week	4-16 week
+8-12 weeks	10000038	Mus musculus C3H/He	520	8-12 week	8-12 week
+NULL	10000260	Mus musculus B10.A(4R)	521	null	null
+17 years	9606	Homo sapiens (human)	522	17 year	17 year
+18-76 years	9606	Homo sapiens (human)	523	18-76 year	18-76 year
+5- to 8- weeks -old	10000000	Mus musculus BALB/c	524	5- to 8- week -old	5- to 8- week -old
+average age 35.1	9606	Homo sapiens (human)	525	average age 35.1	average age 35.1
+NULL	10000632	Mus musculus NOD	526	null	null
+29-51 years	9606	Homo sapiens (human)	527	29-51 year	29-51 year
+18-56 years	9606	Homo sapiens (human)	528	18-56 year	18-56 year
+20-67 years	9606	Homo sapiens (human)	529	20-67 year	20-67 year
+23-42 years	9606	Homo sapiens (human)	530	23-42 year	23-42 year
+NULL	10000227	Mus musculus OT-1 TCR Tg	531	null	null
+Mean age = 30.7 years	9606	Homo sapiens (human)	532	mean age = 30.7 year	mean age = 30.7 year
+38-56 years	9606	Homo sapiens (human)	533	38-56 year	38-56 year
+NULL	10000246	Mus musculus (C57BL/6 X DBA/2) Tg(HBV 1.3 genome)chi32	534	null	null
+20-37 years	9606	Homo sapiens (human)	535	20-37 year	20-37 year
+35-55 years	9606	Homo sapiens (human)	536	35-55 year	35-55 year
+NULL	10000210	Mus musculus (BALB/c X C57BL/10) Db null Kb null	537	null	null
+7-10 weeks-old	10000000	Mus musculus BALB/c	538	7-10 week-old	7-10 week
+6-9 months-old	10000194	Bos taurus Holstein-Friesian	539	6-9 month-old	6-9 month
+NULL	10000021	Mus musculus BALB/c-H2dm2	540	null	null
+12-16 weeks	10000000	Mus musculus BALB/c	541	12-16 week	12-16 week
+5 months-3 years	9606	Homo sapiens (human)	542	5 month-3 year	5 month-3 year
+15-74 years	9606	Homo sapiens (human)	543	15-74 year	15-74 year
+22-65 years	9606	Homo sapiens (human)	544	22-65 year	22-65 year
+8-10 weeks old	10001539	Mus musculus TCR transgenic	545	8-10 week old	8-10 week
+34-44 years	9606	Homo sapiens (human)	546	34-44 year	34-44 year
+6-8 weeks	10000975	Mus musculus FVB Db Tg	547	6-8 week	6-8 week
+NULL	10000258	Mus musculus B10.A(2R)	548	null	null
+young adult	9598	Pan troglodytes (chimpanzee)	549	young adult	young adult
+6-10 week old	10000582	Mus musculus HLA-A2 Tg	550	6-10 week old	6-10 week
+12 weeks	10000610	Mus musculus HLA-DR4 Tg	551	12 week	12 week
+8-12 weeks	10000276	Mus musculus B10.S	552	8-12 week	8-12 week
+6-9 months	10000190	Bos taurus Friesian	553	6-9 month	6-9 month
+6-10 week old	10000595	Mus musculus HLA-B7 Tg	554	6-10 week old	6-10 week
+NULL	10001381	Mus musculus HLA-DRB1*15:01 Tg	555	null	null
+NULL	10001539	Mus musculus TCR transgenic	556	null	null
+8-12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	557	8-12 week	8-12 week
+NULL	10000236	Mus musculus CBA/J	558	null	null
+28-60 yrs	9606	Homo sapiens (human)	559	28-60 year	28-60 year
+6-10 weeks	10000219	Mus musculus C57BL/6 X CBA	560	6-10 week	6-10 week
+14-48 years	9606	Homo sapiens (human)	561	14-48 year	14-48 year
+5-7 weeks	10000067	Mus musculus C57BL/6	562	5-7 week	5-7 week
+34-45 years	9606	Homo sapiens (human)	563	34-45 year	34-45 year
+4-6 weeks	10000038	Mus musculus C3H/He	564	4-6 week	4-6 week
+NULL	9490	Saguinus oedipus (cotton-top tamarin)	565	null	null
+6-10 weeks-old	10000016	Mus musculus BALB/c X C57BL/10	566	6-10 week-old	6-10 week
+2-4 months	10000067	Mus musculus C57BL/6	567	2-4 month	2-4 month
+12 months-old	10000192	Bos taurus Hereford-Angus	568	12 month-old	12 month
+40 years-old	9606	Homo sapiens (human)	569	40 year-old	40 year
+10-28 weeks	10000038	Mus musculus C3H/He	570	10-28 week	10-28 week
+8-10 wks.	10000000	Mus musculus BALB/c	571	8-10 week.	8-10 week.
+8-10 wks.	10000067	Mus musculus C57BL/6	572	8-10 week.	8-10 week.
+7-9 weeks	10000067	Mus musculus C57BL/6	573	7-9 week	7-9 week
+5-6 weeks	10000263	Mus musculus B10.BR	574	5-6 week	5-6 week
+50	9606	Homo sapiens (human)	575	50	50
+2-35 years	9606	Homo sapiens (human)	576	2-35 year	2-35 year
+7-37 years	9606	Homo sapiens (human)	577	7-37 year	7-37 year
+5-8 weeks	10000662	Rattus norvegicus Lewis	578	5-8 week	5-8 week
+41 years	9606	Homo sapiens (human)	579	41 year	41 year
+52 years	9606	Homo sapiens (human)	580	52 year	52 year
+4-6 weeks	10090	Mus musculus (mouse)	581	4-6 week	4-6 week
+28-79 years	9606	Homo sapiens (human)	582	28-79 year	28-79 year
+8-10 weeks	10000228	Mus musculus CBA	583	8-10 week	8-10 week
+41-55	9606	Homo sapiens (human)	584	41-55	41-55
+8-20 weeks-old	10000256	Mus musculus B10 X B10.BR	585	8-20 week-old	8-20 week
+NULL	10000011	Mus musculus ABLE Tg TCR	586	null	null
+25-50 years	9606	Homo sapiens (human)	587	25-50 year	25-50 year
+8-14 weeks	10000000	Mus musculus BALB/c	588	8-14 week	8-14 week
+8-14 weeks	10000067	Mus musculus C57BL/6	589	8-14 week	8-14 week
+6-10 wk	10000263	Mus musculus B10.BR	590	6-10 week	6-10 week
+8-10 weeks-old	10000275	Mus musculus B10.RIII	591	8-10 week-old	8-10 week
+6-10 weeks	10000054	Mus musculus DBA/1	592	6-10 week	6-10 week
+4-5 weeks old	10000000	Mus musculus BALB/c	593	4-5 week old	4-5 week
+29 years	9606	Homo sapiens (human)	594	29 year	29 year
+7-8 weeks-old	10000028	Mus musculus C3H	595	7-8 week-old	7-8 week
+4-8 weeks	10000028	Mus musculus C3H	596	4-8 week	4-8 week
+20-65	9606	Homo sapiens (human)	597	20-65	20-65
+29-55 years	9606	Homo sapiens (human)	598	29-55 year	29-55 year
+6-8 weeks old	10090	Mus musculus (mouse)	599	6-8 week old	6-8 week
+Not available	10000067	Mus musculus C57BL/6	600	not available	not available
+6-10 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	601	6-10 week	6-10 week
+NULL	10000269	Mus musculus B10.G	602	null	null
+16-84 years	9606	Homo sapiens (human)	603	16-84 year	16-84 year
+50-64 years	9606	Homo sapiens (human)	604	50-64 year	50-64 year
+28 years-old	9606	Homo sapiens (human)	605	28 year-old	28 year
+29-37 years	9606	Homo sapiens (human)	606	29-37 year	29-37 year
+18-48 years	9606	Homo sapiens (human)	607	18-48 year	18-48 year
+4-8 weeks old	10090	Mus musculus (mouse)	608	4-8 week old	4-8 week
+27 years	9606	Homo sapiens (human)	609	27 year	27 year
+6 months to 2 years	9606	Homo sapiens (human)	610	6 month to 2 year	6 month to 2 year
+4 weeks	10000236	Mus musculus CBA/J	611	4 week	4 week
+8 weeks	10000257	Mus musculus B10 X B10.S	612	8 week	8 week
+5-8 weeks-old	10000067	Mus musculus C57BL/6	613	5-8 week-old	5-8 week
+NULL	10001377	Mus musculus HLA-DQB1*06:01 Tg	614	null	null
+NULL	10000054	Mus musculus DBA/1	615	null	null
+32 years old	9606	Homo sapiens (human)	616	32 year old	32 year
+18-33 months	9544	Macaca mulatta (rhesus macaque)	617	18-33 month	18-33 month
+6-10 weeks old	10000582	Mus musculus HLA-A2 Tg	618	6-10 week old	6-10 week
+8-years-old	9598	Pan troglodytes (chimpanzee)	619	8-year-old	8 year
+14 years	9606	Homo sapiens (human)	620	14 year	14 year
+10 to 17 days-old	10000627	Mus musculus MRL/MpJ	621	10 to 17 days-old	10 to 17 days-old
+NULL	10000212	Mus musculus (C57BL/6 X 129/SV) p53 null	622	null	null
+8-10 weeks	10000649	Mus musculus SJL	623	8-10 week	8-10 week
+8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	624	8 week	8 week
+6-10 weeks	10000047	Mus musculus C57BL/10	625	6-10 week	6-10 week
+6-16 wk	10000000	Mus musculus BALB/c	626	6-16 week	6-16 week
+1 month	10000193	Bos taurus Holstein	627	1 month	1 month
+23-52 years	9606	Homo sapiens (human)	628	23-52 year	23-52 year
+Sucking	10000067	Mus musculus C57BL/6	629	sucking	sucking
+average 48 years	9606	Homo sapiens (human)	630	average 48 year	average 48 year
+4-6 weeks old	10000067	Mus musculus C57BL/6	631	4-6 week old	4-6 week
+6 years	9521	Saimiri sciureus (South American squirrel monkey)	632	6 year	6 year
+27-67 years	9606	Homo sapiens (human)	633	27-67 year	27-67 year
+8-10 weeks	10000582	Mus musculus HLA-A2 Tg	634	8-10 week	8-10 week
+6-8 weeks old	10000630	Mus musculus NHI Swiss	635	6-8 week old	6-8 week
+NULL	10000653	Mus musculus Swiss	636	null	null
+8 to 10 weeks	10000605	Mus musculus HLA-DR2 Tg	637	8 to 10 week	8 to 10 week
+12-15 months	9606	Homo sapiens (human)	638	12-15 month	12-15 month
+10 days	10000289	Mus musculus BALB.B	639	10 days	10 days
+32 years	9606	Homo sapiens (human)	640	32 year	32 year
+6 to 10 wk	10000000	Mus musculus BALB/c	641	6 to 10 week	6 to 10 week
+NULL	10000265	Mus musculus AND TCR Tg	642	null	null
+NULL	10000230	Mus musculus CBA X AKR	643	null	null
+8-12 weeks-old	10000042	Mus musculus C3HeB X DBA/2	644	8-12 week-old	8-12 week
+8-12 weeks-old	10000043	Mus musculus C3HeB/FeJ	645	8-12 week-old	8-12 week
+6 to 8 weeks	10000632	Mus musculus NOD	646	6 to 8 week	6 to 8 week
+4 weeks	10000000	Mus musculus BALB/c	647	4 week	4 week
+NULL	10000019	Mus musculus BALB/cByJ	648	null	null
+4-6 months	10000000	Mus musculus BALB/c	649	4-6 month	4-6 month
+3-4 months-old	10000233	Mus musculus CBA/Ca	650	3-4 month-old	3-4 month
+6 weeks or older	10000233	Mus musculus CBA/Ca	651	6 week or older	6 week or older
+NULL	10000656	Mus musculus VM X DBA/2	652	null	null
+1 year	9913	Bos taurus (bovine)	653	1 year	1 year
+10 weeks	10000954	Gallus gallus Prague CB	654	10 week	10 week
+20-50 years	9606	Homo sapiens (human)	655	20-50 year	20-50 year
+NULL	10000060	Mus musculus Flu HAtrunc Tg	656	null	null
+36 years	9606	Homo sapiens (human)	657	36 year	36 year
+NULL	10000028	Mus musculus C3H	658	null	null
+12-18 years	9606	Homo sapiens (human)	659	12-18 year	12-18 year
+6-10 weeks	10000276	Mus musculus B10.S	660	6-10 week	6-10 week
+6-18 weeks	10000038	Mus musculus C3H/He	661	6-18 week	6-18 week
+NULL	10000189	Bos taurus Brahman-Angus	662	null	null
+21-39 years	9606	Homo sapiens (human)	663	21-39 year	21-39 year
+8 to 10 weeks	10000610	Mus musculus HLA-DR4 Tg	664	8 to 10 week	8 to 10 week
+6-10 wk	10002138	Mus musculus B10	665	6-10 week	6-10 week
+8-10 wk	10000216	Mus musculus C57BL/6 X BALB/c	666	8-10 week	8-10 week
+8 to 12 weeks	10000000	Mus musculus BALB/c	667	8 to 12 week	8 to 12 week
+NULL	10000955	Bos taurus Jersey	668	null	null
+4 weeks	10000067	Mus musculus C57BL/6	669	4 week	4 week
+6-12 weeks old	10000000	Mus musculus BALB/c	670	6-12 week old	6-12 week
+28-58 years old	9606	Homo sapiens (human)	671	28-58 year old	28-58 year
+4-8 weeks	10000067	Mus musculus C57BL/6	672	4-8 week	4-8 week
+NULL	10000626	Mus musculus MRL X B10.BR	673	null	null
+40-73 years old	9606	Homo sapiens (human)	674	40-73 year old	40-73 year
+5-6 weeks	10000649	Mus musculus SJL	675	5-6 week	5-6 week
+47 years	9606	Homo sapiens (human)	676	47 year	47 year
+6-10 weeks	10000038	Mus musculus C3H/He	677	6-10 week	6-10 week
+6-10 weeks	10000649	Mus musculus SJL	678	6-10 week	6-10 week
+6 weeks or older	10000000	Mus musculus BALB/c	679	6 week or older	6 week or older
+62-74 years	9606	Homo sapiens (human)	680	62-74 year	62-74 year
+4-12 weeks-old	10000000	Mus musculus BALB/c	681	4-12 week-old	4-12 week
+8-12 weeks old	10000260	Mus musculus B10.A(4R)	682	8-12 week old	8-12 week
+6 weeks	10000228	Mus musculus CBA	683	6 week	6 week
+NULL	37293	Aotus nancymaae (Ma's night monkey)	684	null	null
+6-7 wk	10000236	Mus musculus CBA/J	685	6-7 week	6-7 week
+37 yrs average	9606	Homo sapiens (human)	686	37 year average	37 year average
+4-5 weeks	10000286	Mus musculus B6.PL Thy1a/Cy	687	4-5 week	4-5 week
+6-8 wk.	10000028	Mus musculus C3H	688	6-8 week.	6-8 week.
+3-6 weeks	10000000	Mus musculus BALB/c	689	3-6 week	3-6 week
+5 to 19 weeks	10000067	Mus musculus C57BL/6	690	5 to 19 week	5 to 19 week
+6-weeks	10000067	Mus musculus C57BL/6	691	6-week	6 week
+22-108 months	9606	Homo sapiens (human)	692	22-108 month	22-108 month
+6-10 wk	10000000	Mus musculus BALB/c	693	6-10 week	6-10 week
+NULL	10000072	Mus musculus C57BL/6 Db null Kb null	694	null	null
+NULL	10000671	Mus musculus (BALB/c x B10.G)F1-B10.G bone marrow chimera	695	null	null
+23-54 years-old	9606	Homo sapiens (human)	696	23-54 year-old	23-54 year
+20-23 years	9606	Homo sapiens (human)	697	20-23 year	20-23 year
+8 to 10 weeks	10000000	Mus musculus BALB/c	698	8 to 10 week	8 to 10 week
+21	9606	Homo sapiens (human)	699	21	21
+8-10 weeks-old	10000067	Mus musculus C57BL/6	700	8-10 week-old	8-10 week
+child	9606	Homo sapiens (human)	701	child	child
+NULL	10000071	Mus musculus C57BL/6 Db null	702	null	null
+NULL	10000651	Mus musculus SMARTA TCR Tg	703	null	null
+6-10 weeks	10000653	Mus musculus Swiss	704	6-10 week	6-10 week
+46-74 years old	9606	Homo sapiens (human)	705	46-74 year old	46-74 year
+16 years-old	9606	Homo sapiens (human)	706	16 year-old	16 year
+10 days	10000067	Mus musculus C57BL/6	707	10 days	10 days
+6-8 week	10000067	Mus musculus C57BL/6	708	6-8 week	6-8 week
+4-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	709	4-8 week	4-8 week
+14-24 weeks	10000067	Mus musculus C57BL/6	710	14-24 week	14-24 week
+6-18 weeks-old	10000038	Mus musculus C3H/He	711	6-18 week-old	6-18 week
+10-17 days	10000627	Mus musculus MRL/MpJ	712	10-17 days	10-17 days
+NULL	10000672	Mus musculus B10.BR-SCID  bone marrow chimera	713	null	null
+22 to 80 years	9606	Homo sapiens (human)	714	22 to 80 year	22 to 80 year
+NULL	10000261	Mus musculus B10.A(5R)	715	null	null
+8-10 wk	10090	Mus musculus (mouse)	716	8-10 week	8-10 week
+7-10 weeks-old	10000047	Mus musculus C57BL/10	717	7-10 week-old	7-10 week
+20-65 years	9606	Homo sapiens (human)	718	20-65 year	20-65 year
+5 to 8 weeks	10000067	Mus musculus C57BL/6	719	5 to 8 week	5 to 8 week
+37 yrs. Average	9606	Homo sapiens (human)	720	37 year. average	37 year. average
+8 weeks	10000582	Mus musculus HLA-A2 Tg	721	8 week	8 week
+19-29 years	9606	Homo sapiens (human)	722	19-29 year	19-29 year
+8-12 week	10000000	Mus musculus BALB/c	723	8-12 week	8-12 week
+1-13 years	9606	Homo sapiens (human)	724	1-13 year	1-13 year
+36-47 years	9606	Homo sapiens (human)	725	36-47 year	36-47 year
+4 weeks old	10000000	Mus musculus BALB/c	726	4 week old	4 week
+4 to 6 weeks	10001128	Mus musculus N15 TCR Tg	727	4 to 6 week	4 to 6 week
+NULL	10000097	Mus musculus C57BL/6 Kb null	728	null	null
+6-8 wk	10000216	Mus musculus C57BL/6 X BALB/c	729	6-8 week	6-8 week
+1 year	10000917	Equus caballus Arabian	730	1 year	1 year
+47.6	9606	Homo sapiens (human)	731	47.6	47.6
+8-12 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	732	8-12 week old	8-12 week
+6-10 weeks-old	10000290	Mus musculus BALB.K	733	6-10 week-old	6-10 week
+6-8-week-old	10000067	Mus musculus C57BL/6	734	6-8-week-old	6-8 week
+8 weeks	10000067	Mus musculus C57BL/6	735	8 week	8 week
+35-65 years	9606	Homo sapiens (human)	736	35-65 year	35-65 year
+NULL	10000618	Mus musculus ICR	737	null	null
+22 to 64 years	9606	Homo sapiens (human)	738	22 to 64 year	22 to 64 year
+6-16 weeks	10000000	Mus musculus BALB/c	739	6-16 week	6-16 week
+9 to 12 weeks	10000067	Mus musculus C57BL/6	740	9 to 12 week	9 to 12 week
+24-45 years	9606	Homo sapiens (human)	741	24-45 year	24-45 year
+8-10 weeks-old	10000051	Mus musculus C57BL/10 X DBA/2	742	8-10 week-old	8-10 week
+mean age 54 years	9606	Homo sapiens (human)	743	mean age 54 year	mean age 54 year
+50-76	9606	Homo sapiens (human)	744	50-76	50-76
+3 months-old	10000228	Mus musculus CBA	745	3 month-old	3 month
+9 weeks old	10000067	Mus musculus C57BL/6	746	9 week old	9 week
+45-66 years	9606	Homo sapiens (human)	747	45-66 year	45-66 year
+8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	748	8 week	8 week
+8-12 wks	10000057	Mus musculus F5 TCR Tg	749	8-12 week	8-12 week
+NULL	10000061	Mus musculus FVB	750	null	null
+NULL	10000229	Mus musculus HLA-B*27:05 Tg	751	null	null
+7 to 9 weeks	10000067	Mus musculus C57BL/6	752	7 to 9 week	7 to 9 week
+33-67 years	9606	Homo sapiens (human)	753	33-67 year	33-67 year
+12-16 weeks	10090	Mus musculus (mouse)	754	12-16 week	12-16 week
+6 to 12 weeks	10000067	Mus musculus C57BL/6	755	6 to 12 week	6 to 12 week
+NULL	10000270	Mus musculus B10.HTT	756	null	null
+8 to 12-week-old	10000000	Mus musculus BALB/c	757	8 to 12-week-old	8 to 12 week
+22-32 years	9606	Homo sapiens (human)	758	22-32 year	22-32 year
+NULL	10000288	Mus musculus B6Smn.C3-Faslgld	759	null	null
+1 year-old	10000191	Bos taurus Hereford	760	1 year-old	1 year
+8-34 years	9606	Homo sapiens (human)	761	8-34 year	8-34 year
+4-6 weeks	10000286	Mus musculus B6.PL Thy1a/Cy	762	4-6 week	4-6 week
+NULL	10000290	Mus musculus BALB.K	763	null	null
+25 to 61 years	9606	Homo sapiens (human)	764	25 to 61 year	25 to 61 year
+3 weeks	10000632	Mus musculus NOD	765	3 week	3 week
+NULL	10001596	Mus musculus B6.mOVA-Tg	766	null	null
+43 years old	9606	Homo sapiens (human)	767	43 year old	43 year
+31-80	9606	Homo sapiens (human)	768	31-80	31-80
+6 wo	10000067	Mus musculus C57BL/6	769	6 week	6 week
+31-37	9606	Homo sapiens (human)	770	31-37	31-37
+1-52 years	9606	Homo sapiens (human)	771	1-52 year	1-52 year
+Adults and children (ages 4.5-10.5 and 15-44)	9606	Homo sapiens (human)	772	adults and children (ages 4.5-10.5 and 15-44)	adults and children (ages 4.5-10.5 and 15-44)
+8-12 wk	10000216	Mus musculus C57BL/6 X BALB/c	773	8-12 week	8-12 week
+6-8 weeks	10000601	Mus musculus HLA-DR1 Tg	774	6-8 week	6-8 week
+Neonates	9606	Homo sapiens (human)	775	neonates	neonates
+>9 years	9606	Homo sapiens (human)	776	>9 year	>9 year
+At least 8 weeks old	10000067	Mus musculus C57BL/6	777	at least 8 week old	at least 8 week
+8-24 weeks old	10000260	Mus musculus B10.A(4R)	778	8-24 week old	8-24 week
+At birth	9995	Marmota monax (groundhog)	779	at birth	at birth
+Adult	10000000	Mus musculus BALB/c	780	adult	adult
+21-84 years	9606	Homo sapiens (human)	781	21-84 year	21-84 year
+6-8 weeks-old	10000067	Mus musculus C57BL/6	782	6-8 week-old	6-8 week
+12-14 weeks	10000067	Mus musculus C57BL/6	783	12-14 week	12-14 week
+8-25 years	9606	Homo sapiens (human)	784	8-25 year	8-25 year
+19-39 years	9606	Homo sapiens (human)	785	19-39 year	19-39 year
+NULL	9541	Macaca fascicularis (crab eating macaque)	786	null	null
+NULL	10000033	Mus musculus C3H.SW	787	null	null
+6-10 weeks old	10000632	Mus musculus NOD	788	6-10 week old	6-10 week
+65 years	9606	Homo sapiens (human)	789	65 year	65 year
+6 to 10 weeks	10000000	Mus musculus BALB/c	790	6 to 10 week	6 to 10 week
+8-24 weeks old	10000258	Mus musculus B10.A(2R)	791	8-24 week old	8-24 week
+6-8 weeks	10000227	Mus musculus OT-1 TCR Tg	792	6-8 week	6-8 week
+47	9606	Homo sapiens (human)	793	47	47
+8-10 weeks-old	10090	Mus musculus (mouse)	794	8-10 week-old	8-10 week
+NULL	10001217	Mus musculus pmel-1 TCR Tg	795	null	null
+8-12 week	10000582	Mus musculus HLA-A2 Tg	796	8-12 week	8-12 week
+NULL	9539	Macaca (macaque)	797	null	null
+66-88	9606	Homo sapiens (human)	798	66-88	66-88
+34-35 years	9606	Homo sapiens (human)	799	34-35 year	34-35 year
+34-41 years	9606	Homo sapiens (human)	800	34-41 year	34-41 year
+53 years	9606	Homo sapiens (human)	801	53 year	53 year
+4-5 weeks	10090	Mus musculus (mouse)	802	4-5 week	4-5 week
+6-16 wk	10000009	Mus musculus BALB/c IFNgamma null	803	6-16 week	6-16 week
+8-24 weeks old	10000047	Mus musculus C57BL/10	804	8-24 week old	8-24 week
+>10 years	9606	Homo sapiens (human)	805	>10 year	>10 year
+6-8 weeks	10000037	Mus musculus C3H/FeJ X C57BL/6	806	6-8 week	6-8 week
+5-6 weeks-old	10090	Mus musculus (mouse)	807	5-6 week-old	5-6 week
+6-10 wks	10090	Mus musculus (mouse)	808	6-10 week	6-10 week
+5-10 years-old	9606	Homo sapiens (human)	809	5-10 year-old	5-10 year
+4-15 years	9606	Homo sapiens (human)	810	4-15 year	4-15 year
+19 to 91 years	9606	Homo sapiens (human)	811	19 to 91 year	19 to 91 year
+NULL	10000669	Cavia porcellus Hartley	812	null	null
+3-4 weeks	10000000	Mus musculus BALB/c	813	3-4 week	3-4 week
+45-55 yrs	9606	Homo sapiens (human)	814	45-55 year	45-55 year
+5-6 weeks	10001634	Mus musculus IFNR null	815	5-6 week	5-6 week
+10 weeks	10000635	Mus musculus NOD/Lt	816	10 week	10 week
+Mean: 30 years	9606	Homo sapiens (human)	817	mean: 30 year	mean: 30 year
+8-14 weeks	10090	Mus musculus (mouse)	818	8-14 week	8-14 week
+6-8 weeks old	10000653	Mus musculus Swiss	819	6-8 week old	6-8 week
+4 to 8 weeks	10000019	Mus musculus BALB/cByJ	820	4 to 8 week	4 to 8 week
+29 to 53 years	9606	Homo sapiens (human)	821	29 to 53 year	29 to 53 year
+8-20 weeks-old	10000263	Mus musculus B10.BR	822	8-20 week-old	8-20 week
+23-34 years	9606	Homo sapiens (human)	823	23-34 year	23-34 year
+22 years	9606	Homo sapiens (human)	824	22 year	22 year
+2-6 months	10000000	Mus musculus BALB/c	825	2-6 month	2-6 month
+8-12 wk.	10000067	Mus musculus C57BL/6	826	8-12 week.	8-12 week.
+8-12 wk.	10000223	Mus musculus C57BL/6J IAbeta null	827	8-12 week.	8-12 week.
+8 weeks	10002231	Mus musculus J15 TCR Tg	828	8 week	8 week
+NULL	10000040	Mus musculus 3A9 TCR Tg	829	null	null
+22 weeks	10000067	Mus musculus C57BL/6	830	22 week	22 week
+7 weeks	10001487	Mus musculus Apolipoprotein E null	831	7 week	7 week
+NULL	9940	Ovis aries (domestic sheep)	832	null	null
+13-64 years	9606	Homo sapiens (human)	833	13-64 year	13-64 year
+60-95 yrs	9606	Homo sapiens (human)	834	60-95 year	60-95 year
+35 years	9606	Homo sapiens (human)	835	35 year	35 year
+16-50 years-old	9606	Homo sapiens (human)	836	16-50 year-old	16-50 year
+6-10 weeks	10000607	Mus musculus HLA-DR3 Tg	837	6-10 week	6-10 week
+6-8 weeks	10000658	Rattus norvegicus Brown Norway	838	6-8 week	6-8 week
+> 8 wk.	10000211	Mus musculus (C57BL/10 X DBA/2) InsHA Tg	839	> 8 week.	> 8 week.
+6-8 weeks old	10000054	Mus musculus DBA/1	840	6-8 week old	6-8 week
+3 months	10000000	Mus musculus BALB/c	841	3 month	3 month
+NULL	10000267	Mus musculus B10.CE-H13b Aw/(30NX)Sn	842	null	null
+6 weeks	10000236	Mus musculus CBA/J	843	6 week	6 week
+average of 30.2 years	9606	Homo sapiens (human)	844	average of 30.2 year	average of 30.2 year
+4-5 weeks-old	10000000	Mus musculus BALB/c	845	4-5 week-old	4-5 week
+23 to 55 years	9606	Homo sapiens (human)	846	23 to 55 year	23 to 55 year
+6-7 weeks	10000662	Rattus norvegicus Lewis	847	6-7 week	6-7 week
+8 week-old	10000000	Mus musculus BALB/c	848	8 week-old	8 week
+8-12 weeks	10000063	Mus musculus B10.A	849	8-12 week	8-12 week
+8-12 wk	10000105	Mus musculus TRAMP Tg	850	8-12 week	8-12 week
+> 8 wk.	10000051	Mus musculus C57BL/10 X DBA/2	851	> 8 week.	> 8 week.
+NULL	10000004	Mus musculus BALB/c Factor IX null	852	null	null
+6-week-old	10000000	Mus musculus BALB/c	853	6-week-old	6 week
+50-65 years	9606	Homo sapiens (human)	854	50-65 year	50-65 year
+12 to 16 weeks	10000000	Mus musculus BALB/c	855	12 to 16 week	12 to 16 week
+7 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	856	7 to 10 week	7 to 10 week
+16 weeks	10000635	Mus musculus NOD/Lt	857	16 week	16 week
+25-40 years	9606	Homo sapiens (human)	858	25-40 year	25-40 year
+12-16 weeks	10000217	Mus musculus C57BL/6 X BALB/c-H2dm2	859	12-16 week	12-16 week
+12-16 weeks	10000216	Mus musculus C57BL/6 X BALB/c	860	12-16 week	12-16 week
+29 to 36 years	9606	Homo sapiens (human)	861	29 to 36 year	29 to 36 year
+8 weeks	10000063	Mus musculus B10.A	862	8 week	8 week
+5 weeks	10000067	Mus musculus C57BL/6	863	5 week	5 week
+8 wk	10000067	Mus musculus C57BL/6	864	8 week	8 week
+NULL	10002763	Mus musculus HLA-A*11:01 Tg	865	null	null
+8-12 weeks old	10090	Mus musculus (mouse)	866	8-12 week old	8-12 week
+6-10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	867	6-10 week	6-10 week
+8-12 weeks-old	10000000	Mus musculus BALB/c	868	8-12 week-old	8-12 week
+21-46 years	9606	Homo sapiens (human)	869	21-46 year	21-46 year
+8-13 weeks	10000216	Mus musculus C57BL/6 X BALB/c	870	8-13 week	8-13 week
+8-10	10000000	Mus musculus BALB/c	871	8-10	8-10
+20-45 years	9606	Homo sapiens (human)	872	20-45 year	20-45 year
+18 to 40 years	9606	Homo sapiens (human)	873	18 to 40 year	18 to 40 year
+8 week	10000000	Mus musculus BALB/c	874	8 week	8 week
+6-8 weeks	10000219	Mus musculus C57BL/6 X CBA	875	6-8 week	6-8 week
+8-24 weeks	10000007	Mus musculus 6.5 TCR Tg	876	8-24 week	8-24 week
+NULL	10001467	Mus musculus TAZ10 TCR Tg	877	null	null
+58 years	9606	Homo sapiens (human)	878	58 year	58 year
+21-87 years	9606	Homo sapiens (human)	879	21-87 year	21-87 year
+18-65  years	9606	Homo sapiens (human)	880	18-65  year	18-65  year
+25-38 years	9606	Homo sapiens (human)	881	25-38 year	25-38 year
+8 week old	10000067	Mus musculus C57BL/6	882	8 week old	8 week
+23-32	9606	Homo sapiens (human)	883	23-32	23-32
+8 to 10 weeks	10090	Mus musculus (mouse)	884	8 to 10 week	8 to 10 week
+3-5 weeks	10090	Mus musculus (mouse)	885	3-5 week	3-5 week
+21-62 years	9606	Homo sapiens (human)	886	21-62 year	21-62 year
+4-8 weeks	10000047	Mus musculus C57BL/10	887	4-8 week	4-8 week
+8-9 weeks	10000582	Mus musculus HLA-A2 Tg	888	8-9 week	8-9 week
+7-8 weeks	10000067	Mus musculus C57BL/6	889	7-8 week	7-8 week
+9 weeks	10000067	Mus musculus C57BL/6	890	9 week	9 week
+NULL	10001782	Mus musculus HLA-B*07:02 Tg	891	null	null
+7 to 12 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	892	7 to 12 week	7 to 12 week
+NULL	10000614	Mus musculus HLA-DR51 Tg	893	null	null
+9 weeks	10000632	Mus musculus NOD	894	9 week	9 week
+22-59 years	9606	Homo sapiens (human)	895	22-59 year	22-59 year
+8-12 weeks old	10000223	Mus musculus C57BL/6J IAbeta null	896	8-12 week old	8-12 week
+6-10 weeks	10000014	Mus musculus BALB/c X B10.BR	897	6-10 week	6-10 week
+23-66 years	9606	Homo sapiens (human)	898	23-66 year	23-66 year
+29-67 years	9606	Homo sapiens (human)	899	29-67 year	29-67 year
+8-12 weeks-old	10000216	Mus musculus C57BL/6 X BALB/c	900	8-12 week-old	8-12 week
+7-17 years old	9606	Homo sapiens (human)	901	7-17 year old	7-17 year
+8-78 years	9606	Homo sapiens (human)	902	8-78 year	8-78 year
+NULL	10000099	Mus musculus D7 TCR Tg	903	null	null
+1 month	10000000	Mus musculus BALB/c	904	1 month	1 month
+NULL	10116	Rattus norvegicus (brown rat)	905	null	null
+6-7 weeks	10000649	Mus musculus SJL	906	6-7 week	6-7 week
+NULL	10000252	Mus musculus A.SW	907	null	null
+NULL	292213	Aotus griseimembra	908	null	null
+NULL	10001983	Mus musculus HLA-DRB1*03:01 Tg	909	null	null
+NULL	10000257	Mus musculus B10 X B10.S	910	null	null
+NULL	10000285	Mus musculus B6.FVB-Tg(Itgax-DTR/EGFP)57Lan/J X C57BL/6	911	null	null
+24-73 years	9606	Homo sapiens (human)	912	24-73 year	24-73 year
+NULL	10000251	Mus musculus A.BY	913	null	null
+22-36 years	9606	Homo sapiens (human)	914	22-36 year	22-36 year
+6-12 weeks	10000271	Mus musculus B10.M	915	6-12 week	6-12 week
+34 years	9606	Homo sapiens (human)	916	34 year	34 year
+45-72 years	9606	Homo sapiens (human)	917	45-72 year	45-72 year
+6-10 weeks	10000233	Mus musculus CBA/Ca	918	6-10 week	6-10 week
+8-20 weeks-old	10000047	Mus musculus C57BL/10	919	8-20 week-old	8-20 week
+~ 33 to 55 years	9606	Homo sapiens (human)	920	~ 33 to 55 year	~ 33 to 55 year
+42-67 years	9606	Homo sapiens (human)	921	42-67 year	42-67 year
+50 yrs	9606	Homo sapiens (human)	922	50 year	50 year
+NULL	10000007	Mus musculus 6.5 TCR Tg	923	null	null
+6-10 weeks old	10000067	Mus musculus C57BL/6	924	6-10 week old	6-10 week
+6-10 weeks	10000220	Mus musculus C57BL/6 X DBA/2	925	6-10 week	6-10 week
+32-43 years	9606	Homo sapiens (human)	926	32-43 year	32-43 year
+6-8 weeks	10000290	Mus musculus BALB.K	927	6-8 week	6-8 week
+8-15 weeks	10000259	Mus musculus B10.A(3R)	928	8-15 week	8-15 week
+54 years old	9606	Homo sapiens (human)	929	54 year old	54 year
+NULL	10000031	Mus musculus C3H.NB	930	null	null
+8-16 weeks	10000263	Mus musculus B10.BR	931	8-16 week	8-16 week
+50-73 years	9606	Homo sapiens (human)	932	50-73 year	50-73 year
+7 weeks	10000632	Mus musculus NOD	933	7 week	7 week
+52-62 years	9606	Homo sapiens (human)	934	52-62 year	52-62 year
+42	9606	Homo sapiens (human)	935	42	42
+23 years	9606	Homo sapiens (human)	936	23 year	23 year
+23 and 61 years	9606	Homo sapiens (human)	937	23 and 61 year	23 and 61 year
+10-36 years	9606	Homo sapiens (human)	938	10-36 year	10-36 year
+20-56 years	9606	Homo sapiens (human)	939	20-56 year	20-56 year
+31	9606	Homo sapiens (human)	940	31	31
+31-42	9606	Homo sapiens (human)	941	31-42	31-42
+11-62 years-old	9606	Homo sapiens (human)	942	11-62 year-old	11-62 year
+57 to 75 years	9606	Homo sapiens (human)	943	57 to 75 year	57 to 75 year
+29-70	9606	Homo sapiens (human)	944	29-70	29-70
+8-14 weeks	10000216	Mus musculus C57BL/6 X BALB/c	945	8-14 week	8-14 week
+NULL	10000058	Mus musculus Flu (PR8) HA Tg	946	null	null
+6-10 weeks	10001926	Mus musculus FVIII null	947	6-10 week	6-10 week
+64 years	9606	Homo sapiens (human)	948	64 year	64 year
+59-61 years	9606	Homo sapiens (human)	949	59-61 year	59-61 year
+5-6 weeks old	10000000	Mus musculus BALB/c	950	5-6 week old	5-6 week
+32-74	9606	Homo sapiens (human)	951	32-74	32-74
+4-5 years	9544	Macaca mulatta (rhesus macaque)	952	4-5 year	4-5 year
+8 weeks-old	10000632	Mus musculus NOD	953	8 week-old	8 week
+7-12 week	10000253	Mus musculus A/J	954	7-12 week	7-12 week
+6-8	10000067	Mus musculus C57BL/6	955	6-8	6-8
+50-69 years	9606	Homo sapiens (human)	956	50-69 year	50-69 year
+20-52 years	9606	Homo sapiens (human)	957	20-52 year	20-52 year
+26	9606	Homo sapiens (human)	958	26	26
+42 years	9606	Homo sapiens (human)	959	42 year	42 year
+9 weeks	10000624	Mus musculus MF1	960	9 week	9 week
+18-70 years-old	9606	Homo sapiens (human)	961	18-70 year-old	18-70 year
+39 to 67 years	9606	Homo sapiens (human)	962	39 to 67 year	39 to 67 year
+1.1-11.6 years	9606	Homo sapiens (human)	963	1.1-11.6 year	1.1-11.6 year
+6-8 weeks	10000187	Sus scrofa Landrace X Large White	964	6-8 week	6-8 week
+17-65 years	9606	Homo sapiens (human)	965	17-65 year	17-65 year
+2-day old	10000000	Mus musculus BALB/c	966	2-day old	2 day
+2 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	967	2 month	2 month
+11 or 18 weeks	10000632	Mus musculus NOD	968	11 or 18 week	11 or 18 week
+11-50	9606	Homo sapiens (human)	969	11-50	11-50
+10-15 years	9598	Pan troglodytes (chimpanzee)	970	10-15 year	10-15 year
+6-12 weeks old	10090	Mus musculus (mouse)	971	6-12 week old	6-12 week
+8-12 weeks	10000289	Mus musculus BALB.B	972	8-12 week	8-12 week
+NULL	10001071	Mus musculus (A.CA x C57BL/6)F1	973	null	null
+6-8 weeks	10000273	Mus musculus B10.P	974	6-8 week	6-8 week
+7-12 weeks	10090	Mus musculus (mouse)	975	7-12 week	7-12 week
+39-73 years	9606	Homo sapiens (human)	976	39-73 year	39-73 year
+13-82 years	9606	Homo sapiens (human)	977	13-82 year	13-82 year
+18-61 years	9606	Homo sapiens (human)	978	18-61 year	18-61 year
+10 to over 90 years	9606	Homo sapiens (human)	979	10 to over 90 year	10 to over 90 year
+8-12 weeks	10000618	Mus musculus ICR	980	8-12 week	8-12 week
+6-8 weeks old	10000063	Mus musculus B10.A	981	6-8 week old	6-8 week
+6-8 weeks old	10000274	Mus musculus B10.PL	982	6-8 week old	6-8 week
+9-72	9606	Homo sapiens (human)	983	9-72	9-72
+6-8 weeks	10000236	Mus musculus CBA/J	984	6-8 week	6-8 week
+4 to 8 weeks	10090	Mus musculus (mouse)	985	4 to 8 week	4 to 8 week
+6-8 weeks old	10000279	Mus musculus B10.SM	986	6-8 week old	6-8 week
+6-8 weeks	10000053	Mus musculus DBA	987	6-8 week	6-8 week
+Adult (within 24 hours of parturition)	9606	Homo sapiens (human)	988	adult (within 24 hour of parturition)	adult (within 24 hour of parturition)
+6 to 8-week old	10000000	Mus musculus BALB/c	989	6 to 8-week old	6 to 8 week
+6-8 weeks old	10000253	Mus musculus A/J	990	6-8 week old	6-8 week
+0.5-15 years-old	9606	Homo sapiens (human)	991	0.5-15 year-old	0.5-15 year
+7-9 weeks	10000047	Mus musculus C57BL/10	992	7-9 week	7-9 week
+6-8 weeks old	10000281	Mus musculus B10.WB	993	6-8 week old	6-8 week
+21-30 years	9606	Homo sapiens (human)	994	21-30 year	21-30 year
+6-8 weeks	10000101	Mus musculus C57BL/6 Perforin null	995	6-8 week	6-8 week
+10-12 weeks old	10000000	Mus musculus BALB/c	996	10-12 week old	10-12 week
+5-8 weeks-old	10000000	Mus musculus BALB/c	997	5-8 week-old	5-8 week
+4-8 weeks	10000019	Mus musculus BALB/cByJ	998	4-8 week	4-8 week
+30-60 years old	9606	Homo sapiens (human)	999	30-60 year old	30-60 year
+18 weeks	10000632	Mus musculus NOD	1000	18 week	18 week
+< 11 years	9606	Homo sapiens (human)	1001	< 11 year	< 11 year
+8-14 weeks	10001211	Mus musculus (C57BL/6 X A/J)	1002	8-14 week	8-14 week
+26 years old	9606	Homo sapiens (human)	1003	26 year old	26 year
+43 years	9606	Homo sapiens (human)	1004	43 year	43 year
+5-8 weeks old	10000011	Mus musculus ABLE Tg TCR	1005	5-8 week old	5-8 week
+6-7 weeks	10000067	Mus musculus C57BL/6	1006	6-7 week	6-7 week
+25-88 years	9606	Homo sapiens (human)	1007	25-88 year	25-88 year
+20-72 years	9606	Homo sapiens (human)	1008	20-72 year	20-72 year
+6-8 weeks	10000234	Mus musculus HLA-G Transgenic	1009	6-8 week	6-8 week
+NULL	10000605	Mus musculus HLA-DR2 Tg	1010	null	null
+3 weeks	10000000	Mus musculus BALB/c	1011	3 week	3 week
+2 months and 5 months	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	1012	2 month and 5 month	2 month and 5 month
+6-7 weeks	10000038	Mus musculus C3H/He	1013	6-7 week	6-7 week
+8-10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1014	8-10 week	8-10 week
+8-10 weeks old	10000632	Mus musculus NOD	1015	8-10 week old	8-10 week
+7 days	10000067	Mus musculus C57BL/6	1016	7 days	7 days
+7 day old	10000067	Mus musculus C57BL/6	1017	7 day old	7 day
+28 to 33 years	9606	Homo sapiens (human)	1018	28 to 33 year	28 to 33 year
+42 to 43 years	9606	Homo sapiens (human)	1019	42 to 43 year	42 to 43 year
+5 months	10000224	Mus musculus C57BL/6JTgN(Alb1HBV)44Bri	1020	5 month	5 month
+6-9 weeks	10000013	Mus musculus BALB/c X A/J	1021	6-9 week	6-9 week
+6 weeks	10000028	Mus musculus C3H	1022	6 week	6 week
+45.8 years	9606	Homo sapiens (human)	1023	45.8 year	45.8 year
+22 to 42 years	9606	Homo sapiens (human)	1024	22 to 42 year	22 to 42 year
+8-16 weeks	10000618	Mus musculus ICR	1025	8-16 week	8-16 week
+20 to 69 years	9606	Homo sapiens (human)	1026	20 to 69 year	20 to 69 year
+28 to 30 years	9606	Homo sapiens (human)	1027	28 to 30 year	28 to 30 year
+8-12 weeks	10000228	Mus musculus CBA	1028	8-12 week	8-12 week
+NULL	10000113	Homo sapiens Black	1029	null	null
+2-6 months	10000601	Mus musculus HLA-DR1 Tg	1030	2-6 month	2-6 month
+6-12 weeks	10000594	Mus musculus HLA-B27 Tg	1031	6-12 week	6-12 week
+7-12 weeks-old	10000038	Mus musculus C3H/He	1032	7-12 week-old	7-12 week
+newborn	10000000	Mus musculus BALB/c	1033	newborn	newborn
+5 or 6 weeks	10090	Mus musculus (mouse)	1034	5 or 6 week	5 or 6 week
+6-12 weeks	10000289	Mus musculus BALB.B	1035	6-12 week	6-12 week
+20 to 64 years	9606	Homo sapiens (human)	1036	20 to 64 year	20 to 64 year
+8-24 weeks old	10000263	Mus musculus B10.BR	1037	8-24 week old	8-24 week
+6 weeks or older	10090	Mus musculus (mouse)	1038	6 week or older	6 week or older
+8-24 weeks old	10000278	Mus musculus B10.S(9R)	1039	8-24 week old	8-24 week
+8-24 weeks old	10000051	Mus musculus C57BL/10 X DBA/2	1040	8-24 week old	8-24 week
+6-8 weeks-old	10000263	Mus musculus B10.BR	1041	6-8 week-old	6-8 week
+9.5 months	10001286	Mus musculus APPswe/PSEN1	1042	9.5 month	9.5 month
+3-6 weeks	10000263	Mus musculus B10.BR	1043	3-6 week	3-6 week
+8-24 weeks old	10000053	Mus musculus DBA	1044	8-24 week old	8-24 week
+26-58 years old	9606	Homo sapiens (human)	1045	26-58 year old	26-58 year
+6-12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1046	6-12 week	6-12 week
+8-24 weeks old	10000000	Mus musculus BALB/c	1047	8-24 week old	8-24 week
+NULL	10001998	Mus musculus CD1	1048	null	null
+2-4 months	10000000	Mus musculus BALB/c	1049	2-4 month	2-4 month
+1-14 years	9606	Homo sapiens (human)	1050	1-14 year	1-14 year
+12 weeks-old	9685	Felis catus (cat)	1051	12 week-old	12 week
+NULL	10001301	Mus musculus HLA-DR15 Tg	1052	null	null
+23-44 years	9606	Homo sapiens (human)	1053	23-44 year	23-44 year
+6 weeks	10000043	Mus musculus C3HeB/FeJ	1054	6 week	6 week
+46.3-66.3 years	9606	Homo sapiens (human)	1055	46.3-66.3 year	46.3-66.3 year
+25.5 - 56 years	9606	Homo sapiens (human)	1056	25.5 - 56 year	25.5 - 56 year
+12-13 weeks	10000632	Mus musculus NOD	1057	12-13 week	12-13 week
+NULL	10001400	Mus musculus HLA-DRB1*15:02 Tg	1058	null	null
+44	9606	Homo sapiens (human)	1059	44	44
+6-8 weeks	10000632	Mus musculus NOD	1060	6-8 week	6-8 week
+46 years-old	9606	Homo sapiens (human)	1061	46 year-old	46 year
+18, 35 years	9606	Homo sapiens (human)	1062	18, 35 year	18, 35 year
+6-8	10000000	Mus musculus BALB/c	1063	6-8	6-8
+6 to 8 weeks	10000038	Mus musculus C3H/He	1064	6 to 8 week	6 to 8 week
+5 years	10000190	Bos taurus Friesian	1065	5 year	5 year
+6-10 weeks	10000051	Mus musculus C57BL/10 X DBA/2	1066	6-10 week	6-10 week
+11 weeks	10000637	Mus musculus NODasp	1067	11 week	11 week
+Adult	10000051	Mus musculus C57BL/10 X DBA/2	1068	adult	adult
+6 to 8 weeks	10001257	Mus musculus NOD.H-2h4	1069	6 to 8 week	6 to 8 week
+6-8	10000916	Mus musculus C3H/He-mg	1070	6-8	6-8
+2-3 months	10000000	Mus musculus BALB/c	1071	2-3 month	2-3 month
+54 years	9606	Homo sapiens (human)	1072	54 year	54 year
+3 weeks	10000627	Mus musculus MRL/MpJ	1073	3 week	3 week
+7 yo 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1074	7 year 8 week	7 year 8 week
+NULL	10000622	Mus musculus Kb null	1075	null	null
+20 years	9606	Homo sapiens (human)	1076	20 year	20 year
+6-8 weeks	10000033	Mus musculus C3H.SW	1077	6-8 week	6-8 week
+5 or 8 weeks	10000632	Mus musculus NOD	1078	5 or 8 week	5 or 8 week
+7 weeks	10000000	Mus musculus BALB/c	1079	7 week	7 week
+6 to 8 weeks	10001469	Mus musculus C57BL/6 TSHR null	1080	6 to 8 week	6 to 8 week
+7-12 weeks-old	10090	Mus musculus (mouse)	1081	7-12 week-old	7-12 week
+1 week	10000000	Mus musculus BALB/c	1082	1 week	1 week
+24-51 years	9606	Homo sapiens (human)	1083	24-51 year	24-51 year
+21-58 years-old	9606	Homo sapiens (human)	1084	21-58 year-old	21-58 year
+6-10 weeks-old	10000263	Mus musculus B10.BR	1085	6-10 week-old	6-10 week
+20-69 years	9606	Homo sapiens (human)	1086	20-69 year	20-69 year
+2.5-6 months	10000228	Mus musculus CBA	1087	2.5-6 month	2.5-6 month
+6 to 12 weeks	10000649	Mus musculus SJL	1088	6 to 12 week	6 to 12 week
+NULL	10001326	Mus musculus Tg4 TCR Tg	1089	null	null
+8-14 weeks	10000093	Mus musculus C57BL/6 human IgCkappa Tg	1090	8-14 week	8-14 week
+35.4 yrs. Average	9606	Homo sapiens (human)	1091	35.4 year. average	35.4 year. average
+14 to 53 years	9606	Homo sapiens (human)	1092	14 to 53 year	14 to 53 year
+41 years old	9606	Homo sapiens (human)	1093	41 year old	41 year
+NULL	10000012	Mus musculus BALB/c Thy-LCMV NP Tg	1094	null	null
+6-8 weeks old	10000648	Mus musculus RIIIS	1095	6-8 week old	6-8 week
+7 to 14 weeks	10000002	Mus musculus BALB/c beta2m null	1096	7 to 14 week	7 to 14 week
+4-8-week-old	10000000	Mus musculus BALB/c	1097	4-8-week-old	4-8 week
+6-8 wk.	10000000	Mus musculus BALB/c	1098	6-8 week.	6-8 week.
+8 weeks-old	10000000	Mus musculus BALB/c	1099	8 week-old	8 week
+37 years	9606	Homo sapiens (human)	1100	37 year	37 year
+6 weeks-old	10000653	Mus musculus Swiss	1101	6 week-old	6 week
+6-15 weeks	10000632	Mus musculus NOD	1102	6-15 week	6-15 week
+6-8 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	1103	6-8 week	6-8 week
+NULL	10000655	Mus musculus Swiss Webster	1104	null	null
+6-10 weeks	10090	Mus musculus (mouse)	1105	6-10 week	6-10 week
+9.4 months	10001241	Mus musculus APP	1106	9.4 month	9.4 month
+8-10 weeks	10001244	Mus musculus NOR	1107	8-10 week	8-10 week
+8-15 years	9606	Homo sapiens (human)	1108	8-15 year	8-15 year
+NULL	10001256	Mus musculus GAD286 TCR Tg	1109	null	null
+5 weeks	10000632	Mus musculus NOD	1110	5 week	5 week
+NULL	10001248	Mus musculus NOD.Cg-Tg	1111	null	null
+6-42 years	10000119	Homo sapiens Caucasian	1112	6-42 year	6-42 year
+21-53 years	9606	Homo sapiens (human)	1113	21-53 year	21-53 year
+3-52 years	9606	Homo sapiens (human)	1114	3-52 year	3-52 year
+7-8 weeks	10000632	Mus musculus NOD	1115	7-8 week	7-8 week
+57 years old	9606	Homo sapiens (human)	1116	57 year old	57 year
+25-58 years	9606	Homo sapiens (human)	1117	25-58 year	25-58 year
+13 years	9606	Homo sapiens (human)	1118	13 year	13 year
+Young	10000632	Mus musculus NOD	1119	young	young
+Median age 11.3 years	9606	Homo sapiens (human)	1120	median age 11.3 year	median age 11.3 year
+8-10 weeks	10001211	Mus musculus (C57BL/6 X A/J)	1121	8-10 week	8-10 week
+8-10 weeks	10000220	Mus musculus C57BL/6 X DBA/2	1122	8-10 week	8-10 week
+8-10 weeks	10000218	Mus musculus C57BL/6 X C3H	1123	8-10 week	8-10 week
+10 weeks	10000632	Mus musculus NOD	1124	10 week	10 week
+12-20 weeks	10000236	Mus musculus CBA/J	1125	12-20 week	12-20 week
+8-12 weeks	10000635	Mus musculus NOD/Lt	1126	8-12 week	8-12 week
+9 weeks	10001259	Mus musculus NOD.PD	1127	9 week	9 week
+neonatal	10000632	Mus musculus NOD	1128	neonatal	neonatal
+2 weeks	10000632	Mus musculus NOD	1129	2 week	2 week
+12 weeks	10000632	Mus musculus NOD	1130	12 week	12 week
+NULL	10000635	Mus musculus NOD/Lt	1131	null	null
+NULL	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	1132	null	null
+6 weeks old	10000632	Mus musculus NOD	1133	6 week old	6 week
+2 months to 52 years	9606	Homo sapiens (human)	1134	2 month to 52 year	2 month to 52 year
+16-50 years	9606	Homo sapiens (human)	1135	16-50 year	16-50 year
+6-8 weeks	10001248	Mus musculus NOD.Cg-Tg	1136	6-8 week	6-8 week
+8-14 years	9606	Homo sapiens (human)	1137	8-14 year	8-14 year
+Median age 6.3 years	9606	Homo sapiens (human)	1138	median age 6.3 year	median age 6.3 year
+7-15 weeks	10000582	Mus musculus HLA-A2 Tg	1139	7-15 week	7-15 week
+NULL	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	1140	null	null
+8 weeks old	10000632	Mus musculus NOD	1141	8 week old	8 week
+NULL	10001286	Mus musculus APPswe/PSEN1	1142	null	null
+NULL	10001244	Mus musculus NOR	1143	null	null
+7-48 years	9606	Homo sapiens (human)	1144	7-48 year	7-48 year
+8 to 10 weeks	10001266	Mus musculus NOD/Caj	1145	8 to 10 week	8 to 10 week
+6-8 weeks	10000610	Mus musculus HLA-DR4 Tg	1146	6-8 week	6-8 week
+4 weeks	10001251	Mus musculus RIP-B7	1147	4 week	4 week
+11 weeks	10000632	Mus musculus NOD	1148	11 week	11 week
+46 to 92 years	9606	Homo sapiens (human)	1149	46 to 92 year	46 to 92 year
+8 weeks	10001313	Mus musculus GAD65 p206 TCR Tg	1150	8 week	8 week
+14 week old	10000632	Mus musculus NOD	1151	14 week old	14 week
+3-4 weeks	10000632	Mus musculus NOD	1152	3-4 week	3-4 week
+NULL	10001133	Rattus norvegicus DA	1153	null	null
+8-12 weeks	10000632	Mus musculus NOD	1154	8-12 week	8-12 week
+23-48 years	9606	Homo sapiens (human)	1155	23-48 year	23-48 year
+NULL	10000596	Mus musculus HLA-DQ Transgenic	1156	null	null
+6 to 12 weeks old	10000067	Mus musculus C57BL/6	1157	6 to 12 week old	6 to 12 week
+7-10 weeks	10000649	Mus musculus SJL	1158	7-10 week	7-10 week
+4-6 weeks	10000632	Mus musculus NOD	1159	4-6 week	4-6 week
+NULL	10001261	Mus musculus G9Calpha –/ –.NOD	1160	null	null
+1-16 years	9606	Homo sapiens (human)	1161	1-16 year	1-16 year
+10-16 weeks	10000632	Mus musculus NOD	1162	10-16 week	10-16 week
+8 to 12 weeks	10000662	Rattus norvegicus Lewis	1163	8 to 12 week	8 to 12 week
+22-35 years	9606	Homo sapiens (human)	1164	22-35 year	22-35 year
+16-43 years	9606	Homo sapiens (human)	1165	16-43 year	16-43 year
+4 weeks	10000635	Mus musculus NOD/Lt	1166	4 week	4 week
+4 to 6 weeks old	10001248	Mus musculus NOD.Cg-Tg	1167	4 to 6 week old	4 to 6 week
+4-6 weeks	10001244	Mus musculus NOR	1168	4-6 week	4-6 week
+8-12 weeks	10001244	Mus musculus NOR	1169	8-12 week	8-12 week
+4 weeks	10000632	Mus musculus NOD	1170	4 week	4 week
+10-12 weeks	10000635	Mus musculus NOD/Lt	1171	10-12 week	10-12 week
+1 month	10000632	Mus musculus NOD	1172	1 month	1 month
+6-41 years	9606	Homo sapiens (human)	1173	6-41 year	6-41 year
+8 to 10 weeks	10000070	Mus musculus C57BL/6 bg	1174	8 to 10 week	8 to 10 week
+6-64 years	9606	Homo sapiens (human)	1175	6-64 year	6-64 year
+6-8 weeks	10000635	Mus musculus NOD/Lt	1176	6-8 week	6-8 week
+4 to 5 weeks	10000000	Mus musculus BALB/c	1177	4 to 5 week	4 to 5 week
+2–25 years	9606	Homo sapiens (human)	1178	225 year	225 year
+7 days	10000632	Mus musculus NOD	1179	7 days	7 days
+25	9606	Homo sapiens (human)	1180	25	25
+49	9606	Homo sapiens (human)	1181	49	49
+6-12 weeks	10000632	Mus musculus NOD	1182	6-12 week	6-12 week
+9-20 weeks	10000632	Mus musculus NOD	1183	9-20 week	9-20 week
+20-40 years	9606	Homo sapiens (human)	1184	20-40 year	20-40 year
+6-8 weeks	10002205	Mus musculus TCR-I TCR Tg	1185	6-8 week	6-8 week
+5 weeks	10001256	Mus musculus GAD286 TCR Tg	1186	5 week	5 week
+66-86 years	9606	Homo sapiens (human)	1187	66-86 year	66-86 year
+18-65 years	9606	Homo sapiens (human)	1188	18-65 year	18-65 year
+6-10 weeks	10000632	Mus musculus NOD	1189	6-10 week	6-10 week
+17	9606	Homo sapiens (human)	1190	17	17
+8-12 weeks	10000065	Mus musculus C57BL/10SnJ	1191	8-12 week	8-12 week
+4-20 weeks	10000635	Mus musculus NOD/Lt	1192	4-20 week	4-20 week
+8-10 weeks	10000635	Mus musculus NOD/Lt	1193	8-10 week	8-10 week
+6 weeks	10000635	Mus musculus NOD/Lt	1194	6 week	6 week
+13-31 years	9606	Homo sapiens (human)	1195	13-31 year	13-31 year
+4-12 weeks	10000635	Mus musculus NOD/Lt	1196	4-12 week	4-12 week
+9 or 20 weeks	10000632	Mus musculus NOD	1197	9 or 20 week	9 or 20 week
+12 weeks	10000635	Mus musculus NOD/Lt	1198	12 week	12 week
+4 weeks	10001254	Mus musculus RIP-B7 X BALB/c	1199	4 week	4 week
+NULL	10000187	Sus scrofa Landrace X Large White	1200	null	null
+8-10 weeks	10001237	Mus musculus HLA-B*35:01 Tg	1201	8-10 week	8-10 week
+NULL	10000068	Mus musculus 2C TCR Tg	1202	null	null
+9-25 years	9606	Homo sapiens (human)	1203	9-25 year	9-25 year
+adult	10001275	Rattus norvegicus PVG-RT1u	1204	adult	adult
+NULL	10001260	Mus musculus Tg AI4-NOD.Rag1-/-	1205	null	null
+63-82 years	9606	Homo sapiens (human)	1206	63-82 year	63-82 year
+16-36 years	10000119	Homo sapiens Caucasian	1207	16-36 year	16-36 year
+7-11 weeks	10000632	Mus musculus NOD	1208	7-11 week	7-11 week
+8-11 weeks old	10000065	Mus musculus C57BL/10SnJ	1209	8-11 week old	8-11 week
+20 weeks	10000632	Mus musculus NOD	1210	20 week	20 week
+8-12 weeks	10000598	Mus musculus HLA-DQ8 Tg	1211	8-12 week	8-12 week
+12 weeks	10001256	Mus musculus GAD286 TCR Tg	1212	12 week	12 week
+8-12 weeks	10000266	Mus musculus B10.BR-H2k H2-T18a/SgSnJ	1213	8-12 week	8-12 week
+20-27 weeks	10000632	Mus musculus NOD	1214	20-27 week	20-27 week
+1-32	9606	Homo sapiens (human)	1215	1-32	1-32
+5-10 weeks	10001248	Mus musculus NOD.Cg-Tg	1216	5-10 week	5-10 week
+25-80 years	9606	Homo sapiens (human)	1217	25-80 year	25-80 year
+6-18 weeks	10000632	Mus musculus NOD	1218	6-18 week	6-18 week
+8-12 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	1219	8-12 week	8-12 week
+2-15 years	9606	Homo sapiens (human)	1220	2-15 year	2-15 year
+2-16 years	9606	Homo sapiens (human)	1221	2-16 year	2-16 year
+6-8 weeks	10001271	Mus musculus NOD-PI/NOD8.3	1222	6-8 week	6-8 week
+21-52 years	9606	Homo sapiens (human)	1223	21-52 year	21-52 year
+6-16 weeks	10000598	Mus musculus HLA-DQ8 Tg	1224	6-16 week	6-16 week
+3-34 years	9606	Homo sapiens (human)	1225	3-34 year	3-34 year
+2-3 months	10001221	Mus musculus C57BL/6 x SJL	1226	2-3 month	2-3 month
+6 weeks	10000632	Mus musculus NOD	1227	6 week	6 week
+8-10 weeks	10000032	Mus musculus C3H.Q	1228	8-10 week	8-10 week
+10-14 weeks	10000649	Mus musculus SJL	1229	10-14 week	10-14 week
+8-14 weeks	10000649	Mus musculus SJL	1230	8-14 week	8-14 week
+NULL	10000616	Mus musculus HLA-DRB1*04:01 Tg	1231	null	null
+Mean=28.5 ± 15.0	9606	Homo sapiens (human)	1232	mean=28.5  15.0	mean=28.5  15.0
+35-45 years	9606	Homo sapiens (human)	1233	35-45 year	35-45 year
+21-59 years	9606	Homo sapiens (human)	1234	21-59 year	21-59 year
+13-56 years	9606	Homo sapiens (human)	1235	13-56 year	13-56 year
+>16 weeks	10000632	Mus musculus NOD	1236	>16 week	>16 week
+2-3 months	10001241	Mus musculus APP	1237	2-3 month	2-3 month
+2-3 months	10001282	Mus musculus TGF-beta1	1238	2-3 month	2-3 month
+7-9 weeks	10000054	Mus musculus DBA/1	1239	7-9 week	7-9 week
+5-7 weeks	10000054	Mus musculus DBA/1	1240	5-7 week	5-7 week
+3-22 years	9606	Homo sapiens (human)	1241	3-22 year	3-22 year
+>16 years	9606	Homo sapiens (human)	1242	>16 year	>16 year
+4 to 16 years	9606	Homo sapiens (human)	1243	4 to 16 year	4 to 16 year
+14 to 51 years	9606	Homo sapiens (human)	1244	14 to 51 year	14 to 51 year
+> 6 months	10000632	Mus musculus NOD	1245	> 6 month	> 6 month
+NULL	10002233	Mus musculus 16.2beta TCR Tg	1246	null	null
+18-43 years	9606	Homo sapiens (human)	1247	18-43 year	18-43 year
+20-26 years	9606	Homo sapiens (human)	1248	20-26 year	20-26 year
+2-3 months	10001281	Mus musculus APP/TGF-beta1	1249	2-3 month	2-3 month
+27-41 years	9606	Homo sapiens (human)	1250	27-41 year	27-41 year
+14 to 24 years	9606	Homo sapiens (human)	1251	14 to 24 year	14 to 24 year
+24-66 years	9606	Homo sapiens (human)	1252	24-66 year	24-66 year
+6-8 weeks	10000013	Mus musculus BALB/c X A/J	1253	6-8 week	6-8 week
+NULL	10001019	Mus musculus B10.D2	1254	null	null
+10-14 weeks	10000653	Mus musculus Swiss	1255	10-14 week	10-14 week
+12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1256	12 week	12 week
+5-38 years	9606	Homo sapiens (human)	1257	5-38 year	5-38 year
+3 months	10000632	Mus musculus NOD	1258	3 month	3 month
+2, 3, or 4 months	10000632	Mus musculus NOD	1259	2, 3, or 4 month	2, 3, or 4 month
+12-13 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1260	12-13 week	12-13 week
+10.1 ± 3.6 yr	9606	Homo sapiens (human)	1261	10.1  3.6 year	10.1  3.6 year
+9 weeks	10000635	Mus musculus NOD/Lt	1262	9 week	9 week
+8-10 weeks	10000054	Mus musculus DBA/1	1263	8-10 week	8-10 week
+6-15 weeks	10000649	Mus musculus SJL	1264	6-15 week	6-15 week
+41-73	9606	Homo sapiens (human)	1265	41-73	41-73
+8 to 12 weeks	10001337	Rattus norvegicus LEWIS.1W	1266	8 to 12 week	8 to 12 week
+NULL	10001350	Mus musculus B7-2 null	1267	null	null
+2-12 months	10000649	Mus musculus SJL	1268	2-12 month	2-12 month
+8-12 weeks	10001333	Rattus norvegicus LEW.1N	1269	8-12 week	8-12 week
+34 to 66 years	9606	Homo sapiens (human)	1270	34 to 66 year	34 to 66 year
+25 to 67 years	9606	Homo sapiens (human)	1271	25 to 67 year	25 to 67 year
+8-12 weeks	10000662	Rattus norvegicus Lewis	1272	8-12 week	8-12 week
+32-58	9606	Homo sapiens (human)	1273	32-58	32-58
+28 to 64 years	9606	Homo sapiens (human)	1274	28 to 64 year	28 to 64 year
+28 to 61 years	9606	Homo sapiens (human)	1275	28 to 61 year	28 to 61 year
+Newborn	10000649	Mus musculus SJL	1276	newborn	newborn
+33-77 years	9606	Homo sapiens (human)	1277	33-77 year	33-77 year
+6 to 7 weeks	10000649	Mus musculus SJL	1278	6 to 7 week	6 to 7 week
+2-3 months	10000662	Rattus norvegicus Lewis	1279	2-3 month	2-3 month
+14-20 weeks	10000662	Rattus norvegicus Lewis	1280	14-20 week	14-20 week
+6 to 8 weeks	10000649	Mus musculus SJL	1281	6 to 8 week	6 to 8 week
+6 weeks	10000649	Mus musculus SJL	1282	6 week	6 week
+5 to 6 weeks	10000649	Mus musculus SJL	1283	5 to 6 week	5 to 6 week
+7-8 weeks	10000038	Mus musculus C3H/He	1284	7-8 week	7-8 week
+7-9 weeks old	10000253	Mus musculus A/J	1285	7-9 week old	7-9 week
+16-73 years	9606	Homo sapiens (human)	1286	16-73 year	16-73 year
+6 to 10 weeks	10000649	Mus musculus SJL	1287	6 to 10 week	6 to 10 week
+8-10 weeks	10001133	Rattus norvegicus DA	1288	8-10 week	8-10 week
+8-10 weeks	10000662	Rattus norvegicus Lewis	1289	8-10 week	8-10 week
+mean age 26.5 years	9606	Homo sapiens (human)	1290	mean age 26.5 year	mean age 26.5 year
+5 to 8 weeks	10000649	Mus musculus SJL	1291	5 to 8 week	5 to 8 week
+4 to 8 weeks	10000649	Mus musculus SJL	1292	4 to 8 week	4 to 8 week
+4 to 6 weeks	10000649	Mus musculus SJL	1293	4 to 6 week	4 to 6 week
+NULL	10001410	Mus musculus 5B6 TCR Tg	1294	null	null
+3 to 4 months	10000662	Rattus norvegicus Lewis	1295	3 to 4 month	3 to 4 month
+21-91 years	9606	Homo sapiens (human)	1296	21-91 year	21-91 year
+18-85 years	9606	Homo sapiens (human)	1297	18-85 year	18-85 year
+NULL	10001221	Mus musculus C57BL/6 x SJL	1298	null	null
+NULL	10000665	Rattus norvegicus LOU/M	1299	null	null
+8 to 12 weeks	10000649	Mus musculus SJL	1300	8 to 12 week	8 to 12 week
+33 to 57 years	9606	Homo sapiens (human)	1301	33 to 57 year	33 to 57 year
+5 to 7 weeks	10000649	Mus musculus SJL	1302	5 to 7 week	5 to 7 week
+NULL	10001376	Mus musculus HLA-DQB1*06:04 Tg	1303	null	null
+6 weeks	10000669	Cavia porcellus Hartley	1304	6 week	6 week
+12- 14 weeks	10000632	Mus musculus NOD	1305	12- 14 week	12- 14 week
+NULL	10001314	Mus musculus HPV 16 E7 Tg	1306	null	null
+8 to 13 weeks	10000649	Mus musculus SJL	1307	8 to 13 week	8 to 13 week
+18-82 years	9606	Homo sapiens (human)	1308	18-82 year	18-82 year
+2 to 3 months	10000067	Mus musculus C57BL/6	1309	2 to 3 month	2 to 3 month
+51 years	9606	Homo sapiens (human)	1310	51 year	51 year
+8-12 weeks	10001133	Rattus norvegicus DA	1311	8-12 week	8-12 week
+64-86 years	9606	Homo sapiens (human)	1312	64-86 year	64-86 year
+8 -12 weeks old	10001041	Rattus norvegicus Wistar	1313	8 -12 week old	8 -12 week
+6 to 10 weeks	10001537	Mus musculus PL	1314	6 to 10 week	6 to 10 week
+10 to 12 weeks	10090	Mus musculus (mouse)	1315	10 to 12 week	10 to 12 week
+9-11 weeks old	10000000	Mus musculus BALB/c	1316	9-11 week old	9-11 week
+22 to 56 years	9606	Homo sapiens (human)	1317	22 to 56 year	22 to 56 year
+4 to 6 weeks	10000662	Rattus norvegicus Lewis	1318	4 to 6 week	4 to 6 week
+29 to 54 years	9606	Homo sapiens (human)	1319	29 to 54 year	29 to 54 year
+4-6 weeks	10001446	Rattus norvegicus Wistar Kyoto	1320	4-6 week	4-6 week
+6 to 10 weeks	10000610	Mus musculus HLA-DR4 Tg	1321	6 to 10 week	6 to 10 week
+NULL	10000025	Mus musculus Biozzi AB/H	1322	null	null
+2 months	10001348	Mus musculus A.CA	1323	2 month	2 month
+Young adults	9544	Macaca mulatta (rhesus macaque)	1324	young adults	young adults
+5 to 8 weeks	10000653	Mus musculus Swiss	1325	5 to 8 week	5 to 8 week
+5 to 8 weeks	10001349	Mus musculus SJL X SWR	1326	5 to 8 week	5 to 8 week
+Young adult	10000662	Rattus norvegicus Lewis	1327	young adult	young adult
+NULL	10001356	Mus musculus MBP 84-105 HEL Tg	1328	null	null
+Adult	10000662	Rattus norvegicus Lewis	1329	adult	adult
+6 to 8 weeks	10000000	Mus musculus BALB/c	1330	6 to 8 week	6 to 8 week
+6 to 8 weeks	10000662	Rattus norvegicus Lewis	1331	6 to 8 week	6 to 8 week
+8 to 10 weeks	10000662	Rattus norvegicus Lewis	1332	8 to 10 week	8 to 10 week
+8 to 12 weeks	10001332	Rattus norvegicus LEW.1AV1	1333	8 to 12 week	8 to 12 week
+18-51 years	9606	Homo sapiens (human)	1334	18-51 year	18-51 year
+13-31 weeks	10001406	Mus musculus MLR/lpr	1335	13-31 week	13-31 week
+38.6 years (mean age)	9606	Homo sapiens (human)	1336	38.6 year (mean age)	38.6 year (mean age)
+6 to 8 weeks old	10000054	Mus musculus DBA/1	1337	6 to 8 week old	6 to 8 week
+5-7 weeks	10000973	Mus musculus 129	1338	5-7 week	5-7 week
+8 to 10 weeks	10001384	Mus musculus TCR1640 Tg	1339	8 to 10 week	8 to 10 week
+8 to 12 weeks	10001347	Mus musculus 129/Sv	1340	8 to 12 week	8 to 12 week
+8 weeks	10000662	Rattus norvegicus Lewis	1341	8 week	8 week
+36-55 years	9606	Homo sapiens (human)	1342	36-55 year	36-55 year
+2-12 months	10000255	Mus musculus AKR	1343	2-12 month	2-12 month
+8 to 12 weeks	10001374	Mus musculus ICOS null	1344	8 to 12 week	8 to 12 week
+2 months or 2-10 months	10000047	Mus musculus C57BL/10	1345	2 month or 2-10 month	2 month or 2-10 month
+22-77 years	9606	Homo sapiens (human)	1346	22-77 year	22-77 year
+27-58 years	9606	Homo sapiens (human)	1347	27-58 year	27-58 year
+7 months	10001301	Mus musculus HLA-DR15 Tg	1348	7 month	7 month
+10-13 weeks	10001367	Mus musculus Pten fl/fl GBC	1349	10-13 week	10-13 week
+10-13 weeks	10000067	Mus musculus C57BL/6	1350	10-13 week	10-13 week
+NULL	10001365	Mus musculus Clone 19 TCR Tg	1351	null	null
+6 to 8 weeks	10116	Rattus norvegicus (brown rat)	1352	6 to 8 week	6 to 8 week
+5 months	10000067	Mus musculus C57BL/6	1353	5 month	5 month
+8 to 12 weeks	10001327	Mus musculus PL/J X SJL	1354	8 to 12 week	8 to 12 week
+26-42 years	9606	Homo sapiens (human)	1355	26-42 year	26-42 year
+6-10 weeks	10000658	Rattus norvegicus Brown Norway	1356	6-10 week	6-10 week
+36-43 years	9606	Homo sapiens (human)	1357	36-43 year	36-43 year
+33-56 years	9606	Homo sapiens (human)	1358	33-56 year	33-56 year
+2.5-4 months	10000919	Gallus gallus White Leghorn	1359	2.5-4 month	2.5-4 month
+23 to 52 years	9606	Homo sapiens (human)	1360	23 to 52 year	23 to 52 year
+8-10 weeks	10001221	Mus musculus C57BL/6 x SJL	1361	8-10 week	8-10 week
+14-60 years	9606	Homo sapiens (human)	1362	14-60 year	14-60 year
+89.7 years	9606	Homo sapiens (human)	1363	89.7 year	89.7 year
+14-20 weeks	10001332	Rattus norvegicus LEW.1AV1	1364	14-20 week	14-20 week
+6-10 weeks	10000662	Rattus norvegicus Lewis	1365	6-10 week	6-10 week
+14-20 weeks	10001339	Rattus norvegicus LEWIS.1A	1366	14-20 week	14-20 week
+6 weeks	10000662	Rattus norvegicus Lewis	1367	6 week	6 week
+14-20 weeks	10001337	Rattus norvegicus LEWIS.1W	1368	14-20 week	14-20 week
+8 weeks	10000228	Mus musculus CBA	1369	8 week	8 week
+7-9 weeks old	10000000	Mus musculus BALB/c	1370	7-9 week old	7-9 week
+7-9 weeks old	10000038	Mus musculus C3H/He	1371	7-9 week old	7-9 week
+7-9 weeks old	10000067	Mus musculus C57BL/6	1372	7-9 week old	7-9 week
+7 weeks	10000649	Mus musculus SJL	1373	7 week	7 week
+average age = 19.2 years	9606	Homo sapiens (human)	1374	average age = 19.2 year	average age = 19.2 year
+51	9606	Homo sapiens (human)	1375	51	51
+8 to 10 weeks old	10000216	Mus musculus C57BL/6 X BALB/c	1376	8 to 10 week old	8 to 10 week
+50-58	9606	Homo sapiens (human)	1377	50-58	50-58
+30-45	9606	Homo sapiens (human)	1378	30-45	30-45
+20-63 years	9606	Homo sapiens (human)	1379	20-63 year	20-63 year
+40-69 years	9606	Homo sapiens (human)	1380	40-69 year	40-69 year
+4-17 years	9606	Homo sapiens (human)	1381	4-17 year	4-17 year
+7-15 years	9606	Homo sapiens (human)	1382	7-15 year	7-15 year
+28-44	9606	Homo sapiens (human)	1383	28-44	28-44
+1-2 months	10000662	Rattus norvegicus Lewis	1384	1-2 month	1-2 month
+24-50 years	9606	Homo sapiens (human)	1385	24-50 year	24-50 year
+28-53 years	9606	Homo sapiens (human)	1386	28-53 year	28-53 year
+24-53 years	9606	Homo sapiens (human)	1387	24-53 year	24-53 year
+2-4 months	10000616	Mus musculus HLA-DRB1*04:01 Tg	1388	2-4 month	2-4 month
+24-44 years	9606	Homo sapiens (human)	1389	24-44 year	24-44 year
+2-4 months	10000632	Mus musculus NOD	1390	2-4 month	2-4 month
+24-42 years	9606	Homo sapiens (human)	1391	24-42 year	24-42 year
+25-57 years	9606	Homo sapiens (human)	1392	25-57 year	25-57 year
+22-44 years	9606	Homo sapiens (human)	1393	22-44 year	22-44 year
+14-59 years	9606	Homo sapiens (human)	1394	14-59 year	14-59 year
+10 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	1395	10 to 12 week	10 to 12 week
+2-4 months	10001245	Mus musculus B10.H2g7	1396	2-4 month	2-4 month
+54	9606	Homo sapiens (human)	1397	54	54
+30-56 years	9606	Homo sapiens (human)	1398	30-56 year	30-56 year
+41-69 years	9606	Homo sapiens (human)	1399	41-69 year	41-69 year
+3-45 years	9606	Homo sapiens (human)	1400	3-45 year	3-45 year
+13-46 years	9606	Homo sapiens (human)	1401	13-46 year	13-46 year
+6 to 8 week	10090	Mus musculus (mouse)	1402	6 to 8 week	6 to 8 week
+within 12 hours of birth	10000038	Mus musculus C3H/He	1403	within 12 hour of birth	within 12 hour of birth
+13 days	10000038	Mus musculus C3H/He	1404	13 days	13 days
+10 to 12 weeks	10000595	Mus musculus HLA-B7 Tg	1405	10 to 12 week	10 to 12 week
+2-6 months	10000067	Mus musculus C57BL/6	1406	2-6 month	2-6 month
+17-36 years	9606	Homo sapiens (human)	1407	17-36 year	17-36 year
+8 to 14 weeks	10000067	Mus musculus C57BL/6	1408	8 to 14 week	8 to 14 week
+8-10 weeks	10000252	Mus musculus A.SW	1409	8-10 week	8-10 week
+8-10 weeks	10000038	Mus musculus C3H/He	1410	8-10 week	8-10 week
+8-10 weeks	10000643	Mus musculus P/J	1411	8-10 week	8-10 week
+8-10 weeks	10000648	Mus musculus RIIIS	1412	8-10 week	8-10 week
+older than 8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1413	older than 8 week	older than 8 week
+36 to 79 years	9606	Homo sapiens (human)	1414	36 to 79 year	36 to 79 year
+18-60 years-old	9606	Homo sapiens (human)	1415	18-60 year-old	18-60 year
+6 to 14 weeks	10000649	Mus musculus SJL	1416	6 to 14 week	6 to 14 week
+27-54 years	9606	Homo sapiens (human)	1417	27-54 year	27-54 year
+50 days	10000067	Mus musculus C57BL/6	1418	50 days	50 days
+27-79 years	9606	Homo sapiens (human)	1419	27-79 year	27-79 year
+25-44 years	9606	Homo sapiens (human)	1420	25-44 year	25-44 year
+Neonatal	10000054	Mus musculus DBA/1	1421	neonatal	neonatal
+27 weeks	10001253	Mus musculus HLA-DRB1*04:04 Tg	1422	27 week	27 week
+6 to 8 weeks	10000236	Mus musculus CBA/J	1423	6 to 8 week	6 to 8 week
+26 years	9606	Homo sapiens (human)	1424	26 year	26 year
+36	9606	Homo sapiens (human)	1425	36	36
+NULL	10001287	Mus musculus DBA/1 X B10.Q	1426	null	null
+33-64 years	9606	Homo sapiens (human)	1427	33-64 year	33-64 year
+13-20 years	9606	Homo sapiens (human)	1428	13-20 year	13-20 year
+43	9606	Homo sapiens (human)	1429	43	43
+48	9606	Homo sapiens (human)	1430	48	48
+29	9606	Homo sapiens (human)	1431	29	29
+3 months	10000576	Mus musculus HLA-A*02:01 Tg	1432	3 month	3 month
+3-6 months	10000662	Rattus norvegicus Lewis	1433	3-6 month	3-6 month
+43 years	10000119	Homo sapiens Caucasian	1434	43 year	43 year
+2-3 months	10000067	Mus musculus C57BL/6	1435	2-3 month	2-3 month
+6 to 10 weeks	10000067	Mus musculus C57BL/6	1436	6 to 10 week	6 to 10 week
+10-12 weeks	10000649	Mus musculus SJL	1437	10-12 week	10-12 week
+27	9606	Homo sapiens (human)	1438	27	27
+NULL	10001306	Mus musculus KRN TCR Tg	1439	null	null
+21-83 years old	9606	Homo sapiens (human)	1440	21-83 year old	21-83 year
+4 to 8 weeks old	10000000	Mus musculus BALB/c	1441	4 to 8 week old	4 to 8 week
+38	9606	Homo sapiens (human)	1442	38	38
+24 to 32 years	9606	Homo sapiens (human)	1443	24 to 32 year	24 to 32 year
+12-14 weeks	10000598	Mus musculus HLA-DQ8 Tg	1444	12-14 week	12-14 week
+12-14 weeks	10000607	Mus musculus HLA-DR3 Tg	1445	12-14 week	12-14 week
+2 to 3 months	10000649	Mus musculus SJL	1446	2 to 3 month	2 to 3 month
+19-32 years	10000119	Homo sapiens Caucasian	1447	19-32 year	19-32 year
+8 months	10001240	Mus musculus APPsw	1448	8 month	8 month
+31-88 years	9606	Homo sapiens (human)	1449	31-88 year	31-88 year
+3 weeks	10000635	Mus musculus NOD/Lt	1450	3 week	3 week
+15-20 weeks	10000632	Mus musculus NOD	1451	15-20 week	15-20 week
+5-9 weeks	10000635	Mus musculus NOD/Lt	1452	5-9 week	5-9 week
+8 week old	10000632	Mus musculus NOD	1453	8 week old	8 week
+10 weeks	10000000	Mus musculus BALB/c	1454	10 week	10 week
+adult	9685	Felis catus (cat)	1455	adult	adult
+NULL	10000218	Mus musculus C57BL/6 X C3H	1456	null	null
+10-15 weeks	10001327	Mus musculus PL/J X SJL	1457	10-15 week	10-15 week
+4-8 weeks	10000275	Mus musculus B10.RIII	1458	4-8 week	4-8 week
+39-46 years old	9606	Homo sapiens (human)	1459	39-46 year old	39-46 year
+45 years old	9606	Homo sapiens (human)	1460	45 year old	45 year
+8 to 10 weeks	10001133	Rattus norvegicus DA	1461	8 to 10 week	8 to 10 week
+6-12 weeks	10000228	Mus musculus CBA	1462	6-12 week	6-12 week
+4-8 weeks	10000263	Mus musculus B10.BR	1463	4-8 week	4-8 week
+39 years old	9606	Homo sapiens (human)	1464	39 year old	39 year
+2 months	10000649	Mus musculus SJL	1465	2 month	2 month
+4 to 5 weeks	10000067	Mus musculus C57BL/6	1466	4 to 5 week	4 to 5 week
+8-10 weeks	10000095	Mus musculus C57BL/6 IFNgamma null	1467	8-10 week	8-10 week
+45-52	9606	Homo sapiens (human)	1468	45-52	45-52
+6 to 8 weeks old	10001248	Mus musculus NOD.Cg-Tg	1469	6 to 8 week old	6 to 8 week
+6 -10 weeks old	10000067	Mus musculus C57BL/6	1470	6 -10 week old	6 -10 week
+5 to 6 weeks	10000662	Rattus norvegicus Lewis	1471	5 to 6 week	5 to 6 week
+10-14 weeks old	10001332	Rattus norvegicus LEW.1AV1	1472	10-14 week old	10-14 week
+4-8 weeks	10001135	Mus musculus B10.HTG	1473	4-8 week	4-8 week
+8-10 weeks	10000973	Mus musculus 129	1474	8-10 week	8-10 week
+37–62 years	9606	Homo sapiens (human)	1475	3762 year	3762 year
+1-18 years old	9606	Homo sapiens (human)	1476	1-18 year old	1-18 year
+1-55 years old	9606	Homo sapiens (human)	1477	1-55 year old	1-55 year
+12-20	10001537	Mus musculus PL	1478	12-20	12-20
+10-14 weeks old	10001333	Rattus norvegicus LEW.1N	1479	10-14 week old	10-14 week
+41–64 years	9606	Homo sapiens (human)	1480	4164 year	4164 year
+30-78 years old	9606	Homo sapiens (human)	1481	30-78 year old	30-78 year
+7-10 weeks	10000054	Mus musculus DBA/1	1482	7-10 week	7-10 week
+NULL	10001062	Mus musculus HLA-A*24:02 Tg	1483	null	null
+5 weeks	10000649	Mus musculus SJL	1484	5 week	5 week
+48 years old	9606	Homo sapiens (human)	1485	48 year old	48 year
+12-14 weeks	10000597	Mus musculus HLA-DQ6 Tg	1486	12-14 week	12-14 week
+24-39 years	9606	Homo sapiens (human)	1487	24-39 year	24-39 year
+4 to 6 months	10001287	Mus musculus DBA/1 X B10.Q	1488	4 to 6 month	4 to 6 month
+12-23 weeks	10000632	Mus musculus NOD	1489	12-23 week	12-23 week
+2-6 months	10000598	Mus musculus HLA-DQ8 Tg	1490	2-6 month	2-6 month
+4-8 weeks	10001019	Mus musculus B10.D2	1491	4-8 week	4-8 week
+17-66 years old	9606	Homo sapiens (human)	1492	17-66 year old	17-66 year
+NULL	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	1493	null	null
+NULL	10001245	Mus musculus B10.H2g7	1494	null	null
+Adult (avg. age = 30.8 years)	9606	Homo sapiens (human)	1495	adult (avg. age = 30.8 years)	adult (avg. age = 30.8 years)
+27-66 years	9606	Homo sapiens (human)	1496	27-66 year	27-66 year
+21-56 years	9606	Homo sapiens (human)	1497	21-56 year	21-56 year
+8 to 12 weeks	10001537	Mus musculus PL	1498	8 to 12 week	8 to 12 week
+29-76 years old	9606	Homo sapiens (human)	1499	29-76 year old	29-76 year
+20-55 years old	9606	Homo sapiens (human)	1500	20-55 year old	20-55 year
+28-35 years	9606	Homo sapiens (human)	1501	28-35 year	28-35 year
+<18 hours	10001165	Mus musculus C57BR/cdJ	1502	<18 hour	<18 hour
+8-12 weeks	10000055	Mus musculus DBA/2	1503	8-12 week	8-12 week
+5 - 8 weeks	10000025	Mus musculus Biozzi AB/H	1504	5 - 8 week	5 - 8 week
+NULL	10001470	Mus musculus Factor VIII null	1505	null	null
+49 years	9606	Homo sapiens (human)	1506	49 year	49 year
+4-6 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1507	4-6 week	4-6 week
+10 - 15 years	9544	Macaca mulatta (rhesus macaque)	1508	10 - 15 year	10 - 15 year
+4 weeks old	10000632	Mus musculus NOD	1509	4 week old	4 week
+6-8 weeks	10000274	Mus musculus B10.PL	1510	6-8 week	6-8 week
+25-68 years old	9606	Homo sapiens (human)	1511	25-68 year old	25-68 year
+NULL	10001331	Mus musculus SJL X B10.PL	1512	null	null
+26-60 years	9606	Homo sapiens (human)	1513	26-60 year	26-60 year
+8 to 10 weeks	10000595	Mus musculus HLA-B7 Tg	1514	8 to 10 week	8 to 10 week
+7 to 15 weeks	10090	Mus musculus (mouse)	1515	7 to 15 week	7 to 15 week
+7 to 15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1516	7 to 15 week	7 to 15 week
+NULL	10001291	Mus musculus CBA/Igb	1517	null	null
+6-35 weeks	10000061	Mus musculus FVB	1518	6-35 week	6-35 week
+8-12 weeks	10000601	Mus musculus HLA-DR1 Tg	1519	8-12 week	8-12 week
+5-10 weeks	10000000	Mus musculus BALB/c	1520	5-10 week	5-10 week
+37-74 years	9606	Homo sapiens (human)	1521	37-74 year	37-74 year
+7-10 weeks	10000258	Mus musculus B10.A(2R)	1522	7-10 week	7-10 week
+5-8 weeks old	10000582	Mus musculus HLA-A2 Tg	1523	5-8 week old	5-8 week
+24 hours after birth	10000274	Mus musculus B10.PL	1524	24 hour after birth	24 hour after birth
+38-57 years	9606	Homo sapiens (human)	1525	38-57 year	38-57 year
+27-44 years	9606	Homo sapiens (human)	1526	27-44 year	27-44 year
+6-12 weeks	10000649	Mus musculus SJL	1527	6-12 week	6-12 week
+60 years	9606	Homo sapiens (human)	1528	60 year	60 year
+3 weeks	10001266	Mus musculus NOD/Caj	1529	3 week	3 week
+NULL	10001273	Cavia porcellus Strain 13	1530	null	null
+7-11 weeks	10000274	Mus musculus B10.PL	1531	7-11 week	7-11 week
+6 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1532	6 to 8 week	6 to 8 week
+8-10 weeks	10000274	Mus musculus B10.PL	1533	8-10 week	8-10 week
+NULL	10002202	Mus musculus BDC12-4.1 beta-chain TCR Tg	1534	null	null
+NULL	10000032	Mus musculus C3H.Q	1535	null	null
+8 weeks	10000274	Mus musculus B10.PL	1536	8 week	8 week
+39-47 years old	9606	Homo sapiens (human)	1537	39-47 year old	39-47 year
+5 to 7 weeks	10000067	Mus musculus C57BL/6	1538	5 to 7 week	5 to 7 week
+19-25	9606	Homo sapiens (human)	1539	19-25	19-25
+19-26	9606	Homo sapiens (human)	1540	19-26	19-26
+NULL	10001327	Mus musculus PL/J X SJL	1541	null	null
+37-53 years old	9606	Homo sapiens (human)	1542	37-53 year old	37-53 year
+Children (avg. age = 9.5 years)	9606	Homo sapiens (human)	1543	children (avg. age = 9.5 years)	children (avg. age = 9.5 years)
+>27 weeks	10000632	Mus musculus NOD	1544	>27 week	>27 week
+8-10 weeks	10000055	Mus musculus DBA/2	1545	8-10 week	8-10 week
+6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1546	6 week	6 week
+31-57 years	9606	Homo sapiens (human)	1547	31-57 year	31-57 year
+3 to 5 months	10001331	Mus musculus SJL X B10.PL	1548	3 to 5 month	3 to 5 month
+NULL	10001272	Cavia porcellus Strain 2	1549	null	null
+14-49 years	9606	Homo sapiens (human)	1550	14-49 year	14-49 year
+NULL	10000013	Mus musculus BALB/c X A/J	1551	null	null
+8-12 weeks	10000275	Mus musculus B10.RIII	1552	8-12 week	8-12 week
+31-76 years	9606	Homo sapiens (human)	1553	31-76 year	31-76 year
+21-31 years	9606	Homo sapiens (human)	1554	21-31 year	21-31 year
+6-10 weeks	10000228	Mus musculus CBA	1555	6-10 week	6-10 week
+6-12 weeks	10001537	Mus musculus PL	1556	6-12 week	6-12 week
+8-12 weeks	10001332	Rattus norvegicus LEW.1AV1	1557	8-12 week	8-12 week
+39	9606	Homo sapiens (human)	1558	39	39
+6-8 weeks	10001365	Mus musculus Clone 19 TCR Tg	1559	6-8 week	6-8 week
+53 to 71 years	9606	Homo sapiens (human)	1560	53 to 71 year	53 to 71 year
+4-5 weeks	10001133	Rattus norvegicus DA	1561	4-5 week	4-5 week
+4 months	10001240	Mus musculus APPsw	1562	4 month	4 month
+31 years old	9606	Homo sapiens (human)	1563	31 year old	31 year
+8-12 weeks	10001337	Rattus norvegicus LEWIS.1W	1564	8-12 week	8-12 week
+21-27 years	9606	Homo sapiens (human)	1565	21-27 year	21-27 year
+NULL	10000975	Mus musculus FVB Db Tg	1566	null	null
+14-46 years	9606	Homo sapiens (human)	1567	14-46 year	14-46 year
+8-10 weeks	10000610	Mus musculus HLA-DR4 Tg	1568	8-10 week	8-10 week
+8-12 weeks	10000610	Mus musculus HLA-DR4 Tg	1569	8-12 week	8-12 week
+8 to 12 week	10000576	Mus musculus HLA-A*02:01 Tg	1570	8 to 12 week	8 to 12 week
+18 to 70 years	9606	Homo sapiens (human)	1571	18 to 70 year	18 to 70 year
+20-78 years	9606	Homo sapiens (human)	1572	20-78 year	20-78 year
+18-71 years	9606	Homo sapiens (human)	1573	18-71 year	18-71 year
+22-76 years	9606	Homo sapiens (human)	1574	22-76 year	22-76 year
+30-72 years	9606	Homo sapiens (human)	1575	30-72 year	30-72 year
+NULL	10001288	Mus musculus MMC-1 (collagen mutant)	1576	null	null
+NULL	10000973	Mus musculus 129	1577	null	null
+4-12 weeks	10000067	Mus musculus C57BL/6	1578	4-12 week	4-12 week
+57.1-70.1 years	9606	Homo sapiens (human)	1579	57.1-70.1 year	57.1-70.1 year
+6-12 weeks	10000263	Mus musculus B10.BR	1580	6-12 week	6-12 week
+8-12 weeks	10000054	Mus musculus DBA/1	1581	8-12 week	8-12 week
+8-12 weeks	10001299	Mus musculus HLA-DRB1*04:02 Tg	1582	8-12 week	8-12 week
+NULL	9925	Capra hircus (domestic goat)	1583	null	null
+6 weeks	10002837	Mus musculus HLA-DQA1*05:01/DQB1*02:01 Tg	1584	6 week	6 week
+14-86 years	9606	Homo sapiens (human)	1585	14-86 year	14-86 year
+30-74 years	9606	Homo sapiens (human)	1586	30-74 year	30-74 year
+18-49 years	9606	Homo sapiens (human)	1587	18-49 year	18-49 year
+31 years	9606	Homo sapiens (human)	1588	31 year	31 year
+NULL	10001311	Mus musculus HH8 TCR Tg	1589	null	null
+30-83 years	9606	Homo sapiens (human)	1590	30-83 year	30-83 year
+19-95 years	9606	Homo sapiens (human)	1591	19-95 year	19-95 year
+neonates	10000663	Rattus norvegicus LOU	1592	neonates	neonates
+mean age 31 years	9606	Homo sapiens (human)	1593	mean age 31 year	mean age 31 year
+8 weeks or older	10000000	Mus musculus BALB/c	1594	8 week or older	8 week or older
+26-34 years	9606	Homo sapiens (human)	1595	26-34 year	26-34 year
+8-12 weeks	10001537	Mus musculus PL	1596	8-12 week	8-12 week
+26 to 53 years	9606	Homo sapiens (human)	1597	26 to 53 year	26 to 53 year
+27-62 years	9606	Homo sapiens (human)	1598	27-62 year	27-62 year
+14-44 years	9606	Homo sapiens (human)	1599	14-44 year	14-44 year
+5-12 weeks	10000000	Mus musculus BALB/c	1600	5-12 week	5-12 week
+18 to 59 years old	9606	Homo sapiens (human)	1601	18 to 59 year old	18 to 59 year
+6 to 12 weeks	10000233	Mus musculus CBA/Ca	1602	6 to 12 week	6 to 12 week
+1 year	10001097	Sus scrofa Yorkshire	1603	1 year	1 year
+14-26 years	9606	Homo sapiens (human)	1604	14-26 year	14-26 year
+8 to 12 weeks old	10000275	Mus musculus B10.RIII	1605	8 to 12 week old	8 to 12 week
+16-24 years	9606	Homo sapiens (human)	1606	16-24 year	16-24 year
+6-9 weeks	10000662	Rattus norvegicus Lewis	1607	6-9 week	6-9 week
+4-6 weeks	10001041	Rattus norvegicus Wistar	1608	4-6 week	4-6 week
+NULL	10001321	Rattus norvegicus DR-BB/Wor	1609	null	null
+NULL	10000231	Mus musculus CBA X BALB/c	1610	null	null
+8-10 weeks	10001291	Mus musculus CBA/Igb	1611	8-10 week	8-10 week
+8-10 weeks	10000064	Mus musculus C57BL/10.Q	1612	8-10 week	8-10 week
+20 weeks old	10000632	Mus musculus NOD	1613	20 week old	20 week
+22-84 years	9606	Homo sapiens (human)	1614	22-84 year	22-84 year
+21-72 years	9606	Homo sapiens (human)	1615	21-72 year	21-72 year
+29-55	9606	Homo sapiens (human)	1616	29-55	29-55
+5.5-7.5 months	10001240	Mus musculus APPsw	1617	5.5-7.5 month	5.5-7.5 month
+7 weeks	10000662	Rattus norvegicus Lewis	1618	7 week	7 week
+8-12 weeks	10001287	Mus musculus DBA/1 X B10.Q	1619	8-12 week	8-12 week
+19-48	9606	Homo sapiens (human)	1620	19-48	19-48
+7-12 weeks	10000032	Mus musculus C3H.Q	1621	7-12 week	7-12 week
+34-60 years old	9606	Homo sapiens (human)	1622	34-60 year old	34-60 year
+34-58 years	9606	Homo sapiens (human)	1623	34-58 year	34-58 year
+10-12 weeks	10000054	Mus musculus DBA/1	1624	10-12 week	10-12 week
+13 days	10000236	Mus musculus CBA/J	1625	13 days	13 days
+7-12 weeks	10000038	Mus musculus C3H/He	1626	7-12 week	7-12 week
+7-12 weeks	10000000	Mus musculus BALB/c	1627	7-12 week	7-12 week
+6 to 12 weeks	10001314	Mus musculus HPV 16 E7 Tg	1628	6 to 12 week	6 to 12 week
+NULL	10000663	Rattus norvegicus LOU	1629	null	null
+8-12 weeks	10000274	Mus musculus B10.PL	1630	8-12 week	8-12 week
+3 to 21 years	9555	Papio anubis (Doguera baboon)	1631	3 to 21 year	3 to 21 year
+23-69 years	9606	Homo sapiens (human)	1632	23-69 year	23-69 year
+26-52 years	9606	Homo sapiens (human)	1633	26-52 year	26-52 year
+NULL	9986	Oryctolagus cuniculus (rabbit)	1634	null	null
+2 months	10141	Cavia porcellus (guinea pig)	1635	2 month	2 month
+NULL	10001302	Mus musculus qCII85.33 TCR Tg	1636	null	null
+8-11 weeks	10000662	Rattus norvegicus Lewis	1637	8-11 week	8-11 week
+3 - 4 weeks	10000632	Mus musculus NOD	1638	3 - 4 week	3 - 4 week
+23-53	9606	Homo sapiens (human)	1639	23-53	23-53
+24-36	9606	Homo sapiens (human)	1640	24-36	24-36
+8-16 weeks	10000032	Mus musculus C3H.Q	1641	8-16 week	8-16 week
+3 month	10000649	Mus musculus SJL	1642	3 month	3 month
+2-4 months	10000610	Mus musculus HLA-DR4 Tg	1643	2-4 month	2-4 month
+57 years	9606	Homo sapiens (human)	1644	57 year	57 year
+16 - 24 weeks old	10000632	Mus musculus NOD	1645	16 - 24 week old	16 - 24 week
+2 to 4 months	10000649	Mus musculus SJL	1646	2 to 4 month	2 to 4 month
+median age 28 years	9606	Homo sapiens (human)	1647	median age 28 year	median age 28 year
+7 weeks	10000032	Mus musculus C3H.Q	1648	7 week	7 week
+3-20 weeks	10000632	Mus musculus NOD	1649	3-20 week	3-20 week
+12-16 weeks	10001244	Mus musculus NOR	1650	12-16 week	12-16 week
+16-46 years	9606	Homo sapiens (human)	1651	16-46 year	16-46 year
+15	9606	Homo sapiens (human)	1652	15	15
+6 months	10000000	Mus musculus BALB/c	1653	6 month	6 month
+28-39 years	9606	Homo sapiens (human)	1654	28-39 year	28-39 year
+33-50 years	9606	Homo sapiens (human)	1655	33-50 year	33-50 year
+25-60 years	9606	Homo sapiens (human)	1656	25-60 year	25-60 year
+25-72 years	9606	Homo sapiens (human)	1657	25-72 year	25-72 year
+39-82 years	9606	Homo sapiens (human)	1658	39-82 year	39-82 year
+10-12 weeks	10001277	Mus musculus NOD-Ealpha Tg	1659	10-12 week	10-12 week
+4-7 weeks	10000632	Mus musculus NOD	1660	4-7 week	4-7 week
+4 - 5 weeks	10000632	Mus musculus NOD	1661	4 - 5 week	4 - 5 week
+5-7 weeks old	10000632	Mus musculus NOD	1662	5-7 week old	5-7 week
+36-65 years	9606	Homo sapiens (human)	1663	36-65 year	36-65 year
+4.5 - 6 months	10001241	Mus musculus APP	1664	4.5 - 6 month	4.5 - 6 month
+5-7 weeks	10000632	Mus musculus NOD	1665	5-7 week	5-7 week
+2-3 months	10001537	Mus musculus PL	1666	2-3 month	2-3 month
+2-3 months	10000649	Mus musculus SJL	1667	2-3 month	2-3 month
+5 weeks	10001241	Mus musculus APP	1668	5 week	5 week
+43-65	9606	Homo sapiens (human)	1669	43-65	43-65
+6-8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	1670	6-8 week	6-8 week
+18-36 years	9606	Homo sapiens (human)	1671	18-36 year	18-36 year
+2-4 months	10001041	Rattus norvegicus Wistar	1672	2-4 month	2-4 month
+12-16 months	10001241	Mus musculus APP	1673	12-16 month	12-16 month
+7-12 weeks	10001288	Mus musculus MMC-1 (collagen mutant)	1674	7-12 week	7-12 week
+7-9 weeks	10000662	Rattus norvegicus Lewis	1675	7-9 week	7-9 week
+8-14 weeks	10001300	Rattus norvegicus WA/KIR/kcl	1676	8-14 week	8-14 week
+NULL	10001298	Mus musculus insulin 2 null	1677	null	null
+6 to 8 weeks	10000610	Mus musculus HLA-DR4 Tg	1678	6 to 8 week	6 to 8 week
+7 weeks	10000067	Mus musculus C57BL/6	1679	7 week	7 week
+15-20 weeks	10000635	Mus musculus NOD/Lt	1680	15-20 week	15-20 week
+7 weeks	10001288	Mus musculus MMC-1 (collagen mutant)	1681	7 week	7 week
+neonate	10000054	Mus musculus DBA/1	1682	neonate	neonate
+Mean age 65 years	9606	Homo sapiens (human)	1683	mean age 65 year	mean age 65 year
+8 to 12 weeks	10000054	Mus musculus DBA/1	1684	8 to 12 week	8 to 12 week
+8-12 weeks	10001300	Rattus norvegicus WA/KIR/kcl	1685	8-12 week	8-12 week
+8 to 12 weeks old	10000054	Mus musculus DBA/1	1686	8 to 12 week old	8 to 12 week
+8-12 weeks.	10001356	Mus musculus MBP 84-105 HEL Tg	1687	8-12 week.	8-12 week.
+10 to 12 weeks old	10000047	Mus musculus C57BL/10	1688	10 to 12 week old	10 to 12 week
+36-39 years	9606	Homo sapiens (human)	1689	36-39 year	36-39 year
+4-7 weeks old	10001248	Mus musculus NOD.Cg-Tg	1690	4-7 week old	4-7 week
+Neonate and adult	9606	Homo sapiens (human)	1691	neonate and adult	neonate and adult
+52-89 years	9606	Homo sapiens (human)	1692	52-89 year	52-89 year
+50 years old	9606	Homo sapiens (human)	1693	50 year old	50 year
+8-24 weeks	10000067	Mus musculus C57BL/6	1694	8-24 week	8-24 week
+8-20 weeks	10000000	Mus musculus BALB/c	1695	8-20 week	8-20 week
+<70 years	9606	Homo sapiens (human)	1696	<70 year	<70 year
+56 years	9606	Homo sapiens (human)	1697	56 year	56 year
+8 to 14 weeks	10001537	Mus musculus PL	1698	8 to 14 week	8 to 14 week
+8 to 24 weeks	10000067	Mus musculus C57BL/6	1699	8 to 24 week	8 to 24 week
+6 weeks	10000061	Mus musculus FVB	1700	6 week	6 week
+16-75 years	9606	Homo sapiens (human)	1701	16-75 year	16-75 year
+embryo	9031	Gallus gallus (chicken)	1702	embryo	embryo
+NULL	10001313	Mus musculus GAD65 p206 TCR Tg	1703	null	null
+8-36 years	9606	Homo sapiens (human)	1704	8-36 year	8-36 year
+8-53 years	9606	Homo sapiens (human)	1705	8-53 year	8-53 year
+20-27 years	9606	Homo sapiens (human)	1706	20-27 year	20-27 year
+3 to 5 months	10000206	Oryctolagus cuniculus New Zealand White	1707	3 to 5 month	3 to 5 month
+8 to 12 weeks	10000275	Mus musculus B10.RIII	1708	8 to 12 week	8 to 12 week
+18-86 years	9606	Homo sapiens (human)	1709	18-86 year	18-86 year
+21-67 years	9606	Homo sapiens (human)	1710	21-67 year	21-67 year
+4-5 weeks	10000649	Mus musculus SJL	1711	4-5 week	4-5 week
+26-59 years old	9606	Homo sapiens (human)	1712	26-59 year old	26-59 year
+8 to 20 weeks	10000274	Mus musculus B10.PL	1713	8 to 20 week	8 to 20 week
+6-12 weeks	10001329	Mus musculus PL/J X B10.PL	1714	6-12 week	6-12 week
+5-16 years	9606	Homo sapiens (human)	1715	5-16 year	5-16 year
+7 to 10 weeks	10000025	Mus musculus Biozzi AB/H	1716	7 to 10 week	7 to 10 week
+33 years	9606	Homo sapiens (human)	1717	33 year	33 year
+2-6 months	10036	Mesocricetus auratus (Syrian golden hamster)	1718	2-6 month	2-6 month
+6 weeks	10001314	Mus musculus HPV 16 E7 Tg	1719	6 week	6 week
+7-10 weeks	10000263	Mus musculus B10.BR	1720	7-10 week	7-10 week
+7-10 weeks	10001019	Mus musculus B10.D2	1721	7-10 week	7-10 week
+60-62 years	9606	Homo sapiens (human)	1722	60-62 year	60-62 year
+68 years	9606	Homo sapiens (human)	1723	68 year	68 year
+18-70	9606	Homo sapiens (human)	1724	18-70	18-70
+5-6 weeks	10000094	Mus musculus C57BL/6 IAbeta null	1725	5-6 week	5-6 week
+8 to 10 weeks	10000582	Mus musculus HLA-A2 Tg	1726	8 to 10 week	8 to 10 week
+10 to 14 weeks	10000000	Mus musculus BALB/c	1727	10 to 14 week	10 to 14 week
+7-78 years	9606	Homo sapiens (human)	1728	7-78 year	7-78 year
+8 to 10 weeks	10001166	Mus musculus HLA-A24 Tg	1729	8 to 10 week	8 to 10 week
+NULL	10000002	Mus musculus BALB/c beta2m null	1730	null	null
+25-55 years	9606	Homo sapiens (human)	1731	25-55 year	25-55 year
+~ 31 to 55 years	9606	Homo sapiens (human)	1732	~ 31 to 55 year	~ 31 to 55 year
+15 weeks	10000632	Mus musculus NOD	1733	15 week	15 week
+8-12 wk	10000038	Mus musculus C3H/He	1734	8-12 week	8-12 week
+NULL	9521	Saimiri sciureus (South American squirrel monkey)	1735	null	null
+8-12 weeks	10000108	Mus musculus C57BL/6 X B10.D2	1736	8-12 week	8-12 week
+8-10 weeks old	10000228	Mus musculus CBA	1737	8-10 week old	8-10 week
+6-8 weeks	10000055	Mus musculus DBA/2	1738	6-8 week	6-8 week
+NULL	NULL	NULL	1739	null	null
+18 weeks	10000637	Mus musculus NODasp	1740	18 week	18 week
+6-10 weeks	10000271	Mus musculus B10.M	1741	6-10 week	6-10 week
+5 to 6 weeks	10000067	Mus musculus C57BL/6	1742	5 to 6 week	5 to 6 week
+8 week old	10000000	Mus musculus BALB/c	1743	8 week old	8 week
+NULL	10000673	Mus musculus F1sc H-2b scid chimera	1744	null	null
+46-48 yrs	9606	Homo sapiens (human)	1745	46-48 year	46-48 year
+4-week old	10000649	Mus musculus SJL	1746	4-week old	4 week
+4-8 weeks	10000038	Mus musculus C3H/He	1747	4-8 week	4-8 week
+18-50 years-old	9606	Homo sapiens (human)	1748	18-50 year-old	18-50 year
+8-12 weeks old	10000641	Mus musculus OF1	1749	8-12 week old	8-12 week
+52-59 years	9606	Homo sapiens (human)	1750	52-59 year	52-59 year
+< 12 hours	10000000	Mus musculus BALB/c	1751	< 12 hour	< 12 hour
+5 weeks	10001634	Mus musculus IFNR null	1752	5 week	5 week
+18-40 years	9606	Homo sapiens (human)	1753	18-40 year	18-40 year
+8 Week	10000067	Mus musculus C57BL/6	1754	8 week	8 week
+6-8 weeks	10000283	Mus musculus B6.129S2-Cd28tm1Mak	1755	6-8 week	6-8 week
+28 to 68 years	9606	Homo sapiens (human)	1756	28 to 68 year	28 to 68 year
+6 to 8 weeks	10000582	Mus musculus HLA-A2 Tg	1757	6 to 8 week	6 to 8 week
+8 wk.	10000216	Mus musculus C57BL/6 X BALB/c	1758	8 week.	8 week.
+8-15 weeks	10000038	Mus musculus C3H/He	1759	8-15 week	8-15 week
+1 day	10000000	Mus musculus BALB/c	1760	1 day	1 day
+39-63 years	9606	Homo sapiens (human)	1761	39-63 year	39-63 year
+11 to 74 months	9606	Homo sapiens (human)	1762	11 to 74 month	11 to 74 month
+adult	10000047	Mus musculus C57BL/10	1763	adult	adult
+6-8 weeks	10000655	Mus musculus Swiss Webster	1764	6-8 week	6-8 week
+18-38 years	9606	Homo sapiens (human)	1765	18-38 year	18-38 year
+57-62 years	9606	Homo sapiens (human)	1766	57-62 year	57-62 year
+3-14 years	9606	Homo sapiens (human)	1767	3-14 year	3-14 year
+63 years	9606	Homo sapiens (human)	1768	63 year	63 year
+10 to 12 weeks	10000000	Mus musculus BALB/c	1769	10 to 12 week	10 to 12 week
+38 years	9606	Homo sapiens (human)	1770	38 year	38 year
+20-64 years	9606	Homo sapiens (human)	1771	20-64 year	20-64 year
+6-8 wk.	10000067	Mus musculus C57BL/6	1772	6-8 week.	6-8 week.
+NULL	9823	Sus scrofa (pig)	1773	null	null
+Adults (15-44)	9606	Homo sapiens (human)	1774	adults (15-44)	adults (15-44)
+8 to 12 weeks	10001166	Mus musculus HLA-A24 Tg	1775	8 to 12 week	8 to 12 week
+8-14 wk	10000607	Mus musculus HLA-DR3 Tg	1776	8-14 week	8-14 week
+19-77 years	9606	Homo sapiens (human)	1777	19-77 year	19-77 year
+4-6 weeks	10000019	Mus musculus BALB/cByJ	1778	4-6 week	4-6 week
+23-67 years	9606	Homo sapiens (human)	1779	23-67 year	23-67 year
+47-65 years	9606	Homo sapiens (human)	1780	47-65 year	47-65 year
+18-63 years old	9606	Homo sapiens (human)	1781	18-63 year old	18-63 year
+26-63 years	9606	Homo sapiens (human)	1782	26-63 year	26-63 year
+36 years old	9606	Homo sapiens (human)	1783	36 year old	36 year
+4-week old	10000271	Mus musculus B10.M	1784	4-week old	4 week
+19-53 years	10000119	Homo sapiens Caucasian	1785	19-53 year	19-53 year
+25-31 years	9606	Homo sapiens (human)	1786	25-31 year	25-31 year
+2 months old	10000000	Mus musculus BALB/c	1787	2 month old	2 month
+7-8 weeks	10000236	Mus musculus CBA/J	1788	7-8 week	7-8 week
+8-10 weeks-old	10000284	Mus musculus B6.129S2-Igh-6tm1Cgn	1789	8-10 week-old	8-10 week
+8-24 weeks old	10000028	Mus musculus C3H	1790	8-24 week old	8-24 week
+6-7 weeks	10001634	Mus musculus IFNR null	1791	6-7 week	6-7 week
+40 years	9606	Homo sapiens (human)	1792	40 year	40 year
+Calves	9913	Bos taurus (bovine)	1793	calves	calves
+6-10 weeks	42414	Sigmodon (cotton rat)	1794	6-10 week	6-10 week
+3 to 6 months	10000187	Sus scrofa Landrace X Large White	1795	3 to 6 month	3 to 6 month
+Newborns	9606	Homo sapiens (human)	1796	newborns	newborns
+2 months old	10000187	Sus scrofa Landrace X Large White	1797	2 month old	2 month
+8-10 weeks	10000258	Mus musculus B10.A(2R)	1798	8-10 week	8-10 week
+8-10 weeks	10000028	Mus musculus C3H	1799	8-10 week	8-10 week
+12 months old	10000190	Bos taurus Friesian	1800	12 month old	12 month
+Adult	9796	Equus caballus (domestic horse)	1801	adult	adult
+Adult	10000917	Equus caballus Arabian	1802	adult	adult
+4 weeks	10000038	Mus musculus C3H/He	1803	4 week	4 week
+29-82 years	9606	Homo sapiens (human)	1804	29-82 year	29-82 year
+NULL	10000654	Mus musculus Swiss albino	1805	null	null
+mean age 34.4 years	9606	Homo sapiens (human)	1806	mean age 34.4 year	mean age 34.4 year
+3 weeks	10000228	Mus musculus CBA	1807	3 week	3 week
+4-6 weeks	10000263	Mus musculus B10.BR	1808	4-6 week	4-6 week
+4-6 weeks old	10000649	Mus musculus SJL	1809	4-6 week old	4-6 week
+6-10 weeks old	10000228	Mus musculus CBA	1810	6-10 week old	6-10 week
+2-3 months	10000576	Mus musculus HLA-A*02:01 Tg	1811	2-3 month	2-3 month
+7-8 weeks old	10000649	Mus musculus SJL	1812	7-8 week old	7-8 week
+NULL	10001119	Mus musculus BA	1813	null	null
+19 to 56 years	9606	Homo sapiens (human)	1814	19 to 56 year	19 to 56 year
+11-19 years	9544	Macaca mulatta (rhesus macaque)	1815	11-19 year	11-19 year
+4-5 months	9940	Ovis aries (domestic sheep)	1816	4-5 month	4-5 month
+6-8 weeks	10000261	Mus musculus B10.A(5R)	1817	6-8 week	6-8 week
+NULL	10001024	Mus musculus CE/J	1818	null	null
+6-8 weeks	10000061	Mus musculus FVB	1819	6-8 week	6-8 week
+22-45 years	9606	Homo sapiens (human)	1820	22-45 year	22-45 year
+9-12 months	10000190	Bos taurus Friesian	1821	9-12 month	9-12 month
+6-10 weeks	10001122	Mus musculus µMT	1822	6-10 week	6-10 week
+6-8	10000649	Mus musculus SJL	1823	6-8	6-8
+6-8	10000062	Mus musculus FVB/J	1824	6-8	6-8
+5-16 weeks old	10000067	Mus musculus C57BL/6	1825	5-16 week old	5-16 week
+6-8	10000053	Mus musculus DBA	1826	6-8	6-8
+18-50 years old	9606	Homo sapiens (human)	1827	18-50 year old	18-50 year
+NULL	10000914	Mus musculus TO	1828	null	null
+> 6 months	10000190	Bos taurus Friesian	1829	> 6 month	> 6 month
+NULL	10000917	Equus caballus Arabian	1830	null	null
+9-12 months old	10000190	Bos taurus Friesian	1831	9-12 month old	9-12 month
+6-12 weeks	10001019	Mus musculus B10.D2	1832	6-12 week	6-12 week
+6-12 weeks	10000047	Mus musculus C57BL/10	1833	6-12 week	6-12 week
+6-12 weeks	10000261	Mus musculus B10.A(5R)	1834	6-12 week	6-12 week
+6-12 weeks	10000278	Mus musculus B10.S(9R)	1835	6-12 week	6-12 week
+40-60 years	9606	Homo sapiens (human)	1836	40-60 year	40-60 year
+6-8 weeks	10001019	Mus musculus B10.D2	1837	6-8 week	6-8 week
+0.8 years	10000194	Bos taurus Holstein-Friesian	1838	0.8 year	0.8 year
+4.1-15.2 years	9606	Homo sapiens (human)	1839	4.1-15.2 year	4.1-15.2 year
+2 years	10000917	Equus caballus Arabian	1840	2 year	2 year
+4 wk - 3 mo	10000000	Mus musculus BALB/c	1841	4 week - 3 month	4 week - 3 month
+4-8 weeks	10000919	Gallus gallus White Leghorn	1842	4-8 week	4-8 week
+1 year	10000194	Bos taurus Holstein-Friesian	1843	1 year	1 year
+3-8 years	10000194	Bos taurus Holstein-Friesian	1844	3-8 year	3-8 year
+23-43 years	9606	Homo sapiens (human)	1845	23-43 year	23-43 year
+5 weeks	10000662	Rattus norvegicus Lewis	1846	5 week	5 week
+6-10 weeks	10000973	Mus musculus 129	1847	6-10 week	6-10 week
+41-68 years	9606	Homo sapiens (human)	1848	41-68 year	41-68 year
+5-7 weeks	10000228	Mus musculus CBA	1849	5-7 week	5-7 week
+9 weeks	10000028	Mus musculus C3H	1850	9 week	9 week
+mean age = 30 years	9606	Homo sapiens (human)	1851	mean age = 30 year	mean age = 30 year
+4 weeks-old	10000662	Rattus norvegicus Lewis	1852	4 week-old	4 week
+60-90 days	10000000	Mus musculus BALB/c	1853	60-90 days	60-90 days
+6-12 weeks	10000260	Mus musculus B10.A(4R)	1854	6-12 week	6-12 week
+26-80 years	9606	Homo sapiens (human)	1855	26-80 year	26-80 year
+11 weeks	10000025	Mus musculus Biozzi AB/H	1856	11 week	11 week
+8-9 weeks	10000000	Mus musculus BALB/c	1857	8-9 week	8-9 week
+9 weeks	10000000	Mus musculus BALB/c	1858	9 week	9 week
+2-5 years	9685	Felis catus (cat)	1859	2-5 year	2-5 year
+6 month-old	10000193	Bos taurus Holstein	1860	6 month-old	6 month
+8-14 weeks	10000065	Mus musculus C57BL/10SnJ	1861	8-14 week	8-14 week
+8-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1862	8-10 week	8-10 week
+6-8 weeks	10000289	Mus musculus BALB.B	1863	6-8 week	6-8 week
+4-6 months	10000194	Bos taurus Holstein-Friesian	1864	4-6 month	4-6 month
+3-4 weeks old	10000228	Mus musculus CBA	1865	3-4 week old	3-4 week
+8 weeks	10000290	Mus musculus BALB.K	1866	8 week	8 week
+8 weeks	10001998	Mus musculus CD1	1867	8 week	8 week
+8 weeks to 6 months	10000253	Mus musculus A/J	1868	8 week to 6 month	8 week to 6 month
+8 weeks to 6 months	10000067	Mus musculus C57BL/6	1869	8 week to 6 month	8 week to 6 month
+8 weeks to 6 months	10000000	Mus musculus BALB/c	1870	8 week to 6 month	8 week to 6 month
+10 weeks	10000067	Mus musculus C57BL/6	1871	10 week	10 week
+8 weeks	10000236	Mus musculus CBA/J	1872	8 week	8 week
+8 weeks	10000260	Mus musculus B10.A(4R)	1873	8 week	8 week
+20-83 years	9606	Homo sapiens (human)	1874	20-83 year	20-83 year
+6 weeks	10001068	Mus musculus C57/BL/6 LCMV NP Tg	1875	6 week	6 week
+24-47 years	9606	Homo sapiens (human)	1876	24-47 year	24-47 year
+8 to 14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	1877	8 to 14 week	8 to 14 week
+8 to 14 weeks	10002763	Mus musculus HLA-A*11:01 Tg	1878	8 to 14 week	8 to 14 week
+8-15 weeks	10000000	Mus musculus BALB/c	1879	8-15 week	8-15 week
+8-12 weeks	10000582	Mus musculus HLA-A2 Tg	1880	8-12 week	8-12 week
+4-6 wks	10000067	Mus musculus C57BL/6	1881	4-6 week	4-6 week
+8 to 14 weeks	10002852	Mus musculus HLA-A1 Tg	1882	8 to 14 week	8 to 14 week
+42.8-66.5 years	9606	Homo sapiens (human)	1883	42.8-66.5 year	42.8-66.5 year
+20 to 79 years	9606	Homo sapiens (human)	1884	20 to 79 year	20 to 79 year
+6-10 weeks	10000028	Mus musculus C3H	1885	6-10 week	6-10 week
+NULL	10001072	Mus musculus (A/Sn x CBA)F1	1886	null	null
+3 weeks	10000625	Mus musculus MRL	1887	3 week	3 week
+3 weeks	10000263	Mus musculus B10.BR	1888	3 week	3 week
+8 to 14 weeks	10001782	Mus musculus HLA-B*07:02 Tg	1889	8 to 14 week	8 to 14 week
+8 to 14 weeks	10001062	Mus musculus HLA-A*24:02 Tg	1890	8 to 14 week	8 to 14 week
+8 to 14 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1891	8 to 14 week	8 to 14 week
+6-8weeks	10000000	Mus musculus BALB/c	1892	6-8weeks	6-8weeks
+8 to 10 weeks	10000601	Mus musculus HLA-DR1 Tg	1893	8 to 10 week	8 to 10 week
+5-8 weeks	10001090	Mus musculus YA26 TCR Tg	1894	5-8 week	5-8 week
+12 weeks	10000228	Mus musculus CBA	1895	12 week	12 week
+16 weeks	10000582	Mus musculus HLA-A2 Tg	1896	16 week	16 week
+65-74 years old	9606	Homo sapiens (human)	1897	65-74 year old	65-74 year
+74 years old	9606	Homo sapiens (human)	1898	74 year old	74 year
+20-57 years	9606	Homo sapiens (human)	1899	20-57 year	20-57 year
+5-8 weeks	10001363	Mus musculus 2D2 TCR Tg	1900	5-8 week	5-8 week
+10-14 weeks	10000632	Mus musculus NOD	1901	10-14 week	10-14 week
+3-4 weeks	10000067	Mus musculus C57BL/6	1902	3-4 week	3-4 week
+44.9 to 74.1 years	9606	Homo sapiens (human)	1903	44.9 to 74.1 year	44.9 to 74.1 year
+6 weeks	10000054	Mus musculus DBA/1	1904	6 week	6 week
+NULL	9483	Callithrix jacchus (common marmoset)	1905	null	null
+32-70 years	9606	Homo sapiens (human)	1906	32-70 year	32-70 year
+37-66 years	9606	Homo sapiens (human)	1907	37-66 year	37-66 year
+8 weeks old	10000067	Mus musculus C57BL/6	1908	8 week old	8 week
+23-81 years	9606	Homo sapiens (human)	1909	23-81 year	23-81 year
+12-64 years	9606	Homo sapiens (human)	1910	12-64 year	12-64 year
+11-18 years	9606	Homo sapiens (human)	1911	11-18 year	11-18 year
+23 days	10116	Rattus norvegicus (brown rat)	1912	23 days	23 days
+NULL	10000978	Mus musculus C57BL/6 X BALB/cByJ	1913	null	null
+6-8 weeks	10000043	Mus musculus C3HeB/FeJ	1914	6-8 week	6-8 week
+7-8 years	10000917	Equus caballus Arabian	1915	7-8 year	7-8 year
+NULL	10000043	Mus musculus C3HeB/FeJ	1916	null	null
+40 years or older	10000119	Homo sapiens Caucasian	1917	40 year or older	40 year or older
+21-35	9606	Homo sapiens (human)	1918	21-35	21-35
+2 months old	10000576	Mus musculus HLA-A*02:01 Tg	1919	2 month old	2 month
+NULL	10000195	Capra hircus Saanen	1920	null	null
+6-9 weeks	10000000	Mus musculus BALB/c	1921	6-9 week	6-9 week
+7-8 weeks	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	1922	7-8 week	7-8 week
+6 to 8 weeks	10000206	Oryctolagus cuniculus New Zealand White	1923	6 to 8 week	6 to 8 week
+6-8 weeks	10000009	Mus musculus BALB/c IFNgamma null	1924	6-8 week	6-8 week
+68-76	9606	Homo sapiens (human)	1925	68-76	68-76
+25-37	9606	Homo sapiens (human)	1926	25-37	25-37
+42-62 years	9606	Homo sapiens (human)	1927	42-62 year	42-62 year
+6-9 days	10000067	Mus musculus C57BL/6	1928	6-9 days	6-9 days
+NULL	9615	Canis lupus familiaris (dogs)	1929	null	null
+53-54 years	9606	Homo sapiens (human)	1930	53-54 year	53-54 year
+2 months	10000187	Sus scrofa Landrace X Large White	1931	2 month	2 month
+8 to 12-weeks	10000000	Mus musculus BALB/c	1932	8 to 12-week	8 to 12 week
+6-8 weeks	10000661	Rattus norvegicus Fischer 344	1933	6-8 week	6-8 week
+14-74	9606	Homo sapiens (human)	1934	14-74	14-74
+6-9 days	10000000	Mus musculus BALB/c	1935	6-9 days	6-9 days
+8-10 weeks	10000047	Mus musculus C57BL/10	1936	8-10 week	8-10 week
+26-79 years	9606	Homo sapiens (human)	1937	26-79 year	26-79 year
+>45 years	9606	Homo sapiens (human)	1938	>45 year	>45 year
+8-20 weeks	10000067	Mus musculus C57BL/6	1939	8-20 week	8-20 week
+24 to 46 years	9606	Homo sapiens (human)	1940	24 to 46 year	24 to 46 year
+25-73	9606	Homo sapiens (human)	1941	25-73	25-73
+24-58 years	9606	Homo sapiens (human)	1942	24-58 year	24-58 year
+6-8 weeks	10000016	Mus musculus BALB/c X C57BL/10	1943	6-8 week	6-8 week
+8 weeks	10000253	Mus musculus A/J	1944	8 week	8 week
+80 days	10000067	Mus musculus C57BL/6	1945	80 days	80 days
+52.2 - 69 years	9606	Homo sapiens (human)	1946	52.2 - 69 year	52.2 - 69 year
+1-12 years	10000119	Homo sapiens Caucasian	1947	1-12 year	1-12 year
+6 months	10000193	Bos taurus Holstein	1948	6 month	6 month
+2 months	9823	Sus scrofa (pig)	1949	2 month	2 month
+6-9 weeks	10000038	Mus musculus C3H/He	1950	6-9 week	6-9 week
+NULL	10001094	Mus musculus C57BL/6 IL-4 Tg	1951	null	null
+8-20 weeks	10090	Mus musculus (mouse)	1952	8-20 week	8-20 week
+over 18 years old	9606	Homo sapiens (human)	1953	over 18 year old	over 18 year
+14-55 years	9606	Homo sapiens (human)	1954	14-55 year	14-55 year
+20-51	9606	Homo sapiens (human)	1955	20-51	20-51
+6-8 weeks	10000258	Mus musculus B10.A(2R)	1956	6-8 week	6-8 week
+10-12 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	1957	10-12 week	10-12 week
+NULL	10000254	Mus musculus A/Sn	1958	null	null
+27 to 56 years	9606	Homo sapiens (human)	1959	27 to 56 year	27 to 56 year
+10-13 days	9823	Sus scrofa (pig)	1960	10-13 days	10-13 days
+6 week	10000067	Mus musculus C57BL/6	1961	6 week	6 week
+NULL	10001128	Mus musculus N15 TCR Tg	1962	null	null
+22-35 years old	9606	Homo sapiens (human)	1963	22-35 year old	22-35 year
+Newborn	10001165	Mus musculus C57BR/cdJ	1964	newborn	newborn
+15-18 months	10000191	Bos taurus Hereford	1965	15-18 month	15-18 month
+7.5-8 weeks	10000028	Mus musculus C3H	1966	7.5-8 week	7.5-8 week
+15 weeks	9615	Canis lupus familiaris (dogs)	1967	15 week	15 week
+8-16 weeks	10000274	Mus musculus B10.PL	1968	8-16 week	8-16 week
+19-48 years	9606	Homo sapiens (human)	1969	19-48 year	19-48 year
+55-60 years	9606	Homo sapiens (human)	1970	55-60 year	55-60 year
+8-14 weeks	10001537	Mus musculus PL	1971	8-14 week	8-14 week
+NULL	10001336	Mus musculus MS2-3C8 TCR Tg	1972	null	null
+60	9606	Homo sapiens (human)	1973	60	60
+81 years	9606	Homo sapiens (human)	1974	81 year	81 year
+8 weeks	10001537	Mus musculus PL	1975	8 week	8 week
+34	9606	Homo sapiens (human)	1976	34	34
+48 years	9606	Homo sapiens (human)	1977	48 year	48 year
+22-54 years	9606	Homo sapiens (human)	1978	22-54 year	22-54 year
+6 weeks	10000063	Mus musculus B10.A	1979	6 week	6 week
+23-45 years	9606	Homo sapiens (human)	1980	23-45 year	23-45 year
+6 weeks	10001019	Mus musculus B10.D2	1981	6 week	6 week
+6-8 weeks	10000618	Mus musculus ICR	1982	6-8 week	6-8 week
+6 weeks	10000047	Mus musculus C57BL/10	1983	6 week	6 week
+6 weeks	10000263	Mus musculus B10.BR	1984	6 week	6 week
+NULL	10001103	Mus musculus SV40 Tg	1985	null	null
+4 years	9606	Homo sapiens (human)	1986	4 year	4 year
+53 yrs	9606	Homo sapiens (human)	1987	53 year	53 year
+38-53	9606	Homo sapiens (human)	1988	38-53	38-53
+mean age = 27 years	9606	Homo sapiens (human)	1989	mean age = 27 year	mean age = 27 year
+36-37 years	9606	Homo sapiens (human)	1990	36-37 year	36-37 year
+adult	10000067	Mus musculus C57BL/6	1991	adult	adult
+NULL	10001067	Mus musculus B10.D1	1992	null	null
+NULL	10001066	Mus musculus B10.RIH	1993	null	null
+3-12 years	9796	Equus caballus (domestic horse)	1994	3-12 year	3-12 year
+7-8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	1995	7-8 week	7-8 week
+8-12 weeks	10001097	Sus scrofa Yorkshire	1996	8-12 week	8-12 week
+9-10 weeks	10001103	Mus musculus SV40 Tg	1997	9-10 week	9-10 week
+8-9 weeks	10001103	Mus musculus SV40 Tg	1998	8-9 week	8-9 week
+3 - 4 week old	10000067	Mus musculus C57BL/6	1999	3 - 4 week old	3 - 4 week
+3-5 week-old	10000000	Mus musculus BALB/c	2000	3-5 week-old	3-5 week
+28-58 years	9606	Homo sapiens (human)	2001	28-58 year	28-58 year
+1-2 years	9606	Homo sapiens (human)	2002	1-2 year	1-2 year
+6-18 weeks old	10000000	Mus musculus BALB/c	2003	6-18 week old	6-18 week
+32-37 years	9606	Homo sapiens (human)	2004	32-37 year	32-37 year
+6-16 weeks	10000067	Mus musculus C57BL/6	2005	6-16 week	6-16 week
+8-16 weeks	10001087	Mus musculus C57BL/6 bm14	2006	8-16 week	8-16 week
+NULL	10000095	Mus musculus C57BL/6 IFNgamma null	2007	null	null
+NULL	10001041	Rattus norvegicus Wistar	2008	null	null
+NULL	10001322	Oryctolagus cuniculus HLA-A2.1 Tg	2009	null	null
+74 years	9606	Homo sapiens (human)	2010	74 year	74 year
+16-53	9606	Homo sapiens (human)	2011	16-53	16-53
+NULL	10000101	Mus musculus C57BL/6 Perforin null	2012	null	null
+NULL	10001104	Mus musculus B6 TNF alpha null	2013	null	null
+2-8 years	10000185	Canis familiaris beagle	2014	2-8 year	2-8 year
+4 weeks	10000661	Rattus norvegicus Fischer 344	2015	4 week	4 week
+NULL	10001211	Mus musculus (C57BL/6 X A/J)	2016	null	null
+19-57	9606	Homo sapiens (human)	2017	19-57	19-57
+Calf	9913	Bos taurus (bovine)	2018	calf	calf
+18-64 years	9606	Homo sapiens (human)	2019	18-64 year	18-64 year
+NULL	10000219	Mus musculus C57BL/6 X CBA	2020	null	null
+Calves and cows	9913	Bos taurus (bovine)	2021	calves and cows	calves and cows
+53 years	10000119	Homo sapiens Caucasian	2022	53 year	53 year
+11 weeks	10001657	Mus musculus NZW X BALB/c	2023	11 week	11 week
+2-6 months	10000265	Mus musculus AND TCR Tg	2024	2-6 month	2-6 month
+23 years old	9606	Homo sapiens (human)	2025	23 year old	23 year
+8 to 10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	2026	8 to 10 week	8 to 10 week
+8-12 weeks	10000219	Mus musculus C57BL/6 X CBA	2027	8-12 week	8-12 week
+8-10 weeks	10002233	Mus musculus 16.2beta TCR Tg	2028	8-10 week	8-10 week
+8-12 weeks	10001208	Mus musculus B6.C-H-2bm1	2029	8-12 week	8-12 week
+30-78	9606	Homo sapiens (human)	2030	30-78	30-78
+38-50 years	9606	Homo sapiens (human)	2031	38-50 year	38-50 year
+23-45 years old	9606	Homo sapiens (human)	2032	23-45 year old	23-45 year
+30-45 years old	9606	Homo sapiens (human)	2033	30-45 year old	30-45 year
+23-35 years old	9606	Homo sapiens (human)	2034	23-35 year old	23-35 year
+8 yr	9598	Pan troglodytes (chimpanzee)	2035	8 year	8 year
+4 weeks-old	10000919	Gallus gallus White Leghorn	2036	4 week-old	4 week
+6-12 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	2037	6-12 week	6-12 week
+6-12 weeks	10001214	Mus musculus B10.A(18R)	2038	6-12 week	6-12 week
+NULL	10001219	Mus musculus B10.A x A/J	2039	null	null
+6-12 weeks	10000258	Mus musculus B10.A(2R)	2040	6-12 week	6-12 week
+6-12 weeks	10000259	Mus musculus B10.A(3R)	2041	6-12 week	6-12 week
+6-12 weeks	10000253	Mus musculus A/J	2042	6-12 week	6-12 week
+2 months	9606	Homo sapiens (human)	2043	2 month	2 month
+50 days	10001105	Mus musculus SV11	2044	50 days	50 days
+35 to 41 years	9606	Homo sapiens (human)	2045	35 to 41 year	35 to 41 year
+47 to 53 years	9606	Homo sapiens (human)	2046	47 to 53 year	47 to 53 year
+2-3 months	10000616	Mus musculus HLA-DRB1*04:01 Tg	2047	2-3 month	2-3 month
+4 to 6 weeks	10000236	Mus musculus CBA/J	2048	4 to 6 week	4 to 6 week
+NULL	10001001	Rattus norvegicus WKAH	2049	null	null
+12 months	10001240	Mus musculus APPsw	2050	12 month	12 month
+8-10 weeks	10002208	Mus musculus DO11.10 TCR Tg	2051	8-10 week	8-10 week
+29 years old	9606	Homo sapiens (human)	2052	29 year old	29 year
+24 years old	9606	Homo sapiens (human)	2053	24 year old	24 year
+24-32 years old	9606	Homo sapiens (human)	2054	24-32 year old	24-32 year
+4-6 weeks	10000228	Mus musculus CBA	2055	4-6 week	4-6 week
+10 days	10000000	Mus musculus BALB/c	2056	10 days	10 days
+7 to 10 weeks	10001287	Mus musculus DBA/1 X B10.Q	2057	7 to 10 week	7 to 10 week
+8-10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	2058	8-10 week	8-10 week
+68 years, and 70 years	9606	Homo sapiens (human)	2059	68 year, and 70 year	68 year, and 70 year
+young adult	10001301	Mus musculus HLA-DR15 Tg	2060	young adult	young adult
+mean age = 49.2 years	9606	Homo sapiens (human)	2061	mean age = 49.2 year	mean age = 49.2 year
+42-61 years	9606	Homo sapiens (human)	2062	42-61 year	42-61 year
+NULL	10001218	Mus musculus B10.A x A.BY	2063	null	null
+11 to 47 years	9606	Homo sapiens (human)	2064	11 to 47 year	11 to 47 year
+27-29 years	9606	Homo sapiens (human)	2065	27-29 year	27-29 year
+7-8 weeks	10000253	Mus musculus A/J	2066	7-8 week	7-8 week
+NULL	10001509	Mus musculus BM3.3 TCR Tg	2067	null	null
+6-12 weeks	10000256	Mus musculus B10 X B10.BR	2068	6-12 week	6-12 week
+6 to 7 weeks	10000054	Mus musculus DBA/1	2069	6 to 7 week	6 to 7 week
+12 weeks	10001405	Mus musculus NZB X NZW	2070	12 week	12 week
+3 weeks	10000067	Mus musculus C57BL/6	2071	3 week	3 week
+16 weeks	10001248	Mus musculus NOD.Cg-Tg	2072	16 week	16 week
+10 to 12 weeks	10000581	Mus musculus HLA-A11 Tg	2073	10 to 12 week	10 to 12 week
+1-7 years	10000194	Bos taurus Holstein-Friesian	2074	1-7 year	1-7 year
+25-52 years	9606	Homo sapiens (human)	2075	25-52 year	25-52 year
+6-12 weeks	10000054	Mus musculus DBA/1	2076	6-12 week	6-12 week
+11-42 years	9606	Homo sapiens (human)	2077	11-42 year	11-42 year
+20 months	9606	Homo sapiens (human)	2078	20 month	20 month
+31-58.8 years	9606	Homo sapiens (human)	2079	31-58.8 year	31-58.8 year
+6-11 weeks	10000632	Mus musculus NOD	2080	6-11 week	6-11 week
+23-58 years	9606	Homo sapiens (human)	2081	23-58 year	23-58 year
+18-41 years	9606	Homo sapiens (human)	2082	18-41 year	18-41 year
+24-46 years	9606	Homo sapiens (human)	2083	24-46 year	24-46 year
+NULL	10001251	Mus musculus RIP-B7	2084	null	null
+2 to 4 weeks	9913	Bos taurus (bovine)	2085	2 to 4 week	2 to 4 week
+4-14 weeks	10000632	Mus musculus NOD	2086	4-14 week	4-14 week
+13-45	9606	Homo sapiens (human)	2087	13-45	13-45
+12-43	9606	Homo sapiens (human)	2088	12-43	12-43
+4-9 weeks	10000632	Mus musculus NOD	2089	4-9 week	4-9 week
+6 - 8 weeks	10000092	Mus musculus gBT-I TCR Tg	2090	6 - 8 week	6 - 8 week
+46	9606	Homo sapiens (human)	2091	46	46
+10-52	9606	Homo sapiens (human)	2092	10-52	10-52
+53-83 years	9606	Homo sapiens (human)	2093	53-83 year	53-83 year
+12-41	9606	Homo sapiens (human)	2094	12-41	12-41
+6 - 8 weeks	10000067	Mus musculus C57BL/6	2095	6 - 8 week	6 - 8 week
+13	9606	Homo sapiens (human)	2096	13	13
+54-81 years	9606	Homo sapiens (human)	2097	54-81 year	54-81 year
+Median age 5.5 years	9606	Homo sapiens (human)	2098	median age 5.5 year	median age 5.5 year
+30-48 years	9606	Homo sapiens (human)	2099	30-48 year	30-48 year
+27-70 years	9606	Homo sapiens (human)	2100	27-70 year	27-70 year
+NULL	10001610	Mus musculus A1 TCR Tg	2101	null	null
+6-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2102	6-10 week	6-10 week
+8-12 weeks	10001234	Mus musculus C57BL/6 OX40 null	2103	8-12 week	8-12 week
+8 to 10 weeks	10000632	Mus musculus NOD	2104	8 to 10 week	8 to 10 week
+32 to 65 years	9606	Homo sapiens (human)	2105	32 to 65 year	32 to 65 year
+27 to 51	9606	Homo sapiens (human)	2106	27 to 51	27 to 51
+4-5 weeks	10000632	Mus musculus NOD	2107	4-5 week	4-5 week
+11 weeks	10001269	Mus musculus NOD HSP60 Tg	2108	11 week	11 week
+NULL	10001269	Mus musculus NOD HSP60 Tg	2109	null	null
+8 to 10 weeks old	10000635	Mus musculus NOD/Lt	2110	8 to 10 week old	8 to 10 week
+less than 30 years	9606	Homo sapiens (human)	2111	less than 30 year	less than 30 year
+12-24 weeks	10000632	Mus musculus NOD	2112	12-24 week	12-24 week
+1 month	10000635	Mus musculus NOD/Lt	2113	1 month	1 month
+7 days	10000635	Mus musculus NOD/Lt	2114	7 days	7 days
+NULL	10001611	Mus musculus B10.AKM	2115	null	null
+juvenile	10000632	Mus musculus NOD	2116	juvenile	juvenile
+1.8-18 years	9606	Homo sapiens (human)	2117	1.8-18 year	1.8-18 year
+7-40 years	9606	Homo sapiens (human)	2118	7-40 year	7-40 year
+8-29 years	9606	Homo sapiens (human)	2119	8-29 year	8-29 year
+2-62 years	9606	Homo sapiens (human)	2120	2-62 year	2-62 year
+33-75 years	9606	Homo sapiens (human)	2121	33-75 year	33-75 year
+6 to 16 weeks	10000067	Mus musculus C57BL/6	2122	6 to 16 week	6 to 16 week
+67 years old	9606	Homo sapiens (human)	2123	67 year old	67 year
+> 24 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2124	> 24 week	> 24 week
+8 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2125	8 week	8 week
+24-65 years	9606	Homo sapiens (human)	2126	24-65 year	24-65 year
+19-65 years	9606	Homo sapiens (human)	2127	19-65 year	19-65 year
+6 weeks	10002836	Mus musculus HLA-DQ2 Tg	2128	6 week	6 week
+7-17 weeks	10000632	Mus musculus NOD	2129	7-17 week	7-17 week
+7 to 15 weeks	10000582	Mus musculus HLA-A2 Tg	2130	7 to 15 week	7 to 15 week
+NULL	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	2131	null	null
+40	9606	Homo sapiens (human)	2132	40	40
+9-20 weeks	10000067	Mus musculus C57BL/6	2133	9-20 week	9-20 week
+7 to 15 weeks	10000061	Mus musculus FVB	2134	7 to 15 week	7 to 15 week
+14-25 years	9606	Homo sapiens (human)	2135	14-25 year	14-25 year
+10 weeks	10001248	Mus musculus NOD.Cg-Tg	2136	10 week	10 week
+29-49 years	9606	Homo sapiens (human)	2137	29-49 year	29-49 year
+4 week	10000632	Mus musculus NOD	2138	4 week	4 week
+4 to 7 weeks old	10001248	Mus musculus NOD.Cg-Tg	2139	4 to 7 week old	4 to 7 week
+17 weeks	10000632	Mus musculus NOD	2140	17 week	17 week
+12-15 weeks	10000632	Mus musculus NOD	2141	12-15 week	12-15 week
+5-12 weeks	10001248	Mus musculus NOD.Cg-Tg	2142	5-12 week	5-12 week
+>6 weeks	10000632	Mus musculus NOD	2143	>6 week	>6 week
+27- 76 years	9606	Homo sapiens (human)	2144	27- 76 year	27- 76 year
+NULL	10002236	Mus musculus 17.6α-8.3β TCR Tg	2145	null	null
+NULL	8022	Oncorhynchus mykiss (rainbow trout)	2146	null	null
+5-8 weeks	10001261	Mus musculus G9Calpha –/ –.NOD	2147	5-8 week	5-8 week
+4 weeks	10001255	Mus musculus RIP-B7 H2d/d	2148	4 week	4 week
+7 to 10 weeks	10000067	Mus musculus C57BL/6	2149	7 to 10 week	7 to 10 week
+NULL	10001547	Mus musculus C57BL/6 TCR transgenic	2150	null	null
+4 weeks	10001248	Mus musculus NOD.Cg-Tg	2151	4 week	4 week
+65 days	10000667	Rattus norvegicus Sprague-Dawley	2152	65 days	65 days
+adult	9940	Ovis aries (domestic sheep)	2153	adult	adult
+17-46 years	9606	Homo sapiens (human)	2154	17-46 year	17-46 year
+17-20 years	9606	Homo sapiens (human)	2155	17-20 year	17-20 year
+16-26 weeks	10000632	Mus musculus NOD	2156	16-26 week	16-26 week
+NULL	10001068	Mus musculus C57/BL/6 LCMV NP Tg	2157	null	null
+12 years 9 months	9606	Homo sapiens (human)	2158	12 year 9 month	12 year 9 month
+13-15 years	9606	Homo sapiens (human)	2159	13-15 year	13-15 year
+NULL	10001274	Cavia porcellus Strain (2 X 13)	2160	null	null
+7-8 weeks	10001248	Mus musculus NOD.Cg-Tg	2161	7-8 week	7-8 week
+19	9606	Homo sapiens (human)	2162	19	19
+20-25 years	9606	Homo sapiens (human)	2163	20-25 year	20-25 year
+4.5 weeks	10000632	Mus musculus NOD	2164	4.5 week	4.5 week
+NULL	10001240	Mus musculus APPsw	2165	null	null
+28	9606	Homo sapiens (human)	2166	28	28
+3 month	10000067	Mus musculus C57BL/6	2167	3 month	3 month
+8 to 12 weeks old	10000067	Mus musculus C57BL/6	2168	8 to 12 week old	8 to 12 week
+4-12 weeks	10000632	Mus musculus NOD	2169	4-12 week	4-12 week
+12-20 weeks	10000632	Mus musculus NOD	2170	12-20 week	12-20 week
+4-8 weeks	10000632	Mus musculus NOD	2171	4-8 week	4-8 week
+47-56 years	9606	Homo sapiens (human)	2172	47-56 year	47-56 year
+6-10 weeks	10000952	Mus musculus B6.129P2-B2m tm1Unc/J	2173	6-10 week	6-10 week
+60-91 years	9606	Homo sapiens (human)	2174	60-91 year	60-91 year
+24-day-old	10000667	Rattus norvegicus Sprague-Dawley	2175	24-day-old	24 day
+8 weeks	10000220	Mus musculus C57BL/6 X DBA/2	2176	8 week	8 week
+1.5-22 months	10000007	Mus musculus 6.5 TCR Tg	2177	1.5-22 month	1.5-22 month
+1.5-18 months	10000007	Mus musculus 6.5 TCR Tg	2178	1.5-18 month	1.5-18 month
+6-8 weeks	10000642	Mus musculus Outbred	2179	6-8 week	6-8 week
+24-52 years	9606	Homo sapiens (human)	2180	24-52 year	24-52 year
+3-8 months	10000000	Mus musculus BALB/c	2181	3-8 month	3-8 month
+NULL	10001166	Mus musculus HLA-A24 Tg	2182	null	null
+NULL	10000595	Mus musculus HLA-B7 Tg	2183	null	null
+NULL	10001600	Rattus norvegicus WAG	2184	null	null
+NULL	10000238	Mus musculus CD1d null	2185	null	null
+3-8 months	10000063	Mus musculus B10.A	2186	3-8 month	3-8 month
+2 years	9913	Bos taurus (bovine)	2187	2 year	2 year
+21-45 years	9606	Homo sapiens (human)	2188	21-45 year	21-45 year
+3 to 8 weeks	10000000	Mus musculus BALB/c	2189	3 to 8 week	3 to 8 week
+27-29 days	10001477	Mus musculus InsHA	2190	27-29 days	27-29 days
+33-36 days	10001477	Mus musculus InsHA	2191	33-36 days	33-36 days
+8 weeks	10000055	Mus musculus DBA/2	2192	8 week	8 week
+4-6 weeks	10000253	Mus musculus A/J	2193	4-6 week	4-6 week
+NULL	10001609	Rattus norvegicus PVG-RT1c	2194	null	null
+8 weeks	10000649	Mus musculus SJL	2195	8 week	8 week
+NULL	10001508	Mus musculus BALB/cA Bom	2196	null	null
+5-8 weeks	10001019	Mus musculus B10.D2	2197	5-8 week	5-8 week
+2 to 4 months	10000267	Mus musculus B10.CE-H13b Aw/(30NX)Sn	2198	2 to 4 month	2 to 4 month
+27-57 years	9606	Homo sapiens (human)	2199	27-57 year	27-57 year
+50 ± 15 years	9606	Homo sapiens (human)	2200	50  15 year	50  15 year
+40 ± 12 years	9606	Homo sapiens (human)	2201	40  12 year	40  12 year
+28-48 years	9606	Homo sapiens (human)	2202	28-48 year	28-48 year
+8-20 weeks	10000033	Mus musculus C3H.SW	2203	8-20 week	8-20 week
+50 years	9606	Homo sapiens (human)	2204	50 year	50 year
+NULL	10002215	Mus musculus Marilyn TCR Tg	2205	null	null
+21-48 years	9606	Homo sapiens (human)	2206	21-48 year	21-48 year
+NULL	10001665	Mus musculus B6.Tlaa	2207	null	null
+21-75 years	9606	Homo sapiens (human)	2208	21-75 year	21-75 year
+8-12 weeks	10001339	Rattus norvegicus LEWIS.1A	2209	8-12 week	8-12 week
+NULL	10001672	Mus musculus B10.129 H46bH47b	2210	null	null
+6-8 weeks	10000007	Mus musculus 6.5 TCR Tg	2211	6-8 week	6-8 week
+2 to 4 months	10000047	Mus musculus C57BL/10	2212	2 to 4 month	2 to 4 month
+17 to 74 years	9606	Homo sapiens (human)	2213	17 to 74 year	17 to 74 year
+8 to 10 weeks	10000658	Rattus norvegicus Brown Norway	2214	8 to 10 week	8 to 10 week
+8 to 10 weeks	10001411	Rattus norvegicus Buffalo	2215	8 to 10 week	8 to 10 week
+8 to 10 weeks	10001413	Rattus norvegicus ACI	2216	8 to 10 week	8 to 10 week
+8 to 10 weeks	10001412	Rattus norvegicus Wistar-Furth	2217	8 to 10 week	8 to 10 week
+NULL	10001656	Mus musculus HNT TCR Tg	2218	null	null
+6 to 12 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	2219	6 to 12 week	6 to 12 week
+NULL	10001385	Cavia porcellus Albino Himalayan Fullingsdorf	2220	null	null
+Adult	9544	Macaca mulatta (rhesus macaque)	2221	adult	adult
+24-49 years	9606	Homo sapiens (human)	2222	24-49 year	24-49 year
+6 weeks	10002232	Mus musculus BDC2.5 TCR Tg	2223	6 week	6 week
+3-22 months	10000007	Mus musculus 6.5 TCR Tg	2224	3-22 month	3-22 month
+4 to 6 weeks	10000063	Mus musculus B10.A	2225	4 to 6 week	4 to 6 week
+4 to 6 weeks	10000000	Mus musculus BALB/c	2226	4 to 6 week	4 to 6 week
+6-10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2227	6-10 week	6-10 week
+8 weeks	10001595	Mus musculus B6.2.16 TCR Tg	2228	8 week	8 week
+NULL	10001727	Mus musculus C3H X B6.K1	2229	null	null
+6 to 8 weeks	10000227	Mus musculus OT-1 TCR Tg	2230	6 to 8 week	6 to 8 week
+20-65 years-old	9606	Homo sapiens (human)	2231	20-65 year-old	20-65 year
+4 months	10001241	Mus musculus APP	2232	4 month	4 month
+> 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2233	> 8 week	> 8 week
+40 -58 years	9606	Homo sapiens (human)	2234	40 -58 year	40 -58 year
+6-8 weeks	10001221	Mus musculus C57BL/6 x SJL	2235	6-8 week	6-8 week
+6-8 weeks	10000668	Cavia porcellus Duncan-Hartley	2236	6-8 week	6-8 week
+6-8 weeks, and 4 months	10000067	Mus musculus C57BL/6	2237	6-8 week, and 4 month	6-8 week, and 4 month
+Young adult	10000067	Mus musculus C57BL/6	2238	young adult	young adult
+12 to 24 weeks	10000632	Mus musculus NOD	2239	12 to 24 week	12 to 24 week
+24-32 years	10000119	Homo sapiens Caucasian	2240	24-32 year	24-32 year
+6 to 35 months	9606	Homo sapiens (human)	2241	6 to 35 month	6 to 35 month
+NULL	10002208	Mus musculus DO11.10 TCR Tg	2242	null	null
+21-77 years	9606	Homo sapiens (human)	2243	21-77 year	21-77 year
+NULL	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	2244	null	null
+NULL	10001363	Mus musculus 2D2 TCR Tg	2245	null	null
+72 to 90 years	9606	Homo sapiens (human)	2246	72 to 90 year	72 to 90 year
+20-47 years	9606	Homo sapiens (human)	2247	20-47 year	20-47 year
+31-68 yeays	9606	Homo sapiens (human)	2248	31-68 year	31-68 year
+31 to 68 years	9606	Homo sapiens (human)	2249	31 to 68 year	31 to 68 year
+8 to 16 weeks	10001275	Rattus norvegicus PVG-RT1u	2250	8 to 16 week	8 to 16 week
+5-7 weeks	10000038	Mus musculus C3H/He	2251	5-7 week	5-7 week
+NULL	10001310	Mus musculus BDC12-4.1 TCR Tg	2252	null	null
+29-60 years	9606	Homo sapiens (human)	2253	29-60 year	29-60 year
+33 to 66 years	9606	Homo sapiens (human)	2254	33 to 66 year	33 to 66 year
+NULL	10001383	Mus musculus Clone 4 TCR Tg	2255	null	null
+29-65 years	9606	Homo sapiens (human)	2256	29-65 year	29-65 year
+6-9 weeks	10000228	Mus musculus CBA	2257	6-9 week	6-9 week
+17-66 years	9606	Homo sapiens (human)	2258	17-66 year	17-66 year
+8-12 weeks	10116	Rattus norvegicus (brown rat)	2259	8-12 week	8-12 week
+4 to 12 weeks	10000000	Mus musculus BALB/c	2260	4 to 12 week	4 to 12 week
+mean age 46 years	9606	Homo sapiens (human)	2261	mean age 46 year	mean age 46 year
+12 years	9606	Homo sapiens (human)	2262	12 year	12 year
+21-41 years	9606	Homo sapiens (human)	2263	21-41 year	21-41 year
+28 to 63 years	9606	Homo sapiens (human)	2264	28 to 63 year	28 to 63 year
+2.5-25.4 years	9606	Homo sapiens (human)	2265	2.5-25.4 year	2.5-25.4 year
+6-10 weeks	10001349	Mus musculus SJL X SWR	2266	6-10 week	6-10 week
+6-8 weeks	10000025	Mus musculus Biozzi AB/H	2267	6-8 week	6-8 week
+NULL	10001765	Oryctolagus cuniculus EIII/JC	2268	null	null
+6 to 12 weeks	10000033	Mus musculus C3H.SW	2269	6 to 12 week	6 to 12 week
+5 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	2270	5 week	5 week
+19-57 years	9606	Homo sapiens (human)	2271	19-57 year	19-57 year
+2 to 6 months	10000000	Mus musculus BALB/c	2272	2 to 6 month	2 to 6 month
+6-14 weeks	10000000	Mus musculus BALB/c	2273	6-14 week	6-14 week
+>6 weeks	10001353	Rattus norvegicus DA X LEW	2274	>6 week	>6 week
+8 weeks	10000187	Sus scrofa Landrace X Large White	2275	8 week	8 week
+NULL	10001364	Mus musculus B6 Calpha null	2276	null	null
+6-10 weeks	10000601	Mus musculus HLA-DR1 Tg	2277	6-10 week	6-10 week
+22-69 years	9606	Homo sapiens (human)	2278	22-69 year	22-69 year
+8 - 10 weeks	10000038	Mus musculus C3H/He	2279	8 - 10 week	8 - 10 week
+3 to 8 weeks	10000063	Mus musculus B10.A	2280	3 to 8 week	3 to 8 week
+7-16 weeks	10000067	Mus musculus C57BL/6	2281	7-16 week	7-16 week
+21 to 40 years	9606	Homo sapiens (human)	2282	21 to 40 year	21 to 40 year
+NULL	10001781	Mus musculus H2-Kb VSV RGYVYQGLTg	2283	null	null
+15-62 years	9606	Homo sapiens (human)	2284	15-62 year	15-62 year
+<3 years	9544	Macaca mulatta (rhesus macaque)	2285	<3 year	<3 year
+43-84 years	9606	Homo sapiens (human)	2286	43-84 year	43-84 year
+8 weeks	10000254	Mus musculus A/Sn	2287	8 week	8 week
+12 weeks	10001133	Rattus norvegicus DA	2288	12 week	12 week
+12 weeks	10001664	Rattus norvegicus Albino Oxford	2289	12 week	12 week
+6-8 weeks	10001099	Mus musculus CF-1	2290	6-8 week	6-8 week
+16 ± 11 days	9913	Bos taurus (bovine)	2291	16  11 days	16  11 days
+41±13 years	9606	Homo sapiens (human)	2292	4113 year	4113 year
+54±10 years	9606	Homo sapiens (human)	2293	5410 year	5410 year
+7-13 weeks	10000067	Mus musculus C57BL/6	2294	7-13 week	7-13 week
+23-64	9606	Homo sapiens (human)	2295	23-64	23-64
+7-74 years	9606	Homo sapiens (human)	2296	7-74 year	7-74 year
+6 to 7 weeks	10000067	Mus musculus C57BL/6	2297	6 to 7 week	6 to 7 week
+5-7 weeks	10000097	Mus musculus C57BL/6 Kb null	2298	5-7 week	5-7 week
+NULL	10001220	Mus musculus OT-II TCR Tg	2299	null	null
+adult	10001411	Rattus norvegicus Buffalo	2300	adult	adult
+adult	10001413	Rattus norvegicus ACI	2301	adult	adult
+2-12 months	10000263	Mus musculus B10.BR	2302	2-12 month	2-12 month
+19 years	9606	Homo sapiens (human)	2303	19 year	19 year
+23-55 years	9606	Homo sapiens (human)	2304	23-55 year	23-55 year
+32-69 years	9606	Homo sapiens (human)	2305	32-69 year	32-69 year
+NULL	10001405	Mus musculus NZB X NZW	2306	null	null
+2-12 months	10001369	Mus musculus C57L	2307	2-12 month	2-12 month
+2-12 months	10000028	Mus musculus C3H	2308	2-12 month	2-12 month
+6 weeks	10001601	Mus musculus C57BL/6 X 129	2309	6 week	6 week
+34 to 73 years	9606	Homo sapiens (human)	2310	34 to 73 year	34 to 73 year
+22 to 82 years	9606	Homo sapiens (human)	2311	22 to 82 year	22 to 82 year
+35-60 years	9606	Homo sapiens (human)	2312	35-60 year	35-60 year
+6 weeks	10000275	Mus musculus B10.RIII	2313	6 week	6 week
+6 to 7 weeks	10001410	Mus musculus 5B6 TCR Tg	2314	6 to 7 week	6 to 7 week
+2-4 months	10000601	Mus musculus HLA-DR1 Tg	2315	2-4 month	2-4 month
+NULL	10001299	Mus musculus HLA-DRB1*04:02 Tg	2316	null	null
+3 months	10000047	Mus musculus C57BL/10	2317	3 month	3 month
+6 to 10 weeks	10000229	Mus musculus HLA-B*27:05 Tg	2318	6 to 10 week	6 to 10 week
+1 month	10000188	Sus scrofa NIH miniature pig	2319	1 month	1 month
+4-8 months	10001221	Mus musculus C57BL/6 x SJL	2320	4-8 month	4-8 month
+20 - >65 years	9606	Homo sapiens (human)	2321	20 - >65 year	20 - >65 year
+NULL	10001789	Mus musculus B10.BR X C3H.OL	2322	null	null
+3 months	10000649	Mus musculus SJL	2323	3 month	3 month
+6-8 weeks	10001414	Mus musculus 172.10 TCR Tg	2324	6-8 week	6-8 week
+NULL	10001802	Mus musculus NY8.3 TCR Tg	2325	null	null
+18-60 years	9606	Homo sapiens (human)	2326	18-60 year	18-60 year
+NULL	10001399	Mus musculus HLA-DQB1*06:02 Tg	2327	null	null
+10 to 16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2328	10 to 16 week	10 to 16 week
+17 to 78 years	9606	Homo sapiens (human)	2329	17 to 78 year	17 to 78 year
+8-12 weeks	10001275	Rattus norvegicus PVG-RT1u	2330	8-12 week	8-12 week
+NULL	10001359	Mus musculus A.TL	2331	null	null
+4 to 6 weeks	10000067	Mus musculus C57BL/6	2332	4 to 6 week	4 to 6 week
+7-70 years	9606	Homo sapiens (human)	2333	7-70 year	7-70 year
+12-48 weeks	10090	Mus musculus (mouse)	2334	12-48 week	12-48 week
+mean age 34.6 years	9606	Homo sapiens (human)	2335	mean age 34.6 year	mean age 34.6 year
+mean age 50.7 years	9606	Homo sapiens (human)	2336	mean age 50.7 year	mean age 50.7 year
+mean age 40 years	9606	Homo sapiens (human)	2337	mean age 40 year	mean age 40 year
+1.5-3 years	9615	Canis lupus familiaris (dogs)	2338	1.5-3 year	1.5-3 year
+8-12 weeks	10000233	Mus musculus CBA/Ca	2339	8-12 week	8-12 week
+8-16 weeks	10000227	Mus musculus OT-1 TCR Tg	2340	8-16 week	8-16 week
+4 months	10000635	Mus musculus NOD/Lt	2341	4 month	4 month
+NULL	10001770	Mus musculus RIP-OVA	2342	null	null
+23 to 81 years	9606	Homo sapiens (human)	2343	23 to 81 year	23 to 81 year
+38 to 71 years	9606	Homo sapiens (human)	2344	38 to 71 year	38 to 71 year
+8-12 weeks.	10001221	Mus musculus C57BL/6 x SJL	2345	8-12 week.	8-12 week.
+2-20 months	10000263	Mus musculus B10.BR	2346	2-20 month	2-20 month
+22 - 64 years	9606	Homo sapiens (human)	2347	22 - 64 year	22 - 64 year
+25-56 years	9606	Homo sapiens (human)	2348	25-56 year	25-56 year
+8 to 10 weeks	10000649	Mus musculus SJL	2349	8 to 10 week	8 to 10 week
+9-35 years	9606	Homo sapiens (human)	2350	9-35 year	9-35 year
+12-36 years	9606	Homo sapiens (human)	2351	12-36 year	12-36 year
+8 to 14 weeks	10000274	Mus musculus B10.PL	2352	8 to 14 week	8 to 14 week
+26-58 years	9606	Homo sapiens (human)	2353	26-58 year	26-58 year
+4 weeks	10000922	Sus scrofa German Landrace	2354	4 week	4 week
+8-12 weeks	10001346	Rattus norvegicus LEWIS.1AR2	2355	8-12 week	8-12 week
+NULL	10001397	Mus musculus MOG null	2356	null	null
+6-8 weeks	10001415	Mus musculus SM1 TCR Tg	2357	6-8 week	6-8 week
+28-61 years	9606	Homo sapiens (human)	2358	28-61 year	28-61 year
+12-29 years	9606	Homo sapiens (human)	2359	12-29 year	12-29 year
+8-20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2360	8-20 week	8-20 week
+8-12 weeks	10001338	Rattus norvegicus LEWIS.1L	2361	8-12 week	8-12 week
+8-12 weeks	10001340	Rattus norvegicus LEWIS.1C	2362	8-12 week	8-12 week
+8-12 weeks	10001343	Rattus norvegicus LEWIS.1WR1	2363	8-12 week	8-12 week
+8-12 weeks	10001341	Rattus norvegicus LEWIS.1D	2364	8-12 week	8-12 week
+8-12 weeks	10001342	Rattus norvegicus LEWIS.1F	2365	8-12 week	8-12 week
+8-12 weeks	10001344	Rattus norvegicus LEWIS.1WR2	2366	8-12 week	8-12 week
+8-12 weeks	10001345	Rattus norvegicus LEWIS.1AR1	2367	8-12 week	8-12 week
+2 to 3 months	10000662	Rattus norvegicus Lewis	2368	2 to 3 month	2 to 3 month
+NULL	10001394	Mus musculus POT TCR Tg	2369	null	null
+27-49 years	9606	Homo sapiens (human)	2370	27-49 year	27-49 year
+8 - 9 weeks old	10000000	Mus musculus BALB/c	2371	8 - 9 week old	8 - 9 week
+6 weeks	10001022	Mus musculus A.BY/SnJ	2372	6 week	6 week
+6-7 weeks	10001221	Mus musculus C57BL/6 x SJL	2373	6-7 week	6-7 week
+5 to 10 weeks	10000274	Mus musculus B10.PL	2374	5 to 10 week	5 to 10 week
+8-12 weeks	10000605	Mus musculus HLA-DR2 Tg	2375	8-12 week	8-12 week
+2-6 months	10000258	Mus musculus B10.A(2R)	2376	2-6 month	2-6 month
+12 to 14 weeks	10090	Mus musculus (mouse)	2377	12 to 14 week	12 to 14 week
+12 to 14 weeks	10000067	Mus musculus C57BL/6	2378	12 to 14 week	12 to 14 week
+12 to 14 weeks	10000610	Mus musculus HLA-DR4 Tg	2379	12 to 14 week	12 to 14 week
+NULL	10001349	Mus musculus SJL X SWR	2380	null	null
+8-16 weeks	10000038	Mus musculus C3H/He	2381	8-16 week	8-16 week
+32-63	9606	Homo sapiens (human)	2382	32-63	32-63
+33-45 years	9606	Homo sapiens (human)	2383	33-45 year	33-45 year
+26-44 years	9606	Homo sapiens (human)	2384	26-44 year	26-44 year
+8-10	10000067	Mus musculus C57BL/6	2385	8-10	8-10
+45	9606	Homo sapiens (human)	2386	45	45
+48-59 years old	9606	Homo sapiens (human)	2387	48-59 year old	48-59 year
+21 to 68 years	9606	Homo sapiens (human)	2388	21 to 68 year	21 to 68 year
+NULL	10001538	Mus musculus HLA Transgenic	2389	null	null
+5-8 weeks	10000063	Mus musculus B10.A	2390	5-8 week	5-8 week
+NULL	10001393	Mus musculus NOD B7-2 null	2391	null	null
+28-64 years	10000119	Homo sapiens Caucasian	2392	28-64 year	28-64 year
+2.5-6 months	10001291	Mus musculus CBA/Igb	2393	2.5-6 month	2.5-6 month
+10 to 14 weeks	10000649	Mus musculus SJL	2394	10 to 14 week	10 to 14 week
+5 weeks	10001324	Mus musculus shiverer (MBP null)	2395	5 week	5 week
+2-12 months	10000275	Mus musculus B10.RIII	2396	2-12 month	2-12 month
+8-10	10001221	Mus musculus C57BL/6 x SJL	2397	8-10	8-10
+5 to 8 weeks	10000025	Mus musculus Biozzi AB/H	2398	5 to 8 week	5 to 8 week
+6 to 8 weeks	10001133	Rattus norvegicus DA	2399	6 to 8 week	6 to 8 week
+8-14 weeks	10001347	Mus musculus 129/Sv	2400	8-14 week	8-14 week
+2-4 months	10000236	Mus musculus CBA/J	2401	2-4 month	2-4 month
+8-12 weeks	10000607	Mus musculus HLA-DR3 Tg	2402	8-12 week	8-12 week
+7 to 14 weeks	10000649	Mus musculus SJL	2403	7 to 14 week	7 to 14 week
+8-10 weeks	10001537	Mus musculus PL	2404	8-10 week	8-10 week
+10 to 12 weeks	10000667	Rattus norvegicus Sprague-Dawley	2405	10 to 12 week	10 to 12 week
+7 to 14 weeks	10000653	Mus musculus Swiss	2406	7 to 14 week	7 to 14 week
+2.5-6 months	10001362	Mus musculus B10.A(5R) X B10.D2	2407	2.5-6 month	2.5-6 month
+63-85 years	9606	Homo sapiens (human)	2408	63-85 year	63-85 year
+21-73 years	9606	Homo sapiens (human)	2409	21-73 year	21-73 year
+6-8 weeks	10001354	Mus musculus SJL X BALB/c	2410	6-8 week	6-8 week
+2-12 months	10000258	Mus musculus B10.A(2R)	2411	2-12 month	2-12 month
+5-8 weeks	10000228	Mus musculus CBA	2412	5-8 week	5-8 week
+28-36 years	9606	Homo sapiens (human)	2413	28-36 year	28-36 year
+33-39	9606	Homo sapiens (human)	2414	33-39	33-39
+6 weeks old	10000038	Mus musculus C3H/He	2415	6 week old	6 week
+37-45 years	9606	Homo sapiens (human)	2416	37-45 year	37-45 year
+NULL	10001353	Rattus norvegicus DA X LEW	2417	null	null
+2 to 3 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	2418	2 to 3 month	2 to 3 month
+8 to 13 weeks	10000067	Mus musculus C57BL/6	2419	8 to 13 week	8 to 13 week
+25-54 years	9606	Homo sapiens (human)	2420	25-54 year	25-54 year
+26-55	9606	Homo sapiens (human)	2421	26-55	26-55
+9-66 years	9606	Homo sapiens (human)	2422	9-66 year	9-66 year
+63-66 years	9606	Homo sapiens (human)	2423	63-66 year	63-66 year
+26-93 years	9606	Homo sapiens (human)	2424	26-93 year	26-93 year
+5-16 weeks	10001327	Mus musculus PL/J X SJL	2425	5-16 week	5-16 week
+5-16 weeks	10001537	Mus musculus PL	2426	5-16 week	5-16 week
+8-12 weeks	10000047	Mus musculus C57BL/10	2427	8-12 week	8-12 week
+34-72 years	9606	Homo sapiens (human)	2428	34-72 year	34-72 year
+19-31 years	9606	Homo sapiens (human)	2429	19-31 year	19-31 year
+5 to 12 week	10001375	Mus musculus NOD X NOR	2430	5 to 12 week	5 to 12 week
+5 to 12 week	10001244	Mus musculus NOR	2431	5 to 12 week	5 to 12 week
+5 to 12 week	10000632	Mus musculus NOD	2432	5 to 12 week	5 to 12 week
+6 to 8 weeks	10001363	Mus musculus 2D2 TCR Tg	2433	6 to 8 week	6 to 8 week
+5-16 weeks	10000649	Mus musculus SJL	2434	5-16 week	5-16 week
+7-12 weeks	10001349	Mus musculus SJL X SWR	2435	7-12 week	7-12 week
+12-16 weeks	10001387	Mus musculus 1.4HBV-Smut Tg	2436	12-16 week	12-16 week
+8-12 weeks	10001019	Mus musculus B10.D2	2437	8-12 week	8-12 week
+8-12 weeks	10000064	Mus musculus C57BL/10.Q	2438	8-12 week	8-12 week
+29-42 years	9606	Homo sapiens (human)	2439	29-42 year	29-42 year
+10 to 14 weeks	10000653	Mus musculus Swiss	2440	10 to 14 week	10 to 14 week
+NULL	10036	Mesocricetus auratus (Syrian golden hamster)	2441	null	null
+8 to 20 weeks	10001331	Mus musculus SJL X B10.PL	2442	8 to 20 week	8 to 20 week
+NULL	10001366	Mus musculus Foxp3gfp.KI	2443	null	null
+29 to 61 years	9606	Homo sapiens (human)	2444	29 to 61 year	29 to 61 year
+5 to 8 weeks	10000024	Mus musculus Biozzi	2445	5 to 8 week	5 to 8 week
+42 to 100 days	10001410	Mus musculus 5B6 TCR Tg	2446	42 to 100 days	42 to 100 days
+42 to 116 days	10001410	Mus musculus 5B6 TCR Tg	2447	42 to 116 days	42 to 116 days
+30 to 40 days	10001410	Mus musculus 5B6 TCR Tg	2448	30 to 40 days	30 to 40 days
+6-10 weeks	10001324	Mus musculus shiverer (MBP null)	2449	6-10 week	6-10 week
+24-40 years	9606	Homo sapiens (human)	2450	24-40 year	24-40 year
+22 to 59 years	9606	Homo sapiens (human)	2451	22 to 59 year	22 to 59 year
+24 to 48 years	9606	Homo sapiens (human)	2452	24 to 48 year	24 to 48 year
+70 years	9606	Homo sapiens (human)	2453	70 year	70 year
+8-12 weeks	10001327	Mus musculus PL/J X SJL	2454	8-12 week	8-12 week
+6-12 weeks	10000605	Mus musculus HLA-DR2 Tg	2455	6-12 week	6-12 week
+26 to 64 years	9606	Homo sapiens (human)	2456	26 to 64 year	26 to 64 year
+7-12 weeks	10000649	Mus musculus SJL	2457	7-12 week	7-12 week
+6 to 12 weeks	10001410	Mus musculus 5B6 TCR Tg	2458	6 to 12 week	6 to 12 week
+Neonates	10001537	Mus musculus PL	2459	neonates	neonates
+6 to 9 weeks	10000662	Rattus norvegicus Lewis	2460	6 to 9 week	6 to 9 week
+24-38 years	9606	Homo sapiens (human)	2461	24-38 year	24-38 year
+37-78 years	9606	Homo sapiens (human)	2462	37-78 year	37-78 year
+2 to 76 years	9606	Homo sapiens (human)	2463	2 to 76 year	2 to 76 year
+6 to 83 years	9606	Homo sapiens (human)	2464	6 to 83 year	6 to 83 year
+24 to 68 years	9606	Homo sapiens (human)	2465	24 to 68 year	24 to 68 year
+NULL	10001352	Mus musculus III	2466	null	null
+24 hours	10000274	Mus musculus B10.PL	2467	24 hour	24 hour
+adult (>18 years)	9606	Homo sapiens (human)	2468	adult (>18 years)	adult (>18 years)
+60-72 years	9606	Homo sapiens (human)	2469	60-72 year	60-72 year
+39-43 years	9606	Homo sapiens (human)	2470	39-43 year	39-43 year
+19-72 years	9606	Homo sapiens (human)	2471	19-72 year	19-72 year
+18-75 years (mean 39.1)	9606	Homo sapiens (human)	2472	18-75 year (mean 39.1)	18-75 year (mean 39.1)
+18-75 years (mean 46)	9606	Homo sapiens (human)	2473	18-75 year (mean 46)	18-75 year (mean 46)
+6 weeks old	10000054	Mus musculus DBA/1	2474	6 week old	6 week
+6 weeks old	10000067	Mus musculus C57BL/6	2475	6 week old	6 week
+23-37 years	9606	Homo sapiens (human)	2476	23-37 year	23-37 year
+5-8 weeks	10000025	Mus musculus Biozzi AB/H	2477	5-8 week	5-8 week
+7-8 weeks	10000662	Rattus norvegicus Lewis	2478	7-8 week	7-8 week
+8 -11 weeks old	10000067	Mus musculus C57BL/6	2479	8 -11 week old	8 -11 week
+8 -11 weeks old	10000000	Mus musculus BALB/c	2480	8 -11 week old	8 -11 week
+mean age 22.8 years	9606	Homo sapiens (human)	2481	mean age 22.8 year	mean age 22.8 year
+15 to 61 years	9606	Homo sapiens (human)	2482	15 to 61 year	15 to 61 year
+15 to 70 years	9606	Homo sapiens (human)	2483	15 to 70 year	15 to 70 year
+6-8 weeks	10000287	Mus musculus P14 TCR Tg	2484	6-8 week	6-8 week
+4 to 8 weeks	10001327	Mus musculus PL/J X SJL	2485	4 to 8 week	4 to 8 week
+at least 8 weeks	10000067	Mus musculus C57BL/6	2486	at least 8 week	at least 8 week
+39-48 years	9606	Homo sapiens (human)	2487	39-48 year	39-48 year
+20 to 48 years	9606	Homo sapiens (human)	2488	20 to 48 year	20 to 48 year
+19 to 57 years	9606	Homo sapiens (human)	2489	19 to 57 year	19 to 57 year
+36-57 years	9606	Homo sapiens (human)	2490	36-57 year	36-57 year
+25-47 years	9606	Homo sapiens (human)	2491	25-47 year	25-47 year
+39 years	9606	Homo sapiens (human)	2492	39 year	39 year
+neonatal	10000662	Rattus norvegicus Lewis	2493	neonatal	neonatal
+39-43	9606	Homo sapiens (human)	2494	39-43	39-43
+5-20 weeks	10000649	Mus musculus SJL	2495	5-20 week	5-20 week
+7 weeks	10001405	Mus musculus NZB X NZW	2496	7 week	7 week
+27 weeks	10001405	Mus musculus NZB X NZW	2497	27 week	27 week
+NULL	10001409	Mus musculus B6 Qa-1b null	2498	null	null
+8-10 weeks	10000063	Mus musculus B10.A	2499	8-10 week	8-10 week
+6-10 weeks	10001405	Mus musculus NZB X NZW	2500	6-10 week	6-10 week
+6-7 weeks	10000055	Mus musculus DBA/2	2501	6-7 week	6-7 week
+6-7 weeks	10000289	Mus musculus BALB.B	2502	6-7 week	6-7 week
+19-51 years	9606	Homo sapiens (human)	2503	19-51 year	19-51 year
+21 years	9606	Homo sapiens (human)	2504	21 year	21 year
+Adults	10141	Cavia porcellus (guinea pig)	2505	adults	adults
+4 weeks	10000228	Mus musculus CBA	2506	4 week	4 week
+3 to 4 weeks	10000649	Mus musculus SJL	2507	3 to 4 week	3 to 4 week
+14.1 years	9606	Homo sapiens (human)	2508	14.1 year	14.1 year
+4 weeks	10001407	Mus musculus SNF1	2509	4 week	4 week
+5.4-16.4 years	9606	Homo sapiens (human)	2510	5.4-16.4 year	5.4-16.4 year
+8-10 weeks	10001405	Mus musculus NZB X NZW	2511	8-10 week	8-10 week
+4-10 weeks	10001326	Mus musculus Tg4 TCR Tg	2512	4-10 week	4-10 week
+6 months	10001407	Mus musculus SNF1	2513	6 month	6 month
+8.4-16.4 years	9606	Homo sapiens (human)	2514	8.4-16.4 year	8.4-16.4 year
+Young adult	10000601	Mus musculus HLA-DR1 Tg	2515	young adult	young adult
+25 years	9606	Homo sapiens (human)	2516	25 year	25 year
+10 to 14 weeks	10000662	Rattus norvegicus Lewis	2517	10 to 14 week	10 to 14 week
+76 years	9606	Homo sapiens (human)	2518	76 year	76 year
+8 to 14 weeks	10000649	Mus musculus SJL	2519	8 to 14 week	8 to 14 week
+3 months	10001405	Mus musculus NZB X NZW	2520	3 month	3 month
+> 8 weeks	10000028	Mus musculus C3H	2521	> 8 week	> 8 week
+29-53 years	9606	Homo sapiens (human)	2522	29-53 year	29-53 year
+> 8 weeks	10001165	Mus musculus C57BR/cdJ	2523	> 8 week	> 8 week
+5-7 weeks	10000023	Mus musculus BDF1	2524	5-7 week	5-7 week
+14-80 years	9606	Homo sapiens (human)	2525	14-80 year	14-80 year
+5-7 weeks	10000236	Mus musculus CBA/J	2526	5-7 week	5-7 week
+2 months	10001406	Mus musculus MLR/lpr	2527	2 month	2 month
+28.8-41.9 years	9606	Homo sapiens (human)	2528	28.8-41.9 year	28.8-41.9 year
+32.8-35.6 years	10000119	Homo sapiens Caucasian	2529	32.8-35.6 year	32.8-35.6 year
+5-20 weeks	10001327	Mus musculus PL/J X SJL	2530	5-20 week	5-20 week
+2-3 months	10000033	Mus musculus C3H.SW	2531	2-3 month	2-3 month
+5-20 weeks	10001537	Mus musculus PL	2532	5-20 week	5-20 week
+29-63	9606	Homo sapiens (human)	2533	29-63	29-63
+7 weeks	10001406	Mus musculus MLR/lpr	2534	7 week	7 week
+4-5 weeks	10001332	Rattus norvegicus LEW.1AV1	2535	4-5 week	4-5 week
+8-10 weeks	10001411	Rattus norvegicus Buffalo	2536	8-10 week	8-10 week
+8-10 weeks	10001412	Rattus norvegicus Wistar-Furth	2537	8-10 week	8-10 week
+5 to 6 weeks	10000228	Mus musculus CBA	2538	5 to 6 week	5 to 6 week
+22 to 51 years	10000119	Homo sapiens Caucasian	2539	22 to 51 year	22 to 51 year
+3-17 years	9606	Homo sapiens (human)	2540	3-17 year	3-17 year
+4 weeks	10001406	Mus musculus MLR/lpr	2541	4 week	4 week
+6 to 60 years	10000119	Homo sapiens Caucasian	2542	6 to 60 year	6 to 60 year
+5.4 years	9606	Homo sapiens (human)	2543	5.4 year	5.4 year
+8 to 12 weeks	10000038	Mus musculus C3H/He	2544	8 to 12 week	8 to 12 week
+8 to 10 weeks	10001405	Mus musculus NZB X NZW	2545	8 to 10 week	8 to 10 week
+14 weeks	10001405	Mus musculus NZB X NZW	2546	14 week	14 week
+6-8 weeks	10001251	Mus musculus RIP-B7	2547	6-8 week	6-8 week
+Fetal	10000649	Mus musculus SJL	2548	fetal	fetal
+10 weeks	10000253	Mus musculus A/J	2549	10 week	10 week
+18-45	9606	Homo sapiens (human)	2550	18-45	18-45
+19-61	9606	Homo sapiens (human)	2551	19-61	19-61
+6-7 weeks	10000236	Mus musculus CBA/J	2552	6-7 week	6-7 week
+4 weeks	10000263	Mus musculus B10.BR	2553	4 week	4 week
+6 to 8 weeks	10000253	Mus musculus A/J	2554	6 to 8 week	6 to 8 week
+6 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2555	6 to 10 week	6 to 10 week
+8 to 12 weeks	10000067	Mus musculus C57BL/6	2556	8 to 12 week	8 to 12 week
+69-83 years	9606	Homo sapiens (human)	2557	69-83 year	69-83 year
+2 months	10000028	Mus musculus C3H	2558	2 month	2 month
+65-85 years	9606	Homo sapiens (human)	2559	65-85 year	65-85 year
+58-85 years	9606	Homo sapiens (human)	2560	58-85 year	58-85 year
+< 42 days	10001410	Mus musculus 5B6 TCR Tg	2561	< 42 days	< 42 days
+27 days	10001410	Mus musculus 5B6 TCR Tg	2562	27 days	27 days
+7-8 weeks	10001244	Mus musculus NOR	2563	7-8 week	7-8 week
+5.4-12 years	9606	Homo sapiens (human)	2564	5.4-12 year	5.4-12 year
+2 months	10000038	Mus musculus C3H/He	2565	2 month	2 month
+24-67	9606	Homo sapiens (human)	2566	24-67	24-67
+5 weeks	10001406	Mus musculus MLR/lpr	2567	5 week	5 week
+8-10 weeks	10001407	Mus musculus SNF1	2568	8-10 week	8-10 week
+NULL	10000016	Mus musculus BALB/c X C57BL/10	2569	null	null
+8.4-12 years	9606	Homo sapiens (human)	2570	8.4-12 year	8.4-12 year
+NULL	10001407	Mus musculus SNF1	2571	null	null
+2-4 months	10000662	Rattus norvegicus Lewis	2572	2-4 month	2-4 month
+15-81 years	9606	Homo sapiens (human)	2573	15-81 year	15-81 year
+25-62 years	9606	Homo sapiens (human)	2574	25-62 year	25-62 year
+28-36 years	10000119	Homo sapiens Caucasian	2575	28-36 year	28-36 year
+18-36 months	10000194	Bos taurus Holstein-Friesian	2576	18-36 month	18-36 month
+26-50 years	9606	Homo sapiens (human)	2577	26-50 year	26-50 year
+3 months	10000625	Mus musculus MRL	2578	3 month	3 month
+3 months	10000236	Mus musculus CBA/J	2579	3 month	3 month
+25 to 55 years	9606	Homo sapiens (human)	2580	25 to 55 year	25 to 55 year
+34 to 67 years	9606	Homo sapiens (human)	2581	34 to 67 year	34 to 67 year
+8-10 weeks	10001208	Mus musculus B6.C-H-2bm1	2582	8-10 week	8-10 week
+10 weeks	10001405	Mus musculus NZB X NZW	2583	10 week	10 week
+6-12 weeks	10000653	Mus musculus Swiss	2584	6-12 week	6-12 week
+4-7 weeks	10000649	Mus musculus SJL	2585	4-7 week	4-7 week
+30 or 35 years	9606	Homo sapiens (human)	2586	30 or 35 year	30 or 35 year
+12-14 weeks	10001405	Mus musculus NZB X NZW	2587	12-14 week	12-14 week
+NULL	10001420	Mus musculus BXSB	2588	null	null
+8 to 10 weeks	10000274	Mus musculus B10.PL	2589	8 to 10 week	8 to 10 week
+8-10 weeks	10000658	Rattus norvegicus Brown Norway	2590	8-10 week	8-10 week
+8-10 weeks	10001413	Rattus norvegicus ACI	2591	8-10 week	8-10 week
+21 to 67 years	9606	Homo sapiens (human)	2592	21 to 67 year	21 to 67 year
+4.1-16.3 years	9606	Homo sapiens (human)	2593	4.1-16.3 year	4.1-16.3 year
+30-34 years	9606	Homo sapiens (human)	2594	30-34 year	30-34 year
+16-52 years	9606	Homo sapiens (human)	2595	16-52 year	16-52 year
+less than 24 hours	10000282	Mus musculus B6(C)-H2-Ab1bm12	2596	less than 24 hour	less than 24 hour
+NULL	10000282	Mus musculus B6(C)-H2-Ab1bm12	2597	null	null
+6 to 7 weeks	10000662	Rattus norvegicus Lewis	2598	6 to 7 week	6 to 7 week
+6 to 7 weeks	10000658	Rattus norvegicus Brown Norway	2599	6 to 7 week	6 to 7 week
+6 to 7 weeks	10001412	Rattus norvegicus Wistar-Furth	2600	6 to 7 week	6 to 7 week
+6 to 8 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2601	6 to 8 week	6 to 8 week
+8-10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2602	8-10 week	8-10 week
+NULL	10001095	Mus musculus C57BL/6 IL-4 null	2603	null	null
+6 to 7 weeks	10001411	Rattus norvegicus Buffalo	2604	6 to 7 week	6 to 7 week
+33-87	9606	Homo sapiens (human)	2605	33-87	33-87
+NULL	10001378	Mus musculus HLA-DRB5*01:01 Tg	2606	null	null
+4 weeks	10001440	Mus musculus B16:A dKO NOD	2607	4 week	4 week
+24 hours	10000662	Rattus norvegicus Lewis	2608	24 hour	24 hour
+38-71 years	9606	Homo sapiens (human)	2609	38-71 year	38-71 year
+6-14 weeks	10000274	Mus musculus B10.PL	2610	6-14 week	6-14 week
+5 to 6 weeks	10000000	Mus musculus BALB/c	2611	5 to 6 week	5 to 6 week
+25 to 76 years	9606	Homo sapiens (human)	2612	25 to 76 year	25 to 76 year
+2-3 months	10000658	Rattus norvegicus Brown Norway	2613	2-3 month	2-3 month
+8 to 12 weeks	10001133	Rattus norvegicus DA	2614	8 to 12 week	8 to 12 week
+23-67	9606	Homo sapiens (human)	2615	23-67	23-67
+34-55 years	9606	Homo sapiens (human)	2616	34-55 year	34-55 year
+2-12 months	10001357	Mus musculus D2.GD	2617	2-12 month	2-12 month
+8-20 weeks	10001019	Mus musculus B10.D2	2618	8-20 week	8-20 week
+21 to 56 years	9606	Homo sapiens (human)	2619	21 to 56 year	21 to 56 year
+6-15	9606	Homo sapiens (human)	2620	6-15	6-15
+26 to 50 years	9606	Homo sapiens (human)	2621	26 to 50 year	26 to 50 year
+18-22 months or 4-6 months	10000067	Mus musculus C57BL/6	2622	18-22 month or 4-6 month	18-22 month or 4-6 month
+4 weeks	10000653	Mus musculus Swiss	2623	4 week	4 week
+29-48 years	9606	Homo sapiens (human)	2624	29-48 year	29-48 year
+8 days or 4-6 months	10000067	Mus musculus C57BL/6	2625	8 days or 4-6 month	8 days or 4-6 month
+36-70 years	9606	Homo sapiens (human)	2626	36-70 year	36-70 year
+24-43 years	9606	Homo sapiens (human)	2627	24-43 year	24-43 year
+10-14 weeks	10001405	Mus musculus NZB X NZW	2628	10-14 week	10-14 week
+52-91 years	9606	Homo sapiens (human)	2629	52-91 year	52-91 year
+NULL	10001419	Mus musculus B6.11 TCR Tg	2630	null	null
+2-20 months	10000067	Mus musculus C57BL/6	2631	2-20 month	2-20 month
+20-58	9606	Homo sapiens (human)	2632	20-58	20-58
+20 to 43 years	9606	Homo sapiens (human)	2633	20 to 43 year	20 to 43 year
+10 to 14 weeks	10001337	Rattus norvegicus LEWIS.1W	2634	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001333	Rattus norvegicus LEW.1N	2635	10 to 14 week	10 to 14 week
+23-78 years	9606	Homo sapiens (human)	2636	23-78 year	23-78 year
+10 to 14 weeks	10001332	Rattus norvegicus LEW.1AV1	2637	10 to 14 week	10 to 14 week
+7-8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2638	7-8 week	7-8 week
+6 to 10 weeks	10000038	Mus musculus C3H/He	2639	6 to 10 week	6 to 10 week
+6-8 weeks	10000597	Mus musculus HLA-DQ6 Tg	2640	6-8 week	6-8 week
+3-4 months	10001240	Mus musculus APPsw	2641	3-4 month	3-4 month
+3-4 months	10000067	Mus musculus C57BL/6	2642	3-4 month	3-4 month
+6 to 12 weeks	10001354	Mus musculus SJL X BALB/c	2643	6 to 12 week	6 to 12 week
+72 years	9606	Homo sapiens (human)	2644	72 year	72 year
+23-87 years	9606	Homo sapiens (human)	2645	23-87 year	23-87 year
+18 weeks	10001407	Mus musculus SNF1	2646	18 week	18 week
+23 to 77 years	9606	Homo sapiens (human)	2647	23 to 77 year	23 to 77 year
+6 to 8 weeks	10001782	Mus musculus HLA-B*07:02 Tg	2648	6 to 8 week	6 to 8 week
+6-8 weeks	10000607	Mus musculus HLA-DR3 Tg	2649	6-8 week	6-8 week
+6-8 weeks	10000598	Mus musculus HLA-DQ8 Tg	2650	6-8 week	6-8 week
+43 to 67 years	9606	Homo sapiens (human)	2651	43 to 67 year	43 to 67 year
+8-9 weeks	10000067	Mus musculus C57BL/6	2652	8-9 week	8-9 week
+2-4 months	10001019	Mus musculus B10.D2	2653	2-4 month	2-4 month
+15 years	9606	Homo sapiens (human)	2654	15 year	15 year
+2-4 months	10000053	Mus musculus DBA	2655	2-4 month	2-4 month
+26-39	9606	Homo sapiens (human)	2656	26-39	26-39
+12 weeks old	10000000	Mus musculus BALB/c	2657	12 week old	12 week
+24-60 years	9606	Homo sapiens (human)	2658	24-60 year	24-60 year
+7 to 10 weeks	10000000	Mus musculus BALB/c	2659	7 to 10 week	7 to 10 week
+6-16 weeks	10000253	Mus musculus A/J	2660	6-16 week	6-16 week
+3-17.7 years	9606	Homo sapiens (human)	2661	3-17.7 year	3-17.7 year
+5-31 years	9606	Homo sapiens (human)	2662	5-31 year	5-31 year
+6-16 weeks	10000252	Mus musculus A.SW	2663	6-16 week	6-16 week
+8 to 10 weels	10000662	Rattus norvegicus Lewis	2664	8 to 10 week	8 to 10 week
+Mean age 10.6 years	9606	Homo sapiens (human)	2665	mean age 10.6 year	mean age 10.6 year
+6 to 10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2666	6 to 10 week	6 to 10 week
+6-16 weeks	10000038	Mus musculus C3H/He	2667	6-16 week	6-16 week
+6-16 weeks	10000055	Mus musculus DBA/2	2668	6-16 week	6-16 week
+2-20 months	10000000	Mus musculus BALB/c	2669	2-20 month	2-20 month
+25-45	9606	Homo sapiens (human)	2670	25-45	25-45
+6-8 weeks	10001426	Mus musculus B6 X bm12	2671	6-8 week	6-8 week
+10 to 14 weeks	10001343	Rattus norvegicus LEWIS.1WR1	2672	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001345	Rattus norvegicus LEWIS.1AR1	2673	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001339	Rattus norvegicus LEWIS.1A	2674	10 to 14 week	10 to 14 week
+22 to 85 years	9606	Homo sapiens (human)	2675	22 to 85 year	22 to 85 year
+10 to 14 weeks	10001346	Rattus norvegicus LEWIS.1AR2	2676	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001344	Rattus norvegicus LEWIS.1WR2	2677	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001133	Rattus norvegicus DA	2678	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001275	Rattus norvegicus PVG-RT1u	2679	10 to 14 week	10 to 14 week
+10 to 14 weeks	10001413	Rattus norvegicus ACI	2680	10 to 14 week	10 to 14 week
+10 to 12 weeks	10000662	Rattus norvegicus Lewis	2681	10 to 12 week	10 to 12 week
+NULL	10002211	Mus musculus MBP121-150 TCR Tg	2682	null	null
+6-8 weeks	10000275	Mus musculus B10.RIII	2683	6-8 week	6-8 week
+3 months	10001041	Rattus norvegicus Wistar	2684	3 month	3 month
+13 to 67 months	9606	Homo sapiens (human)	2685	13 to 67 month	13 to 67 month
+4-6 weeks	10000662	Rattus norvegicus Lewis	2686	4-6 week	4-6 week
+mean age 39 years	9606	Homo sapiens (human)	2687	mean age 39 year	mean age 39 year
+8-10 weeks	10001434	Rattus norvegicus LEWIS X Wistar-Furth	2688	8-10 week	8-10 week
+8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2689	8 week	8 week
+5-10 weeks	10000067	Mus musculus C57BL/6	2690	5-10 week	5-10 week
+18-84 years	9606	Homo sapiens (human)	2691	18-84 year	18-84 year
+26-68 years	9606	Homo sapiens (human)	2692	26-68 year	26-68 year
+8-12 weeks	10000658	Rattus norvegicus Brown Norway	2693	8-12 week	8-12 week
+27-40 years	9606	Homo sapiens (human)	2694	27-40 year	27-40 year
+6-15 years	9606	Homo sapiens (human)	2695	6-15 year	6-15 year
+18 to 49 years	9606	Homo sapiens (human)	2696	18 to 49 year	18 to 49 year
+7-10 weeks	10000000	Mus musculus BALB/c	2697	7-10 week	7-10 week
+10-14 weeks	10000662	Rattus norvegicus Lewis	2698	10-14 week	10-14 week
+7-8 weeks	10000225	Mus musculus C57BL/6N	2699	7-8 week	7-8 week
+33-73 years	9606	Homo sapiens (human)	2700	33-73 year	33-73 year
+6 to 8 weeks	10000275	Mus musculus B10.RIII	2701	6 to 8 week	6 to 8 week
+less than 24 hours	10000067	Mus musculus C57BL/6	2702	less than 24 hour	less than 24 hour
+19-33 years	9606	Homo sapiens (human)	2703	19-33 year	19-33 year
+6-8 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2704	6-8 week	6-8 week
+9-10 weeks	10000067	Mus musculus C57BL/6	2705	9-10 week	9-10 week
+NULL	10001369	Mus musculus C57L	2706	null	null
+25-33 years	9606	Homo sapiens (human)	2707	25-33 year	25-33 year
+6-16 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2708	6-16 week	6-16 week
+28-44 years	9606	Homo sapiens (human)	2709	28-44 year	28-44 year
+6 to 10 weeks	10000255	Mus musculus AKR	2710	6 to 10 week	6 to 10 week
+7-64 years	9606	Homo sapiens (human)	2711	7-64 year	7-64 year
+28-52 years	9606	Homo sapiens (human)	2712	28-52 year	28-52 year
+8 to 10 weeks	10000282	Mus musculus B6(C)-H2-Ab1bm12	2713	8 to 10 week	8 to 10 week
+10 weeks	10000662	Rattus norvegicus Lewis	2714	10 week	10 week
+8-10	10000662	Rattus norvegicus Lewis	2715	8-10	8-10
+under 16 weeks	10000067	Mus musculus C57BL/6	2716	under 16 week	under 16 week
+10 to 14 weeks	10000067	Mus musculus C57BL/6	2717	10 to 14 week	10 to 14 week
+20 to 40 years	9606	Homo sapiens (human)	2718	20 to 40 year	20 to 40 year
+33 to 73 years	9606	Homo sapiens (human)	2719	33 to 73 year	33 to 73 year
+6-7 weeks	10000228	Mus musculus CBA	2720	6-7 week	6-7 week
+6-16 weeks	10001347	Mus musculus 129/Sv	2721	6-16 week	6-16 week
+10 to 14 weeks	10000275	Mus musculus B10.RIII	2722	10 to 14 week	10 to 14 week
+14 days	10001436	Gallus gallus P2a	2723	14 days	14 days
+15 years old	9606	Homo sapiens (human)	2724	15 year old	15 year
+3-6 weeks	10090	Mus musculus (mouse)	2725	3-6 week	3-6 week
+16-39 years	9606	Homo sapiens (human)	2726	16-39 year	16-39 year
+66 years	9606	Homo sapiens (human)	2727	66 year	66 year
+3 months	10000638	Mus musculus Nude	2728	3 month	3 month
+4 weeks	10000638	Mus musculus Nude	2729	4 week	4 week
+6 to 12 weeks	10000275	Mus musculus B10.RIII	2730	6 to 12 week	6 to 12 week
+NULL	10001452	Mus musculus C57/BL6J IRBP null	2731	null	null
+27 to 53 years	9606	Homo sapiens (human)	2732	27 to 53 year	27 to 53 year
+34 to 50 years	9606	Homo sapiens (human)	2733	34 to 50 year	34 to 50 year
+4 months	10001407	Mus musculus SNF1	2734	4 month	4 month
+17 to 47 years	9606	Homo sapiens (human)	2735	17 to 47 year	17 to 47 year
+Average age = 60.5 years	9606	Homo sapiens (human)	2736	average age = 60.5 year	average age = 60.5 year
+6 to 7 weeks	10000607	Mus musculus HLA-DR3 Tg	2737	6 to 7 week	6 to 7 week
+24 to 51 years	9606	Homo sapiens (human)	2738	24 to 51 year	24 to 51 year
+6-9 weeks	10001211	Mus musculus (C57BL/6 X A/J)	2739	6-9 week	6-9 week
+6 to 12 weeks	10001445	Mus musculus FVB/B X B10.RIII	2740	6 to 12 week	6 to 12 week
+5 to 8 weeks	10000263	Mus musculus B10.BR	2741	5 to 8 week	5 to 8 week
+6-8 weeks	10001349	Mus musculus SJL X SWR	2742	6-8 week	6-8 week
+6 to 7 weeks	10000000	Mus musculus BALB/c	2743	6 to 7 week	6 to 7 week
+Average age = 36.9 years	9606	Homo sapiens (human)	2744	average age = 36.9 year	average age = 36.9 year
+38 to 75 years	9606	Homo sapiens (human)	2745	38 to 75 year	38 to 75 year
+34-64 years	9606	Homo sapiens (human)	2746	34-64 year	34-64 year
+5-7 weeks	10000662	Rattus norvegicus Lewis	2747	5-7 week	5-7 week
+NULL	10001454	Mus musculus C57BL/10 X A.BY	2748	null	null
+38-67 years	9606	Homo sapiens (human)	2749	38-67 year	38-67 year
+22 to 41 years	9606	Homo sapiens (human)	2750	22 to 41 year	22 to 41 year
+21 to 33 years	9606	Homo sapiens (human)	2751	21 to 33 year	21 to 33 year
+18 to 45 years	9606	Homo sapiens (human)	2752	18 to 45 year	18 to 45 year
+NULL	9540	Macaca arctoides (bear macaque)	2753	null	null
+7-8 weeks	10001412	Rattus norvegicus Wistar-Furth	2754	7-8 week	7-8 week
+7-8 weeks	10000661	Rattus norvegicus Fischer 344	2755	7-8 week	7-8 week
+7-8 weeks	10001446	Rattus norvegicus Wistar Kyoto	2756	7-8 week	7-8 week
+8-10 weeks	10000236	Mus musculus CBA/J	2757	8-10 week	8-10 week
+31 to 47 years	9606	Homo sapiens (human)	2758	31 to 47 year	31 to 47 year
+6-15 weeks	10001437	Mus musculus Tapasin null	2759	6-15 week	6-15 week
+15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2760	15 week	15 week
+6 to 8 weeks	10001211	Mus musculus (C57BL/6 X A/J)	2761	6 to 8 week	6 to 8 week
+12 to 14 weeks	10000275	Mus musculus B10.RIII	2762	12 to 14 week	12 to 14 week
+8 weeks	10000054	Mus musculus DBA/1	2763	8 week	8 week
+7-10 weeks	10000662	Rattus norvegicus Lewis	2764	7-10 week	7-10 week
+14 weeks	10000662	Rattus norvegicus Lewis	2765	14 week	14 week
+8 to 12 weeks	10000007	Mus musculus 6.5 TCR Tg	2766	8 to 12 week	8 to 12 week
+12 to 26 weeks	10000276	Mus musculus B10.S	2767	12 to 26 week	12 to 26 week
+6-8 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	2768	6-8 week	6-8 week
+6-8 weeks	10001321	Rattus norvegicus DR-BB/Wor	2769	6-8 week	6-8 week
+Adults	10000662	Rattus norvegicus Lewis	2770	adults	adults
+8 to 10 weeks	10001438	Mus musculus BALB/cAnN	2771	8 to 10 week	8 to 10 week
+26-46 years	9606	Homo sapiens (human)	2772	26-46 year	26-46 year
+6 to 8 weeks	10000263	Mus musculus B10.BR	2773	6 to 8 week	6 to 8 week
+NULL	10001453	Mus musculus B10.RIII IRBP null	2774	null	null
+31-64 years	9606	Homo sapiens (human)	2775	31-64 year	31-64 year
+2 to 62	9606	Homo sapiens (human)	2776	2 to 62	2 to 62
+6-8 weeks	10001331	Mus musculus SJL X B10.PL	2777	6-8 week	6-8 week
+4 to 8 months	10001221	Mus musculus C57BL/6 x SJL	2778	4 to 8 month	4 to 8 month
+6 to 7 days or 8 to 12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2779	6 to 7 days or 8 to 12 week	6 to 7 days or 8 to 12 week
+mean age 30 +/- 7 years	9606	Homo sapiens (human)	2780	mean age 30 ± 7 year	mean age 30 ± 7 year
+56.6 ± 19.3 years	9606	Homo sapiens (human)	2781	56.6  19.3 year	56.6  19.3 year
+42.7 years	9606	Homo sapiens (human)	2782	42.7 year	42.7 year
+24 to 79 years	9606	Homo sapiens (human)	2783	24 to 79 year	24 to 79 year
+NULL	10002209	Mus musculus qCII24 TCR Tg	2784	null	null
+22-38 years	9606	Homo sapiens (human)	2785	22-38 year	22-38 year
+19-38 years	9606	Homo sapiens (human)	2786	19-38 year	19-38 year
+28.7 years	9606	Homo sapiens (human)	2787	28.7 year	28.7 year
+5 tp 7 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	2788	5 tp 7 week	5 tp 7 week
+average age = 54.7 years	9606	Homo sapiens (human)	2789	average age = 54.7 year	average age = 54.7 year
+9 to 71 years	9606	Homo sapiens (human)	2790	9 to 71 year	9 to 71 year
+22-83 years	9606	Homo sapiens (human)	2791	22-83 year	22-83 year
+8-10 weeks	10001350	Mus musculus B7-2 null	2792	8-10 week	8-10 week
+16-36 years	9606	Homo sapiens (human)	2793	16-36 year	16-36 year
+8 weeks	10000625	Mus musculus MRL	2794	8 week	8 week
+28-29 years	9606	Homo sapiens (human)	2795	28-29 year	28-29 year
+6 to 12 weeks	10001444	Mus musculus IRBP Tg	2796	6 to 12 week	6 to 12 week
+5-6 weeks	10000625	Mus musculus MRL	2797	5-6 week	5-6 week
+8-10 weeks	10000597	Mus musculus HLA-DQ6 Tg	2798	8-10 week	8-10 week
+8-10 weeks	10000598	Mus musculus HLA-DQ8 Tg	2799	8-10 week	8-10 week
+6.5 months	10001405	Mus musculus NZB X NZW	2800	6.5 month	6.5 month
+16-80 years	9606	Homo sapiens (human)	2801	16-80 year	16-80 year
+6-12 weeks	10001103	Mus musculus SV40 Tg	2802	6-12 week	6-12 week
+8 to 12 weeks	10000028	Mus musculus C3H	2803	8 to 12 week	8 to 12 week
+21-24 years	9606	Homo sapiens (human)	2804	21-24 year	21-24 year
+29-79 years	9606	Homo sapiens (human)	2805	29-79 year	29-79 year
+11-24 years	9606	Homo sapiens (human)	2806	11-24 year	11-24 year
+2-3 months	10000038	Mus musculus C3H/He	2807	2-3 month	2-3 month
+6 to 7 weeks	10001257	Mus musculus NOD.H-2h4	2808	6 to 7 week	6 to 7 week
+10 to 13 weeks	10000054	Mus musculus DBA/1	2809	10 to 13 week	10 to 13 week
+NULL	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	2810	null	null
+28-38 years	9606	Homo sapiens (human)	2811	28-38 year	28-38 year
+25-42 years	9606	Homo sapiens (human)	2812	25-42 year	25-42 year
+28 to 87 years	9606	Homo sapiens (human)	2813	28 to 87 year	28 to 87 year
+NULL	10001090	Mus musculus YA26 TCR Tg	2814	null	null
+31 to 62 years	9606	Homo sapiens (human)	2815	31 to 62 year	31 to 62 year
+Average age = 59.4	9606	Homo sapiens (human)	2816	average age = 59.4	average age = 59.4
+7-15 weeks	10000000	Mus musculus BALB/c	2817	7-15 week	7-15 week
+65-94 years	9606	Homo sapiens (human)	2818	65-94 year	65-94 year
+6 to 8 weeks	10090	Mus musculus (mouse)	2819	6 to 8 week	6 to 8 week
+12 weeks	9615	Canis lupus familiaris (dogs)	2820	12 week	12 week
+7-15 weeks	10000576	Mus musculus HLA-A*02:01 Tg	2821	7-15 week	7-15 week
+7 weeks	10000038	Mus musculus C3H/He	2822	7 week	7 week
+8-14 weeks	10000632	Mus musculus NOD	2823	8-14 week	8-14 week
+7-15 weeks	10090	Mus musculus (mouse)	2824	7-15 week	7-15 week
+33 to 50 years	9606	Homo sapiens (human)	2825	33 to 50 year	33 to 50 year
+6-8 weeks	10001363	Mus musculus 2D2 TCR Tg	2826	6-8 week	6-8 week
+21-70 years	10000119	Homo sapiens Caucasian	2827	21-70 year	21-70 year
+NULL	10000102	Mus musculus C57BL/6 Prp null	2828	null	null
+6-8 weeks	10000206	Oryctolagus cuniculus New Zealand White	2829	6-8 week	6-8 week
+mean age  48.2 years	9606	Homo sapiens (human)	2830	mean age  48.2 year	mean age  48.2 year
+mean age  40.1 years	9606	Homo sapiens (human)	2831	mean age  40.1 year	mean age  40.1 year
+10-14 weeks	10001333	Rattus norvegicus LEW.1N	2832	10-14 week	10-14 week
+NULL	10001440	Mus musculus B16:A dKO NOD	2833	null	null
+24-85 years	9606	Homo sapiens (human)	2834	24-85 year	24-85 year
+18-23 years	9606	Homo sapiens (human)	2835	18-23 year	18-23 year
+27-64 years	9606	Homo sapiens (human)	2836	27-64 year	27-64 year
+10-16 weeks	10000047	Mus musculus C57BL/10	2837	10-16 week	10-16 week
+7-11 weeks	10000662	Rattus norvegicus Lewis	2838	7-11 week	7-11 week
+8-14 weeks	10001271	Mus musculus NOD-PI/NOD8.3	2839	8-14 week	8-14 week
+NULL	10001472	Mus musculus 1E4 TCR Tg	2840	null	null
+11-79 years old	9606	Homo sapiens (human)	2841	11-79 year old	11-79 year
+54-82 years	9606	Homo sapiens (human)	2842	54-82 year	54-82 year
+6 weeks	10000253	Mus musculus A/J	2843	6 week	6 week
+3-24 weeks	10000639	Mus musculus NZB	2844	3-24 week	3-24 week
+54 years	10000113	Homo sapiens Black	2845	54 year	54 year
+2-3 months	10000002	Mus musculus BALB/c beta2m null	2846	2-3 month	2-3 month
+6 to 8 weeks	10001480	Mus musculus C3H/HePAS	2847	6 to 8 week	6 to 8 week
+8-16 weeks	10000649	Mus musculus SJL	2848	8-16 week	8-16 week
+NULL	10002214	Mus musculus A51 TCR Tg	2849	null	null
+NULL	10001446	Rattus norvegicus Wistar Kyoto	2850	null	null
+6-10 years	9606	Homo sapiens (human)	2851	6-10 year	6-10 year
+8 to 12 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	2852	8 to 12 week	8 to 12 week
+10-16 weeks	10001475	Mus musculus H2A+E+	2853	10-16 week	10-16 week
+7-12 months	10000063	Mus musculus B10.A	2854	7-12 month	7-12 month
+8 to 18 weeks	10000000	Mus musculus BALB/c	2855	8 to 18 week	8 to 18 week
+8 to 18 weeks	10000067	Mus musculus C57BL/6	2856	8 to 18 week	8 to 18 week
+NULL	10001479	Mus musculus A23 TCR Tg	2857	null	null
+4 to 6 weeks	10001446	Rattus norvegicus Wistar Kyoto	2858	4 to 6 week	4 to 6 week
+71 years	9606	Homo sapiens (human)	2859	71 year	71 year
+6-10 weeks	10000066	Mus musculus C57BL/1Flu NP(328-498) Tg	2860	6-10 week	6-10 week
+NULL	10001474	Mus musculus GAD specific TCR	2861	null	null
+8 to 12 weeks	10000607	Mus musculus HLA-DR3 Tg	2862	8 to 12 week	8 to 12 week
+8 to 12 weeks	10000598	Mus musculus HLA-DQ8 Tg	2863	8 to 12 week	8 to 12 week
+6 years	9606	Homo sapiens (human)	2864	6 year	6 year
+19-62	9606	Homo sapiens (human)	2865	19-62	19-62
+NULL	10000627	Mus musculus MRL/MpJ	2866	null	null
+28 to 52 years	9606	Homo sapiens (human)	2867	28 to 52 year	28 to 52 year
+6 weeks	10000639	Mus musculus NZB	2868	6 week	6 week
+8 weeks	10000597	Mus musculus HLA-DQ6 Tg	2869	8 week	8 week
+37 ± 12 years	9606	Homo sapiens (human)	2870	37  12 year	37  12 year
+36 ± 13 years	9606	Homo sapiens (human)	2871	36  13 year	36  13 year
+74-92 years	9606	Homo sapiens (human)	2872	74-92 year	74-92 year
+NULL	10000053	Mus musculus DBA	2873	null	null
+8 to 12 weeks	10000252	Mus musculus A.SW	2874	8 to 12 week	8 to 12 week
+4-6 months	10000639	Mus musculus NZB	2875	4-6 month	4-6 month
+3 to 24 years	9606	Homo sapiens (human)	2876	3 to 24 year	3 to 24 year
+4 to 57 years	9606	Homo sapiens (human)	2877	4 to 57 year	4 to 57 year
+12 to 18 weeks	10000000	Mus musculus BALB/c	2878	12 to 18 week	12 to 18 week
+8-10 weeks	10001446	Rattus norvegicus Wistar Kyoto	2879	8-10 week	8-10 week
+8 to 12 weeks	10000597	Mus musculus HLA-DQ6 Tg	2880	8 to 12 week	8 to 12 week
+20 weeks	10000639	Mus musculus NZB	2881	20 week	20 week
+4-6 weeks	10001322	Oryctolagus cuniculus HLA-A2.1 Tg	2882	4-6 week	4-6 week
+24-69 years	9606	Homo sapiens (human)	2883	24-69 year	24-69 year
+27-87 years	9606	Homo sapiens (human)	2884	27-87 year	27-87 year
+NULL	10001271	Mus musculus NOD-PI/NOD8.3	2885	null	null
+2 to 3 months	10000260	Mus musculus B10.A(4R)	2886	2 to 3 month	2 to 3 month
+58-74 years	9606	Homo sapiens (human)	2887	58-74 year	58-74 year
+3-8 months	10000260	Mus musculus B10.A(4R)	2888	3-8 month	3-8 month
+30-58 years old	9606	Homo sapiens (human)	2889	30-58 year old	30-58 year
+NULL	10001679	Mus musculus B10.LP	2890	null	null
+NULL	10002836	Mus musculus HLA-DQ2 Tg	2891	null	null
+8 to 10 weeks	10000236	Mus musculus CBA/J	2892	8 to 10 week	8 to 10 week
+NULL	10000658	Rattus norvegicus Brown Norway	2893	null	null
+20-24 weeks	10000632	Mus musculus NOD	2894	20-24 week	20-24 week
+Young	10000662	Rattus norvegicus Lewis	2895	young	young
+30-54 years old	9606	Homo sapiens (human)	2896	30-54 year old	30-54 year
+27-56 years old	9606	Homo sapiens (human)	2897	27-56 year old	27-56 year
+4 to 7 weeks	10001473	Mus musculus 1H3.1 TCR Tg	2898	4 to 7 week	4 to 7 week
+8 to 12 weeks	10000251	Mus musculus A.BY	2899	8 to 12 week	8 to 12 week
+10-15 weeks	10000582	Mus musculus HLA-A2 Tg	2900	10-15 week	10-15 week
+12 to 26 weeks	10000263	Mus musculus B10.BR	2901	12 to 26 week	12 to 26 week
+6-10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	2902	6-10 week	6-10 week
+38-77 years	9606	Homo sapiens (human)	2903	38-77 year	38-77 year
+32-76 years	9606	Homo sapiens (human)	2904	32-76 year	32-76 year
+5-25 months	10000067	Mus musculus C57BL/6	2905	5-25 month	5-25 month
+10 years	9606	Homo sapiens (human)	2906	10 year	10 year
+24-48 years	9606	Homo sapiens (human)	2907	24-48 year	24-48 year
+16 weeks	10001406	Mus musculus MLR/lpr	2908	16 week	16 week
+26 to 44 years	9606	Homo sapiens (human)	2909	26 to 44 year	26 to 44 year
+8-12 weeks	10001980	Mus musculus Ob.1A12 TCR Tg	2910	8-12 week	8-12 week
+9-11 weeks	10001347	Mus musculus 129/Sv	2911	9-11 week	9-11 week
+9-11 weeks	10000067	Mus musculus C57BL/6	2912	9-11 week	9-11 week
+15-41 years	9606	Homo sapiens (human)	2913	15-41 year	15-41 year
+13-50 years	9606	Homo sapiens (human)	2914	13-50 year	13-50 year
+6- to 7- months	10001407	Mus musculus SNF1	2915	6- to 7- month	6- to 7- month
+4 to 21 years	9544	Macaca mulatta (rhesus macaque)	2916	4 to 21 year	4 to 21 year
+NULL	10001481	Mus musculus B6.CAS3	2917	null	null
+16 weeks	10000000	Mus musculus BALB/c	2918	16 week	16 week
+23 years-old	9606	Homo sapiens (human)	2919	23 year-old	23 year
+16 to 63 years	9606	Homo sapiens (human)	2920	16 to 63 year	16 to 63 year
+2-3 months	9823	Sus scrofa (pig)	2921	2-3 month	2-3 month
+37	9606	Homo sapiens (human)	2922	37	37
+19 to 83 years	9606	Homo sapiens (human)	2923	19 to 83 year	19 to 83 year
+33-68 years old	9606	Homo sapiens (human)	2924	33-68 year old	33-68 year
+25-59 years	9606	Homo sapiens (human)	2925	25-59 year	25-59 year
+6-8 weeks	10001327	Mus musculus PL/J X SJL	2926	6-8 week	6-8 week
+8 weeks	10090	Mus musculus (mouse)	2927	8 week	8 week
+6-10 weeks	10000007	Mus musculus 6.5 TCR Tg	2928	6-10 week	6-10 week
+41 years old	10000113	Homo sapiens Black	2929	41 year old	41 year
+2 to 3 months	10000028	Mus musculus C3H	2930	2 to 3 month	2 to 3 month
+34-65 years	9606	Homo sapiens (human)	2931	34-65 year	34-65 year
+21 to 87 years	9606	Homo sapiens (human)	2932	21 to 87 year	21 to 87 year
+6 years	9544	Macaca mulatta (rhesus macaque)	2933	6 year	6 year
+52 and 70 years	9606	Homo sapiens (human)	2934	52 and 70 year	52 and 70 year
+10 weeks	10000025	Mus musculus Biozzi AB/H	2935	10 week	10 week
+6-67 years	9606	Homo sapiens (human)	2936	6-67 year	6-67 year
+3 to 8 months	10000258	Mus musculus B10.A(2R)	2937	3 to 8 month	3 to 8 month
+8 to 9 weeks	10000038	Mus musculus C3H/He	2938	8 to 9 week	8 to 9 week
+4-6 weeks old	10000253	Mus musculus A/J	2939	4-6 week old	4-6 week
+3 to 8 months	10000000	Mus musculus BALB/c	2940	3 to 8 month	3 to 8 month
+3 to 8 months	10000021	Mus musculus BALB/c-H2dm2	2941	3 to 8 month	3 to 8 month
+6 to 8 weeks	10000228	Mus musculus CBA	2942	6 to 8 week	6 to 8 week
+8 to 12 weeks	10000601	Mus musculus HLA-DR1 Tg	2943	8 to 12 week	8 to 12 week
+NULL	10001506	Mus musculus M3R null	2944	null	null
+NULL	10001542	Mus musculus BALB/c TCR Transgenic	2945	null	null
+3-20 weeks	10000635	Mus musculus NOD/Lt	2946	3-20 week	3-20 week
+20 weeks	10000635	Mus musculus NOD/Lt	2947	20 week	20 week
+18-44 years	9606	Homo sapiens (human)	2948	18-44 year	18-44 year
+25-65 years old	9606	Homo sapiens (human)	2949	25-65 year old	25-65 year
+26.7 +/- 1.0 years	9606	Homo sapiens (human)	2950	26.7 ± 1.0 year	26.7 ± 1.0 year
+0-13 years	9606	Homo sapiens (human)	2951	0-13 year	0-13 year
+22-47 years	9606	Homo sapiens (human)	2952	22-47 year	22-47 year
+10-14 weeks	10001413	Rattus norvegicus ACI	2953	10-14 week	10-14 week
+7 to 9 weeks	10000216	Mus musculus C57BL/6 X BALB/c	2954	7 to 9 week	7 to 9 week
+10-14 weeks	10001337	Rattus norvegicus LEWIS.1W	2955	10-14 week	10-14 week
+12 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	2956	12 week	12 week
+8 weeks	10000053	Mus musculus DBA	2957	8 week	8 week
+2- 4 months	10000000	Mus musculus BALB/c	2958	2- 4 month	2- 4 month
+8 to 12 weeks	10000605	Mus musculus HLA-DR2 Tg	2959	8 to 12 week	8 to 12 week
+39-61 years	10000119	Homo sapiens Caucasian	2960	39-61 year	39-61 year
+NULL	10000029	Mus musculus C3H X DBA/2	2961	null	null
+2-33 months	10000067	Mus musculus C57BL/6	2962	2-33 month	2-33 month
+8 weeks	10001487	Mus musculus Apolipoprotein E null	2963	8 week	8 week
+2, 12, or 20 months	10000067	Mus musculus C57BL/6	2964	2, 12, or 20 month	2, 12, or 20 month
+22-43 years	9606	Homo sapiens (human)	2965	22-43 year	22-43 year
+8-14 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	2966	8-14 week old	8-14 week
+NULL	10000185	Canis familiaris beagle	2967	null	null
+10-14 weeks	10001412	Rattus norvegicus Wistar-Furth	2968	10-14 week	10-14 week
+NULL	10001612	Mus musculus B10.C-H7b(47N)/SN	2969	null	null
+NULL	10001595	Mus musculus B6.2.16 TCR Tg	2970	null	null
+8 weeks	10000667	Rattus norvegicus Sprague-Dawley	2971	8 week	8 week
+25-89 years	9606	Homo sapiens (human)	2972	25-89 year	25-89 year
+30-68 years old	9606	Homo sapiens (human)	2973	30-68 year old	30-68 year
+neonate	9606	Homo sapiens (human)	2974	neonate	neonate
+newborn	10000032	Mus musculus C3H.Q	2975	newborn	newborn
+NULL	10001613	Mus musculus Thy1.1+Bg1	2976	null	null
+6 to 10 weeks	10000104	Mus musculus C57BL/6 TAP null	2977	6 to 10 week	6 to 10 week
+28-43 years	9606	Homo sapiens (human)	2978	28-43 year	28-43 year
+Six week old	10000000	Mus musculus BALB/c	2979	6 week old	6 week
+newborn	10001287	Mus musculus DBA/1 X B10.Q	2980	newborn	newborn
+6-16 weeks	10000033	Mus musculus C3H.SW	2981	6-16 week	6-16 week
+newborn	10001288	Mus musculus MMC-1 (collagen mutant)	2982	newborn	newborn
+24 hours	10000669	Cavia porcellus Hartley	2983	24 hour	24 hour
+NULL	10000631	Mus musculus NMRI	2984	null	null
+6 and 8 weeks	10001438	Mus musculus BALB/cAnN	2985	6 and 8 week	6 and 8 week
+NULL	10001208	Mus musculus B6.C-H-2bm1	2986	null	null
+23-77 years	9606	Homo sapiens (human)	2987	23-77 year	23-77 year
+NULL	10002216	Mus musculus Matahari TCR Tg	2988	null	null
+6-10 weeks	10001470	Mus musculus Factor VIII null	2989	6-10 week	6-10 week
+24-37 years	9606	Homo sapiens (human)	2990	24-37 year	24-37 year
+0-12 years	9606	Homo sapiens (human)	2991	0-12 year	0-12 year
+23-91 years	9606	Homo sapiens (human)	2992	23-91 year	23-91 year
+9-50 years	9606	Homo sapiens (human)	2993	9-50 year	9-50 year
+7-55 years	9606	Homo sapiens (human)	2994	7-55 year	7-55 year
+5-8 weeks	10001634	Mus musculus IFNR null	2995	5-8 week	5-8 week
+8-12 weeks	10000068	Mus musculus 2C TCR Tg	2996	8-12 week	8-12 week
+mean = 32.17±13.32 years	9606	Homo sapiens (human)	2997	mean = 32.1713.32 year	mean = 32.1713.32 year
+mean = 73±8.53 years	9606	Homo sapiens (human)	2998	mean = 738.53 year	mean = 738.53 year
+30 weeks	10001241	Mus musculus APP	2999	30 week	30 week
+17-78 years	9606	Homo sapiens (human)	3000	17-78 year	17-78 year
+19-82 years	9606	Homo sapiens (human)	3001	19-82 year	19-82 year
+34-85 years	9606	Homo sapiens (human)	3002	34-85 year	34-85 year
+11-50 years	9606	Homo sapiens (human)	3003	11-50 year	11-50 year
+8 to 12 weeks	10001041	Rattus norvegicus Wistar	3004	8 to 12 week	8 to 12 week
+8 weeks	10001634	Mus musculus IFNR null	3005	8 week	8 week
+35-62 years	9606	Homo sapiens (human)	3006	35-62 year	35-62 year
+NULL	10001413	Rattus norvegicus ACI	3007	null	null
+8-12 weeks	10000019	Mus musculus BALB/cByJ	3008	8-12 week	8-12 week
+38.1 ± 14.8 years	9606	Homo sapiens (human)	3009	38.1  14.8 year	38.1  14.8 year
+20-70 years	9606	Homo sapiens (human)	3010	20-70 year	20-70 year
+6 to 12 weeks	10000000	Mus musculus BALB/c	3011	6 to 12 week	6 to 12 week
+20-41 years	9606	Homo sapiens (human)	3012	20-41 year	20-41 year
+23-50 years	9606	Homo sapiens (human)	3013	23-50 year	23-50 year
+42 to 50 years	9606	Homo sapiens (human)	3014	42 to 50 year	42 to 50 year
+8 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	3015	8 to 12 week	8 to 12 week
+6 to 12 weeks	10000582	Mus musculus HLA-A2 Tg	3016	6 to 12 week	6 to 12 week
+29-54 years	9606	Homo sapiens (human)	3017	29-54 year	29-54 year
+57-75 years	9606	Homo sapiens (human)	3018	57-75 year	57-75 year
+6-8 weeks	10000233	Mus musculus CBA/Ca	3019	6-8 week	6-8 week
+8-12 weeks	10000007	Mus musculus 6.5 TCR Tg	3020	8-12 week	8-12 week
+9 weeks	10000233	Mus musculus CBA/Ca	3021	9 week	9 week
+36 to 65 years	9606	Homo sapiens (human)	3022	36 to 65 year	36 to 65 year
+NULL	10001241	Mus musculus APP	3023	null	null
+2-4 months	10000649	Mus musculus SJL	3024	2-4 month	2-4 month
+2 to 4 monts	10001208	Mus musculus B6.C-H-2bm1	3025	2 to 4 month	2 to 4 month
+NULL	10000273	Mus musculus B10.P	3026	null	null
+4-6 weeks	10001655	Mus musculus BALB/c Thy 1.1	3027	4-6 week	4-6 week
+8-10 weeks	10000661	Rattus norvegicus Fischer 344	3028	8-10 week	8-10 week
+NULL	10001632	Mus musculus Va14i TCR Tg	3029	null	null
+6-10 weeks	10000287	Mus musculus P14 TCR Tg	3030	6-10 week	6-10 week
+46-67 years	9606	Homo sapiens (human)	3031	46-67 year	46-67 year
+11 weeks	10000000	Mus musculus BALB/c	3032	11 week	11 week
+25 to 59 years	9606	Homo sapiens (human)	3033	25 to 59 year	25 to 59 year
+2-4 months	10001208	Mus musculus B6.C-H-2bm1	3034	2-4 month	2-4 month
+8-24 weeks old	10000277	Mus musculus B10.S(7R)	3035	8-24 week old	8-24 week
+NULL	10002217	Mus musculus C10.4 TCR Tg	3036	null	null
+21-65 years	9606	Homo sapiens (human)	3037	21-65 year	21-65 year
+8-10 weeks	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	3038	8-10 week	8-10 week
+6 to 8 weeks	10000274	Mus musculus B10.PL	3039	6 to 8 week	6 to 8 week
+42.8±11.9 years	9606	Homo sapiens (human)	3040	42.811.9 year	42.811.9 year
+5-9 months	9823	Sus scrofa (pig)	3041	5-9 month	5-9 month
+28-34 years	9606	Homo sapiens (human)	3042	28-34 year	28-34 year
+NULL	10001575	Mus musculus C57BL/6 alpha1,3GT null	3043	null	null
+48.1±12.7 years	9606	Homo sapiens (human)	3044	48.112.7 year	48.112.7 year
+19 to 54 years	9606	Homo sapiens (human)	3045	19 to 54 year	19 to 54 year
+NULL	10001553	Mus musculus 2B4 TCR Tg	3046	null	null
+3-4 weeks	10000662	Rattus norvegicus Lewis	3047	3-4 week	3-4 week
+4 weeks	10141	Cavia porcellus (guinea pig)	3048	4 week	4 week
+2-3 months	10000635	Mus musculus NOD/Lt	3049	2-3 month	2-3 month
+6 weeks	10000287	Mus musculus P14 TCR Tg	3050	6 week	6 week
+newborn	10141	Cavia porcellus (guinea pig)	3051	newborn	newborn
+2 to 3 months	10000000	Mus musculus BALB/c	3052	2 to 3 month	2 to 3 month
+25-67 years	9606	Homo sapiens (human)	3053	25-67 year	25-67 year
+6-10 weeks	10002848	Mus musculus HLA-DPw4 Tg	3054	6-10 week	6-10 week
+4-6 weeks	35658	Mastomys coucha (southern multimammate mouse)	3055	4-6 week	4-6 week
+3-8 months	10000263	Mus musculus B10.BR	3056	3-8 month	3-8 month
+<24 hours	10000063	Mus musculus B10.A	3057	<24 hour	<24 hour
+>8 weeks	10000067	Mus musculus C57BL/6	3058	>8 week	>8 week
+6 to 8 weeks	10000271	Mus musculus B10.M	3059	6 to 8 week	6 to 8 week
+3 to 5 weeks	10000067	Mus musculus C57BL/6	3060	3 to 5 week	3 to 5 week
+NULL	10000050	Mus musculus C57BL/10 X C3H/HeJ	3061	null	null
+NULL	10000225	Mus musculus C57BL/6N	3062	null	null
+7 to 8 weeks	10001410	Mus musculus 5B6 TCR Tg	3063	7 to 8 week	7 to 8 week
+23-76 years	9606	Homo sapiens (human)	3064	23-76 year	23-76 year
+4-6 weeks	10000582	Mus musculus HLA-A2 Tg	3065	4-6 week	4-6 week
+5 to 6 weeks	10000632	Mus musculus NOD	3066	5 to 6 week	5 to 6 week
+21-63 years	9606	Homo sapiens (human)	3067	21-63 year	21-63 year
+1 to 5 years	9685	Felis catus (cat)	3068	1 to 5 year	1 to 5 year
+6-7 weeks	10001339	Rattus norvegicus LEWIS.1A	3069	6-7 week	6-7 week
+28 to 76 years	9606	Homo sapiens (human)	3070	28 to 76 year	28 to 76 year
+2-6 months	10001679	Mus musculus B10.LP	3071	2-6 month	2-6 month
+3 weeks	9031	Gallus gallus (chicken)	3072	3 week	3 week
+mean age = 13.8 years	9606	Homo sapiens (human)	3073	mean age = 13.8 year	mean age = 13.8 year
+5 to 6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3074	5 to 6 week	5 to 6 week
+mean age = 34.8 years	9606	Homo sapiens (human)	3075	mean age = 34.8 year	mean age = 34.8 year
+5 to 6 weeks	10001248	Mus musculus NOD.Cg-Tg	3076	5 to 6 week	5 to 6 week
+6-8 weeks	10000654	Mus musculus Swiss albino	3077	6-8 week	6-8 week
+7 to 10 weeks	10000601	Mus musculus HLA-DR1 Tg	3078	7 to 10 week	7 to 10 week
+25-48 years	9606	Homo sapiens (human)	3079	25-48 year	25-48 year
+3 months	10000635	Mus musculus NOD/Lt	3080	3 month	3 month
+adult	10000667	Rattus norvegicus Sprague-Dawley	3081	adult	adult
+4-5 months	10000635	Mus musculus NOD/Lt	3082	4-5 month	4-5 month
+5 weeks	10000669	Cavia porcellus Hartley	3083	5 week	5 week
+NULL	10002218	Mus musculus TCR75 TCR Tg	3084	null	null
+NULL	10001996	Mus musculus DbGagL TCR Tg	3085	null	null
+6 to 12 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3086	6 to 12 week	6 to 12 week
+10 to 20 weeks	10000662	Rattus norvegicus Lewis	3087	10 to 20 week	10 to 20 week
+6 to 8 weeks	10000054	Mus musculus DBA/1	3088	6 to 8 week	6 to 8 week
+8 months	10001405	Mus musculus NZB X NZW	3089	8 month	8 month
+7	10000632	Mus musculus NOD	3090	7	7
+6 to 8 weeks	10000019	Mus musculus BALB/cByJ	3091	6 to 8 week	6 to 8 week
+9-16 weeks	10000582	Mus musculus HLA-A2 Tg	3092	9-16 week	9-16 week
+69 years	9606	Homo sapiens (human)	3093	69 year	69 year
+3 weeks	10002232	Mus musculus BDC2.5 TCR Tg	3094	3 week	3 week
+mean age = 37.7 years	9606	Homo sapiens (human)	3095	mean age = 37.7 year	mean age = 37.7 year
+6-10 weeks	10000227	Mus musculus OT-1 TCR Tg	3096	6-10 week	6-10 week
+7 to 8 weeks	10001122	Mus musculus µMT	3097	7 to 8 week	7 to 8 week
+21 to 24 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3098	21 to 24 week	21 to 24 week
+56-85	9606	Homo sapiens (human)	3099	56-85	56-85
+2-17 years	9606	Homo sapiens (human)	3100	2-17 year	2-17 year
+63	9606	Homo sapiens (human)	3101	63	63
+4 to 6 weeks	10000233	Mus musculus CBA/Ca	3102	4 to 6 week	4 to 6 week
+40-50 years-old	9606	Homo sapiens (human)	3103	40-50 year-old	40-50 year
+2-3 months	10000220	Mus musculus C57BL/6 X DBA/2	3104	2-3 month	2-3 month
+4 to 5 weeks	10000187	Sus scrofa Landrace X Large White	3105	4 to 5 week	4 to 5 week
+NULL	10001994	Mus musculus OVA23-3 TCR Tg	3106	null	null
+6 to 12 weeks	10001220	Mus musculus OT-II TCR Tg	3107	6 to 12 week	6 to 12 week
+6 to 12 weeks	10001473	Mus musculus 1H3.1 TCR Tg	3108	6 to 12 week	6 to 12 week
+28 to 86 years	9606	Homo sapiens (human)	3109	28 to 86 year	28 to 86 year
+3 months	10000067	Mus musculus C57BL/6	3110	3 month	3 month
+NULL	10001677	Mus musculus N-acetylgalactosaminyltransferase null	3111	null	null
+NULL	10001710	Bos taurus Holstein X Charolais	3112	null	null
+NULL	10001718	Mus musculus B10.A(4R) Kbw9	3113	null	null
+NULL	10001165	Mus musculus C57BR/cdJ	3114	null	null
+4 to 10 weeks	10000028	Mus musculus C3H	3115	4 to 10 week	4 to 10 week
+4 to 10 weeks	10000000	Mus musculus BALB/c	3116	4 to 10 week	4 to 10 week
+8 to 45 years	9606	Homo sapiens (human)	3117	8 to 45 year	8 to 45 year
+0.9-29.4 years	9606	Homo sapiens (human)	3118	0.9-29.4 year	0.9-29.4 year
+5-7 weeks	10000263	Mus musculus B10.BR	3119	5-7 week	5-7 week
+22-45 years-old	9606	Homo sapiens (human)	3120	22-45 year-old	22-45 year
+NULL	10000648	Mus musculus RIIIS	3121	null	null
+9 weeks	10000055	Mus musculus DBA/2	3122	9 week	9 week
+41 and 43 years	9606	Homo sapiens (human)	3123	41 and 43 year	41 and 43 year
+6-10 weeks	10001612	Mus musculus B10.C-H7b(47N)/SN	3124	6-10 week	6-10 week
+9 to 12 weeks	10000649	Mus musculus SJL	3125	9 to 12 week	9 to 12 week
+12-18 weeks	10000635	Mus musculus NOD/Lt	3126	12-18 week	12-18 week
+35-58 years	9606	Homo sapiens (human)	3127	35-58 year	35-58 year
+54-63 years	9606	Homo sapiens (human)	3128	54-63 year	54-63 year
+23 to 33 years	9606	Homo sapiens (human)	3129	23 to 33 year	23 to 33 year
+2-12 months	10000270	Mus musculus B10.HTT	3130	2-12 month	2-12 month
+1-85 years	9606	Homo sapiens (human)	3131	1-85 year	1-85 year
+2 to 3 months	10000033	Mus musculus C3H.SW	3132	2 to 3 month	2 to 3 month
+8 to 10 weeks old	10000067	Mus musculus C57BL/6	3133	8 to 10 week old	8 to 10 week
+26 to 60 years	9606	Homo sapiens (human)	3134	26 to 60 year	26 to 60 year
+39-55 years	9606	Homo sapiens (human)	3135	39-55 year	39-55 year
+37-55 years	9606	Homo sapiens (human)	3136	37-55 year	37-55 year
+2-12 months	10000055	Mus musculus DBA/2	3137	2-12 month	2-12 month
+2-12 months	10000253	Mus musculus A/J	3138	2-12 month	2-12 month
+2-12 months	10001348	Mus musculus A.CA	3139	2-12 month	2-12 month
+2-12 months	10000252	Mus musculus A.SW	3140	2-12 month	2-12 month
+2-12 months	10001024	Mus musculus CE/J	3141	2-12 month	2-12 month
+6-10 weeks	10001327	Mus musculus PL/J X SJL	3142	6-10 week	6-10 week
+40-45 years	9606	Homo sapiens (human)	3143	40-45 year	40-45 year
+35-63 years	9606	Homo sapiens (human)	3144	35-63 year	35-63 year
+2-12 months	10000000	Mus musculus BALB/c	3145	2-12 month	2-12 month
+39-58 years	9606	Homo sapiens (human)	3146	39-58 year	39-58 year
+55-66 years	9606	Homo sapiens (human)	3147	55-66 year	55-66 year
+55 years	9606	Homo sapiens (human)	3148	55 year	55 year
+7 to 10 weeks	10000662	Rattus norvegicus Lewis	3149	7 to 10 week	7 to 10 week
+26-68 years	10000119	Homo sapiens Caucasian	3150	26-68 year	26-68 year
+6 to 8 weeks	10000219	Mus musculus C57BL/6 X CBA	3151	6 to 8 week	6 to 8 week
+5 to 8 weeks	10001363	Mus musculus 2D2 TCR Tg	3152	5 to 8 week	5 to 8 week
+6-10 weeks	10000275	Mus musculus B10.RIII	3153	6-10 week	6-10 week
+44 years old	9606	Homo sapiens (human)	3154	44 year old	44 year
+2-12 months	10090	Mus musculus (mouse)	3155	2-12 month	2-12 month
+2-12 months	10000278	Mus musculus B10.S(9R)	3156	2-12 month	2-12 month
+2-12 months	10000054	Mus musculus DBA/1	3157	2-12 month	2-12 month
+2-12 months	10000030	Mus musculus C3H.JK	3158	2-12 month	2-12 month
+2-12 months	10000032	Mus musculus C3H.Q	3159	2-12 month	2-12 month
+2-12 months	10000033	Mus musculus C3H.SW	3160	2-12 month	2-12 month
+NULL	10000638	Mus musculus Nude	3161	null	null
+2-6 months	10000272	Mus musculus B10.MBR	3162	2-6 month	2-6 month
+2-12 months	10000031	Mus musculus C3H.NB	3163	2-12 month	2-12 month
+27 years old	9606	Homo sapiens (human)	3164	27 year old	27 year
+18 years old	9606	Homo sapiens (human)	3165	18 year old	18 year
+19 years old	9606	Homo sapiens (human)	3166	19 year old	19 year
+25 years old	9606	Homo sapiens (human)	3167	25 year old	25 year
+49 years old	9606	Homo sapiens (human)	3168	49 year old	49 year
+33 years old	9606	Homo sapiens (human)	3169	33 year old	33 year
+40 years old	9606	Homo sapiens (human)	3170	40 year old	40 year
+47 years old	9606	Homo sapiens (human)	3171	47 year old	47 year
+35 years old	9606	Homo sapiens (human)	3172	35 year old	35 year
+19-70 years	9606	Homo sapiens (human)	3173	19-70 year	19-70 year
+53 years old	9606	Homo sapiens (human)	3174	53 year old	53 year
+26-64	9606	Homo sapiens (human)	3175	26-64	26-64
+55 years old	9606	Homo sapiens (human)	3176	55 year old	55 year
+21 years old	9606	Homo sapiens (human)	3177	21 year old	21 year
+31-54	9606	Homo sapiens (human)	3178	31-54	31-54
+18-62 years	9606	Homo sapiens (human)	3179	18-62 year	18-62 year
+28 years old	9606	Homo sapiens (human)	3180	28 year old	28 year
+30-43 years	9606	Homo sapiens (human)	3181	30-43 year	30-43 year
+42 years old	9606	Homo sapiens (human)	3182	42 year old	42 year
+24-63 years	9606	Homo sapiens (human)	3183	24-63 year	24-63 year
+35 to 77 years	9606	Homo sapiens (human)	3184	35 to 77 year	35 to 77 year
+27-40 years-old	9606	Homo sapiens (human)	3185	27-40 year-old	27-40 year
+27-39 years-old	9606	Homo sapiens (human)	3186	27-39 year-old	27-39 year
+23-53 years-old	9606	Homo sapiens (human)	3187	23-53 year-old	23-53 year
+23-41 years-old	9606	Homo sapiens (human)	3188	23-41 year-old	23-41 year
+12 to 20 weeks	10000067	Mus musculus C57BL/6	3189	12 to 20 week	12 to 20 week
+21-28 years	9606	Homo sapiens (human)	3190	21-28 year	21-28 year
+9-78 years	9606	Homo sapiens (human)	3191	9-78 year	9-78 year
+27-42 years-old	9606	Homo sapiens (human)	3192	27-42 year-old	27-42 year
+21-29 years	9606	Homo sapiens (human)	3193	21-29 year	21-29 year
+10 months	10001286	Mus musculus APPswe/PSEN1	3194	10 month	10 month
+6-12 weeks	10001220	Mus musculus OT-II TCR Tg	3195	6-12 week	6-12 week
+23-43 years-old	9606	Homo sapiens (human)	3196	23-43 year-old	23-43 year
+6 months to 14 years	9606	Homo sapiens (human)	3197	6 month to 14 year	6 month to 14 year
+2-71 years	9606	Homo sapiens (human)	3198	2-71 year	2-71 year
+32-42 years-old	9606	Homo sapiens (human)	3199	32-42 year-old	32-42 year
+10-16 weeks	10000067	Mus musculus C57BL/6	3200	10-16 week	10-16 week
+28-40 years-old	9606	Homo sapiens (human)	3201	28-40 year-old	28-40 year
+22 years old	9606	Homo sapiens (human)	3202	22 year old	22 year
+28-32 years-old	9606	Homo sapiens (human)	3203	28-32 year-old	28-32 year
+27-32 years-old	9606	Homo sapiens (human)	3204	27-32 year-old	27-32 year
+7-12 weeks	10000067	Mus musculus C57BL/6	3205	7-12 week	7-12 week
+3 months	10002062	Ovis aries Mallorquina	3206	3 month	3 month
+4 months	10002063	Ovis aries Merino	3207	4 month	4 month
+22-58 years-old	9606	Homo sapiens (human)	3208	22-58 year-old	22-58 year
+18-54 years-old	9606	Homo sapiens (human)	3209	18-54 year-old	18-54 year
+18-55 years-old	9606	Homo sapiens (human)	3210	18-55 year-old	18-55 year
+6-8 weeks	10000019	Mus musculus BALB/cByJ	3211	6-8 week	6-8 week
+18-56 years-old	9606	Homo sapiens (human)	3212	18-56 year-old	18-56 year
+12 to 16 weeks	10000635	Mus musculus NOD/Lt	3213	12 to 16 week	12 to 16 week
+21-55 years-old	9606	Homo sapiens (human)	3214	21-55 year-old	21-55 year
+18-53 years-old	9606	Homo sapiens (human)	3215	18-53 year-old	18-53 year
+mean of 12.2 years	9606	Homo sapiens (human)	3216	mean of 12.2 year	mean of 12.2 year
+mean of 37.0 years	9606	Homo sapiens (human)	3217	mean of 37.0 year	mean of 37.0 year
+24-76 years	9606	Homo sapiens (human)	3218	24-76 year	24-76 year
+20 weeks	10090	Mus musculus (mouse)	3219	20 week	20 week
+5 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3220	5 week	5 week
+27- 60 years	9606	Homo sapiens (human)	3221	27- 60 year	27- 60 year
+23-47 years-old	9606	Homo sapiens (human)	3222	23-47 year-old	23-47 year
+6 months	10000187	Sus scrofa Landrace X Large White	3223	6 month	6 month
+30-50 years-old	9606	Homo sapiens (human)	3224	30-50 year-old	30-50 year
+6-8 weels	10000067	Mus musculus C57BL/6	3225	6-8 week	6-8 week
+30 weeks	10000635	Mus musculus NOD/Lt	3226	30 week	30 week
+3 weeks	10000038	Mus musculus C3H/He	3227	3 week	3 week
+3-4 months	10001405	Mus musculus NZB X NZW	3228	3-4 month	3-4 month
+5 to 16 weeks	10000000	Mus musculus BALB/c	3229	5 to 16 week	5 to 16 week
+6 to 8 weeks or 20 to 22 months	10000067	Mus musculus C57BL/6	3230	6 to 8 week or 20 to 22 month	6 to 8 week or 20 to 22 month
+7-10 weeks	10002209	Mus musculus qCII24 TCR Tg	3231	7-10 week	7-10 week
+35-76 years	9606	Homo sapiens (human)	3232	35-76 year	35-76 year
+17-67 years	9606	Homo sapiens (human)	3233	17-67 year	17-67 year
+32-67 years	9606	Homo sapiens (human)	3234	32-67 year	32-67 year
+15 day	10000007	Mus musculus 6.5 TCR Tg	3235	15 day	15 day
+15 days	10000007	Mus musculus 6.5 TCR Tg	3236	15 days	15 days
+19-86 years	9606	Homo sapiens (human)	3237	19-86 year	19-86 year
+7-26 years	9544	Macaca mulatta (rhesus macaque)	3238	7-26 year	7-26 year
+3 months	9940	Ovis aries (domestic sheep)	3239	3 month	3 month
+8-24 weeks	10001383	Mus musculus Clone 4 TCR Tg	3240	8-24 week	8-24 week
+6-10 weeks	10000019	Mus musculus BALB/cByJ	3241	6-10 week	6-10 week
+9-39 years	9606	Homo sapiens (human)	3242	9-39 year	9-39 year
+6-8 weeks	10001068	Mus musculus C57/BL/6 LCMV NP Tg	3243	6-8 week	6-8 week
+2-12 months	10000063	Mus musculus B10.A	3244	2-12 month	2-12 month
+33-63	9606	Homo sapiens (human)	3245	33-63	33-63
+18-49	9606	Homo sapiens (human)	3246	18-49	18-49
+25-54	9606	Homo sapiens (human)	3247	25-54	25-54
+7-16 weeks	10000038	Mus musculus C3H/He	3248	7-16 week	7-16 week
+7-16 weeks	10000000	Mus musculus BALB/c	3249	7-16 week	7-16 week
+36 to 67 years	9606	Homo sapiens (human)	3250	36 to 67 year	36 to 67 year
+26-57	9606	Homo sapiens (human)	3251	26-57	26-57
+4 to 12 weeks	10000632	Mus musculus NOD	3252	4 to 12 week	4 to 12 week
+43-61 years	10000119	Homo sapiens Caucasian	3253	43-61 year	43-61 year
+24-28 years	9606	Homo sapiens (human)	3254	24-28 year	24-28 year
+22-57 years	9606	Homo sapiens (human)	3255	22-57 year	22-57 year
+34-35	9606	Homo sapiens (human)	3256	34-35	34-35
+6-8 weeks	10000102	Mus musculus C57BL/6 Prp null	3257	6-8 week	6-8 week
+34-64	9606	Homo sapiens (human)	3258	34-64	34-64
+32-35	9606	Homo sapiens (human)	3259	32-35	32-35
+35-64	9606	Homo sapiens (human)	3260	35-64	35-64
+61	9606	Homo sapiens (human)	3261	61	61
+mean age of 49 years	9606	Homo sapiens (human)	3262	mean age of 49 year	mean age of 49 year
+mean age of 57 years	9606	Homo sapiens (human)	3263	mean age of 57 year	mean age of 57 year
+15-90	9606	Homo sapiens (human)	3264	15-90	15-90
+49-60 years	9606	Homo sapiens (human)	3265	49-60 year	49-60 year
+8-16 weeks	10000287	Mus musculus P14 TCR Tg	3266	8-16 week	8-16 week
+39-50 years	9606	Homo sapiens (human)	3267	39-50 year	39-50 year
+8-12 weeks old	10001935	Mus musculus 129/SVE GAA-/-	3268	8-12 week old	8-12 week
+6-7 weeks	10001487	Mus musculus Apolipoprotein E null	3269	6-7 week	6-7 week
+4-15 months	10000067	Mus musculus C57BL/6	3270	4-15 month	4-15 month
+6-12 weeks	10001397	Mus musculus MOG null	3271	6-12 week	6-12 week
+NULL	10002213	Mus musculus 1C6 TCR Tg	3272	null	null
+54-74	9606	Homo sapiens (human)	3273	54-74	54-74
+43-60 years	9606	Homo sapiens (human)	3274	43-60 year	43-60 year
+6-8 weeks	10000063	Mus musculus B10.A	3275	6-8 week	6-8 week
+7 days or 8-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3276	7 days or 8-10 week	7 days or 8-10 week
+4-week-old	10000632	Mus musculus NOD	3277	4-week-old	4 week
+2 weeks	10000067	Mus musculus C57BL/6	3278	2 week	2 week
+six to eight weeks old	10000000	Mus musculus BALB/c	3279	6 to 8 week old	6 to 8 week
+six to eight weeks old	10000067	Mus musculus C57BL/6	3280	6 to 8 week old	6 to 8 week
+20-64 months	9483	Callithrix jacchus (common marmoset)	3281	20-64 month	20-64 month
+20-75 years	9606	Homo sapiens (human)	3282	20-75 year	20-75 year
+Adult (6 weeks)	10000669	Cavia porcellus Hartley	3283	adult (6 weeks)	adult (6 weeks)
+NULL	10002225	Mus musculus gp150 TCR	3284	null	null
+37-46 years	9606	Homo sapiens (human)	3285	37-46 year	37-46 year
+52-96 years	9606	Homo sapiens (human)	3286	52-96 year	52-96 year
+6-12 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	3287	6-12 week	6-12 week
+6-12 weeks	10002226	Mus musculus C3K TCR Tg	3288	6-12 week	6-12 week
+6-8 weeks	10000651	Mus musculus SMARTA TCR Tg	3289	6-8 week	6-8 week
+58-78 years	9606	Homo sapiens (human)	3290	58-78 year	58-78 year
+fetal	10000227	Mus musculus OT-1 TCR Tg	3291	fetal	fetal
+12-14 weeks	10000275	Mus musculus B10.RIII	3292	12-14 week	12-14 week
+6-10 weeks	10000013	Mus musculus BALB/c X A/J	3293	6-10 week	6-10 week
+8 to 10 weeks	10000187	Sus scrofa Landrace X Large White	3294	8 to 10 week	8 to 10 week
+4-7 weeks	10001933	Mus musculus C57BL/6 Aire null	3295	4-7 week	4-7 week
+6-7 weeks	10000187	Sus scrofa Landrace X Large White	3296	6-7 week	6-7 week
+23–52 years	9606	Homo sapiens (human)	3297	2352 year	2352 year
+19–67 years	9606	Homo sapiens (human)	3298	1967 year	1967 year
+8 weeks	10002848	Mus musculus HLA-DPw4 Tg	3299	8 week	8 week
+4-5 weeks	10001933	Mus musculus C57BL/6 Aire null	3300	4-5 week	4-5 week
+10-20 weeks	10001933	Mus musculus C57BL/6 Aire null	3301	10-20 week	10-20 week
+4-7 weeks	10000067	Mus musculus C57BL/6	3302	4-7 week	4-7 week
+6-12 weeks	10000582	Mus musculus HLA-A2 Tg	3303	6-12 week	6-12 week
+20-68 years	9606	Homo sapiens (human)	3304	20-68 year	20-68 year
+50-62 years	9606	Homo sapiens (human)	3305	50-62 year	50-62 year
+8 weeks	10000601	Mus musculus HLA-DR1 Tg	3306	8 week	8 week
+6-9 weeks old	10000038	Mus musculus C3H/He	3307	6-9 week old	6-9 week
+58-75	9606	Homo sapiens (human)	3308	58-75	58-75
+56-63	9606	Homo sapiens (human)	3309	56-63	56-63
+>8 weeks	10000227	Mus musculus OT-1 TCR Tg	3310	>8 week	>8 week
+16-24 weeks	10000000	Mus musculus BALB/c	3311	16-24 week	16-24 week
+16-24 weeks	10000067	Mus musculus C57BL/6	3312	16-24 week	16-24 week
+10 weeks	10002213	Mus musculus 1C6 TCR Tg	3313	10 week	10 week
+32-86 years	9606	Homo sapiens (human)	3314	32-86 year	32-86 year
+20-81 years	9606	Homo sapiens (human)	3315	20-81 year	20-81 year
+1 week	9606	Homo sapiens (human)	3316	1 week	1 week
+37-80 years	9606	Homo sapiens (human)	3317	37-80 year	37-80 year
+25 to 52 years	9606	Homo sapiens (human)	3318	25 to 52 year	25 to 52 year
+6-30 years	9606	Homo sapiens (human)	3319	6-30 year	6-30 year
+NULL	10002235	Mus musculus 506 TCR Tg	3320	null	null
+3 to 6 years	9615	Canis lupus familiaris (dogs)	3321	3 to 6 year	3 to 6 year
+21-35 years	9606	Homo sapiens (human)	3322	21-35 year	21-35 year
+6 to 8 weeks	10000605	Mus musculus HLA-DR2 Tg	3323	6 to 8 week	6 to 8 week
+NULL	10001979	Mus musculus class II null	3324	null	null
+3 years	9615	Canis lupus familiaris (dogs)	3325	3 year	3 year
+7-30	9606	Homo sapiens (human)	3326	7-30	7-30
+23-35 years	9606	Homo sapiens (human)	3327	23-35 year	23-35 year
+3 to 75 years	9606	Homo sapiens (human)	3328	3 to 75 year	3 to 75 year
+8 to 12 weeks	10001363	Mus musculus 2D2 TCR Tg	3329	8 to 12 week	8 to 12 week
+39-54 years	9606	Homo sapiens (human)	3330	39-54 year	39-54 year
+9 weeks	10000662	Rattus norvegicus Lewis	3331	9 week	9 week
+average 44.3 years	9606	Homo sapiens (human)	3332	average 44.3 year	average 44.3 year
+NULL	10001721	Mus musculus HEL expression Tg	3333	null	null
+5-18 years	9606	Homo sapiens (human)	3334	5-18 year	5-18 year
+average 40.8 years	9606	Homo sapiens (human)	3335	average 40.8 year	average 40.8 year
+15-17 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3336	15-17 week	15-17 week
+15-17 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3337	15-17 week	15-17 week
+36-52 years	9606	Homo sapiens (human)	3338	36-52 year	36-52 year
+NULL	10002232	Mus musculus BDC2.5 TCR Tg	3339	null	null
+6 weeks	10000607	Mus musculus HLA-DR3 Tg	3340	6 week	6 week
+NULL	10002207	Mus musculus OT-3 TCR Tg	3341	null	null
+8-10 weeks old	10000101	Mus musculus C57BL/6 Perforin null	3342	8-10 week old	8-10 week
+NULL	10000286	Mus musculus B6.PL Thy1a/Cy	3343	null	null
+16-20 weeks	10000000	Mus musculus BALB/c	3344	16-20 week	16-20 week
+33-62 years	9606	Homo sapiens (human)	3345	33-62 year	33-62 year
+38-62 years	9606	Homo sapiens (human)	3346	38-62 year	38-62 year
+3.6-14.8 years	9606	Homo sapiens (human)	3347	3.6-14.8 year	3.6-14.8 year
+14-75 years	9606	Homo sapiens (human)	3348	14-75 year	14-75 year
+4-6.1 years	9606	Homo sapiens (human)	3349	4-6.1 year	4-6.1 year
+35-68 years	9606	Homo sapiens (human)	3350	35-68 year	35-68 year
+19-32 years	9606	Homo sapiens (human)	3351	19-32 year	19-32 year
+23–63 years	9606	Homo sapiens (human)	3352	2363 year	2363 year
+24–62 years	9606	Homo sapiens (human)	3353	2462 year	2462 year
+NULL	10000674	Mus musculus CB6F1 H-2d chimeric scid	3354	null	null
+21-79	9606	Homo sapiens (human)	3355	21-79	21-79
+21-37	9606	Homo sapiens (human)	3356	21-37	21-37
+26 and 54 years	9606	Homo sapiens (human)	3357	26 and 54 year	26 and 54 year
+11-64 years	9606	Homo sapiens (human)	3358	11-64 year	11-64 year
+16-20 weeks	10001982	Mus musculus 5/4E8 TCR Tg	3359	16-20 week	16-20 week
+34-63 years	9606	Homo sapiens (human)	3360	34-63 year	34-63 year
+NULL	10002012	Mus musculus B6.HOD	3361	null	null
+4-6 months	10001221	Mus musculus C57BL/6 x SJL	3362	4-6 month	4-6 month
+NULL	10002234	Mus musculus 508 TCR Tg	3363	null	null
+15 or 24 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3364	15 or 24 week	15 or 24 week
+37-492 months	9606	Homo sapiens (human)	3365	37-492 month	37-492 month
+11-71 years	9606	Homo sapiens (human)	3366	11-71 year	11-71 year
+31-73 years	9606	Homo sapiens (human)	3367	31-73 year	31-73 year
+6-20 weeks	10000067	Mus musculus C57BL/6	3368	6-20 week	6-20 week
+12 weeks	10001301	Mus musculus HLA-DR15 Tg	3369	12 week	12 week
+48-60 years	9606	Homo sapiens (human)	3370	48-60 year	48-60 year
+2-6 months	10000610	Mus musculus HLA-DR4 Tg	3371	2-6 month	2-6 month
+29 years ± 6.5	9606	Homo sapiens (human)	3372	29 year  6.5	29 year  6.5
+8 weeks	10001407	Mus musculus SNF1	3373	8 week	8 week
+8 to 12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3374	8 to 12 week	8 to 12 week
+20 to 56 years	9606	Homo sapiens (human)	3375	20 to 56 year	20 to 56 year
+4.5-14.3 years	9606	Homo sapiens (human)	3376	4.5-14.3 year	4.5-14.3 year
+2.0-15.1 years	9606	Homo sapiens (human)	3377	2.0-15.1 year	2.0-15.1 year
+8-12 weeks	10001470	Mus musculus Factor VIII null	3378	8-12 week	8-12 week
+59 to 77 years	9606	Homo sapiens (human)	3379	59 to 77 year	59 to 77 year
+6 to 8 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3380	6 to 8 week	6 to 8 week
+57 to 81 years	9606	Homo sapiens (human)	3381	57 to 81 year	57 to 81 year
+17 to 24	9606	Homo sapiens (human)	3382	17 to 24	17 to 24
+12-77 years	9606	Homo sapiens (human)	3383	12-77 year	12-77 year
+22-60 years	9606	Homo sapiens (human)	3384	22-60 year	22-60 year
+8 weeks	9823	Sus scrofa (pig)	3385	8 week	8 week
+30 years or younger	9606	Homo sapiens (human)	3386	30 year or younger	30 year or younger
+25 to 40 years	9606	Homo sapiens (human)	3387	25 to 40 year	25 to 40 year
+3 to 5 months	10000067	Mus musculus C57BL/6	3388	3 to 5 month	3 to 5 month
+6 - 10 weeks	10000067	Mus musculus C57BL/6	3389	6 - 10 week	6 - 10 week
+NULL	10001283	Mus musculus BALB/c X B10.Q	3390	null	null
+25-51 years	9606	Homo sapiens (human)	3391	25-51 year	25-51 year
+6 - 8 weeks	10000582	Mus musculus HLA-A2 Tg	3392	6 - 8 week	6 - 8 week
+8-12 weeks	10001438	Mus musculus BALB/cAnN	3393	8-12 week	8-12 week
+32-66 years (mean = 50.3 year)	9606	Homo sapiens (human)	3394	32-66 year (mean = 50.3 year)	32-66 year (mean = 50.3 year)
+18 to 55 years	9606	Homo sapiens (human)	3395	18 to 55 year	18 to 55 year
+8 - 16 weeks	10000067	Mus musculus C57BL/6	3396	8 - 16 week	8 - 16 week
+8 to 10 weeks or 21 months	10000067	Mus musculus C57BL/6	3397	8 to 10 week or 21 month	8 to 10 week or 21 month
+6 weeks	10090	Mus musculus (mouse)	3398	6 week	6 week
+8-10 weeks	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	3399	8-10 week	8-10 week
+3 - 4 weeks	10000000	Mus musculus BALB/c	3400	3 - 4 week	3 - 4 week
+11-59 years	9606	Homo sapiens (human)	3401	11-59 year	11-59 year
+75-78 years	9606	Homo sapiens (human)	3402	75-78 year	75-78 year
+NULL	10002838	Mus musculus HLA-B*08:01 Tg	3403	null	null
+40 - 63 years	9606	Homo sapiens (human)	3404	40 - 63 year	40 - 63 year
+31-72 years	9606	Homo sapiens (human)	3405	31-72 year	31-72 year
+26-64 years	9606	Homo sapiens (human)	3406	26-64 year	26-64 year
+20-92 years	9606	Homo sapiens (human)	3407	20-92 year	20-92 year
+mean age = 45.2 years	9606	Homo sapiens (human)	3408	mean age = 45.2 year	mean age = 45.2 year
+41-51 years	9606	Homo sapiens (human)	3409	41-51 year	41-51 year
+6 to 12 weeks	10090	Mus musculus (mouse)	3410	6 to 12 week	6 to 12 week
+6 - 8 weeks	10000595	Mus musculus HLA-B7 Tg	3411	6 - 8 week	6 - 8 week
+6 weeks to 22 months	10000067	Mus musculus C57BL/6	3412	6 week to 22 month	6 week to 22 month
+5 to 6 weeks	10002014	Mus musculus Apolipoprotein B null	3413	5 to 6 week	5 to 6 week
+22 to 66 years	9606	Homo sapiens (human)	3414	22 to 66 year	22 to 66 year
+> 6 weeks	10000000	Mus musculus BALB/c	3415	> 6 week	> 6 week
+NULL	10002049	Mus musculus HLA-DRB1*03:02 Tg	3416	null	null
+8 months	10000017	Mus musculus BALB/c X DBA/2	3417	8 month	8 month
+10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3418	10 week	10 week
+3-12 months	10000017	Mus musculus BALB/c X DBA/2	3419	3-12 month	3-12 month
+2-3 months and 18-22 months	10000067	Mus musculus C57BL/6	3420	2-3 month and 18-22 month	2-3 month and 18-22 month
+12 months	10000017	Mus musculus BALB/c X DBA/2	3421	12 month	12 month
+18 months	10000067	Mus musculus C57BL/6	3422	18 month	18 month
+6 - 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3423	6 - 8 week	6 - 8 week
+6-16 weeks	10090	Mus musculus (mouse)	3424	6-16 week	6-16 week
+8-12 weeks	10001347	Mus musculus 129/Sv	3425	8-12 week	8-12 week
+8 weeks	10001349	Mus musculus SJL X SWR	3426	8 week	8 week
+3 to 25 years	9606	Homo sapiens (human)	3427	3 to 25 year	3 to 25 year
+49-59 years	9606	Homo sapiens (human)	3428	49-59 year	49-59 year
+8 weeks	10002210	Mus musculus 8F10 TCR Tg	3429	8 week	8 week
+20-58 years	9606	Homo sapiens (human)	3430	20-58 year	20-58 year
+NULL	10001982	Mus musculus 5/4E8 TCR Tg	3431	null	null
+46 to 61 years	9606	Homo sapiens (human)	3432	46 to 61 year	46 to 61 year
+4 days to 5 weeks	10000067	Mus musculus C57BL/6	3433	4 days to 5 week	4 days to 5 week
+8 to 20 weeks	10000067	Mus musculus C57BL/6	3434	8 to 20 week	8 to 20 week
+NULL	10002841	Mus musculus HLA-B44 Tg	3435	null	null
+NULL	10002845	Mus musculus HLA-C*07:01 Tg	3436	null	null
+22 - 53 years	9606	Homo sapiens (human)	3437	22 - 53 year	22 - 53 year
+NULL	10001989	Mus musculus HLA-A*01:01 Tg	3438	null	null
+NULL	10002212	Mus musculus 8.6 TCR Tg	3439	null	null
+8 weeks	10000973	Mus musculus 129	3440	8 week	8 week
+26 - 52 years	9606	Homo sapiens (human)	3441	26 - 52 year	26 - 52 year
+4 to 6 months	10001240	Mus musculus APPsw	3442	4 to 6 month	4 to 6 month
+21-54 years	9606	Homo sapiens (human)	3443	21-54 year	21-54 year
+8-16 weeks	10000047	Mus musculus C57BL/10	3444	8-16 week	8-16 week
+34-66.5 years	9606	Homo sapiens (human)	3445	34-66.5 year	34-66.5 year
+4 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3446	4 to 8 week	4 to 8 week
+8-16 weeks	10000601	Mus musculus HLA-DR1 Tg	3447	8-16 week	8-16 week
+newborn	10000263	Mus musculus B10.BR	3448	newborn	newborn
+46-78 years	9606	Homo sapiens (human)	3449	46-78 year	46-78 year
+6 to 8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3450	6 to 8 week	6 to 8 week
+> 6 weeks	10090	Mus musculus (mouse)	3451	> 6 week	> 6 week
+23-55 years-old	9606	Homo sapiens (human)	3452	23-55 year-old	23-55 year
+6 to 7 months	10000067	Mus musculus C57BL/6	3453	6 to 7 month	6 to 7 month
+10 months	10000220	Mus musculus C57BL/6 X DBA/2	3454	10 month	10 month
+32-55 years-old	9606	Homo sapiens (human)	3455	32-55 year-old	32-55 year
+31-43 years-old	9606	Homo sapiens (human)	3456	31-43 year-old	31-43 year
+2-3 months or 18-20 months	10001383	Mus musculus Clone 4 TCR Tg	3457	2-3 month or 18-20 month	2-3 month or 18-20 month
+NULL	10002210	Mus musculus 8F10 TCR Tg	3458	null	null
+46-58 years	9606	Homo sapiens (human)	3459	46-58 year	46-58 year
+5 to 6 weeks	10000618	Mus musculus ICR	3460	5 to 6 week	5 to 6 week
+6 - 8 weeks	10000000	Mus musculus BALB/c	3461	6 - 8 week	6 - 8 week
+22 to 54 years	9606	Homo sapiens (human)	3462	22 to 54 year	22 to 54 year
+4-5 weeks	10001260	Mus musculus Tg AI4-NOD.Rag1-/-	3463	4-5 week	4-5 week
+6-13 weeks	10000649	Mus musculus SJL	3464	6-13 week	6-13 week
+24-71 years	9606	Homo sapiens (human)	3465	24-71 year	24-71 year
+18 months	10000000	Mus musculus BALB/c	3466	18 month	18 month
+30-62 years	9606	Homo sapiens (human)	3467	30-62 year	30-62 year
+8-12 weeks	10001098	Mus musculus RAG-1 null	3468	8-12 week	8-12 week
+8 weeks	10001414	Mus musculus 172.10 TCR Tg	3469	8 week	8 week
+34 to 58 years	9606	Homo sapiens (human)	3470	34 to 58 year	34 to 58 year
+NULL	10001634	Mus musculus IFNR null	3471	null	null
+6 weeks to 22 months	10000287	Mus musculus P14 TCR Tg	3472	6 week to 22 month	6 week to 22 month
+5 to 7 weeks	10001438	Mus musculus BALB/cAnN	3473	5 to 7 week	5 to 7 week
+18 to 24 months	10000000	Mus musculus BALB/c	3474	18 to 24 month	18 to 24 month
+35 to 55 years	9606	Homo sapiens (human)	3475	35 to 55 year	35 to 55 year
+12 months	10000067	Mus musculus C57BL/6	3476	12 month	12 month
+6 months	10000017	Mus musculus BALB/c X DBA/2	3477	6 month	6 month
+8 -12 weeks	10000067	Mus musculus C57BL/6	3478	8 -12 week	8 -12 week
+9-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3479	9-10 week	9-10 week
+6-8 weeks	10001383	Mus musculus Clone 4 TCR Tg	3480	6-8 week	6-8 week
+9-10 weeks	10001780	Mus musculus H2-Kb OVA SIINFEKL Tg	3481	9-10 week	9-10 week
+6 to 12 weeks	10000287	Mus musculus P14 TCR Tg	3482	6 to 12 week	6 to 12 week
+4-10 months	10000067	Mus musculus C57BL/6	3483	4-10 month	4-10 month
+1-3 weeks	9031	Gallus gallus (chicken)	3484	1-3 week	1-3 week
+10 to 12 weeks	10000649	Mus musculus SJL	3485	10 to 12 week	10 to 12 week
+21-42 years old	9606	Homo sapiens (human)	3486	21-42 year old	21-42 year
+18-78 years old	9606	Homo sapiens (human)	3487	18-78 year old	18-78 year
+NULL	10002840	Mus musculus HLA-B35 Tg	3488	null	null
+12-20 weeks	10000067	Mus musculus C57BL/6	3489	12-20 week	12-20 week
+26-28 months	10000067	Mus musculus C57BL/6	3490	26-28 month	26-28 month
+2 to 6 months	10000276	Mus musculus B10.S	3491	2 to 6 month	2 to 6 month
+2 to 6 months	10000047	Mus musculus C57BL/10	3492	2 to 6 month	2 to 6 month
+14 to 15 weeks	10001326	Mus musculus Tg4 TCR Tg	3493	14 to 15 week	14 to 15 week
+2 to 6 months	10000257	Mus musculus B10 X B10.S	3494	2 to 6 month	2 to 6 month
+6 weeks	10000973	Mus musculus 129	3495	6 week	6 week
+9-12 years	9606	Homo sapiens (human)	3496	9-12 year	9-12 year
+11-13 years	9606	Homo sapiens (human)	3497	11-13 year	11-13 year
+6 to 8 weeks or > 18 months	10001438	Mus musculus BALB/cAnN	3498	6 to 8 week or > 18 month	6 to 8 week or > 18 month
+38 to 63 years	9606	Homo sapiens (human)	3499	38 to 63 year	38 to 63 year
+12 to 16 weeks	10000028	Mus musculus C3H	3500	12 to 16 week	12 to 16 week
+mean age = 58 years	9606	Homo sapiens (human)	3501	mean age = 58 year	mean age = 58 year
+NULL	10002220	Mus musculus P25 TCR Tg	3502	null	null
+5 to 6 weeks	10001592	Mus musculus LCMV GP33 TCR Tg	3503	5 to 6 week	5 to 6 week
+6 to 8 weeks	10001601	Mus musculus C57BL/6 X 129	3504	6 to 8 week	6 to 8 week
+8-10 weeks old	10001983	Mus musculus HLA-DRB1*03:01 Tg	3505	8-10 week old	8-10 week
+8 to 10 weeks	10000064	Mus musculus C57BL/10.Q	3506	8 to 10 week	8 to 10 week
+2 to 49 years	9606	Homo sapiens (human)	3507	2 to 49 year	2 to 49 year
+22 to 26 months	10000067	Mus musculus C57BL/6	3508	22 to 26 month	22 to 26 month
+2 to 26 months	10000067	Mus musculus C57BL/6	3509	2 to 26 month	2 to 26 month
+23-70 years	9606	Homo sapiens (human)	3510	23-70 year	23-70 year
+7 to 12 weeks	10000067	Mus musculus C57BL/6	3511	7 to 12 week	7 to 12 week
+16-59 years	10000113	Homo sapiens Black	3512	16-59 year	16-59 year
+NULL	10001438	Mus musculus BALB/cAnN	3513	null	null
+20 - 57 years	9606	Homo sapiens (human)	3514	20 - 57 year	20 - 57 year
+10-14 weeks	10000000	Mus musculus BALB/c	3515	10-14 week	10-14 week
+<16 hours	10001165	Mus musculus C57BR/cdJ	3516	<16 hour	<16 hour
+3 months	10000662	Rattus norvegicus Lewis	3517	3 month	3 month
+NULL	10000064	Mus musculus C57BL/10.Q	3518	null	null
+6 - 12 weeks	10000000	Mus musculus BALB/c	3519	6 - 12 week	6 - 12 week
+17 - 60 years	9606	Homo sapiens (human)	3520	17 - 60 year	17 - 60 year
+7-12 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	3521	7-12 week	7-12 week
+8-12 weeks	10000629	Mus musculus ND4 Swiss Webster	3522	8-12 week	8-12 week
+39.8 +/- 10.6 years	9606	Homo sapiens (human)	3523	39.8 ± 10.6 year	39.8 ± 10.6 year
+8 to 16 weeks	10000067	Mus musculus C57BL/6	3524	8 to 16 week	8 to 16 week
+30 years old	9606	Homo sapiens (human)	3525	30 year old	30 year
+NULL	10002050	Mus musculus HLA-DQB1*03:02 Tg	3526	null	null
+8-16 weeks	10000289	Mus musculus BALB.B	3527	8-16 week	8-16 week
+5-7 weeks	10000649	Mus musculus SJL	3528	5-7 week	5-7 week
+5 to 6 weeks	10000287	Mus musculus P14 TCR Tg	3529	5 to 6 week	5 to 6 week
+14-56 years	9606	Homo sapiens (human)	3530	14-56 year	14-56 year
+4 week old	10000067	Mus musculus C57BL/6	3531	4 week old	4 week
+46 years old	9606	Homo sapiens (human)	3532	46 year old	46 year
+18-68 years	9606	Homo sapiens (human)	3533	18-68 year	18-68 year
+NULL	10002222	Mus musculus D1C55 TCR Tg	3534	null	null
+8-12 weeks	10000227	Mus musculus OT-1 TCR Tg	3535	8-12 week	8-12 week
+58 years old	9606	Homo sapiens (human)	3536	58 year old	58 year
+38 years old	9606	Homo sapiens (human)	3537	38 year old	38 year
+52 years old	9606	Homo sapiens (human)	3538	52 year old	52 year
+34 years old	9606	Homo sapiens (human)	3539	34 year old	34 year
+59 years old	9606	Homo sapiens (human)	3540	59 year old	59 year
+10-28 weeks	10000632	Mus musculus NOD	3541	10-28 week	10-28 week
+17 to 26 weeks	10000632	Mus musculus NOD	3542	17 to 26 week	17 to 26 week
+56 years old	9606	Homo sapiens (human)	3543	56 year old	56 year
+8 months	9940	Ovis aries (domestic sheep)	3544	8 month	8 month
+22-53 years	9606	Homo sapiens (human)	3545	22-53 year	22-53 year
+21-55 years	9606	Homo sapiens (human)	3546	21-55 year	21-55 year
+23-57 years	9606	Homo sapiens (human)	3547	23-57 year	23-57 year
+7 to 16 weeks	10000649	Mus musculus SJL	3548	7 to 16 week	7 to 16 week
+24-52	9606	Homo sapiens (human)	3549	24-52	24-52
+19-30	9606	Homo sapiens (human)	3550	19-30	19-30
+26-58	9606	Homo sapiens (human)	3551	26-58	26-58
+57	9606	Homo sapiens (human)	3552	57	57
+6-58 years	9606	Homo sapiens (human)	3553	6-58 year	6-58 year
+24-46	9606	Homo sapiens (human)	3554	24-46	24-46
+10 weeks	10000649	Mus musculus SJL	3555	10 week	10 week
+35-43 years-old	9606	Homo sapiens (human)	3556	35-43 year-old	35-43 year
+18 to 35, or 65 to 95 years.	9606	Homo sapiens (human)	3557	18 to 35, or 65 to 95 year.	18 to 35, or 65 to 95 year.
+7 to 10 weeks	10000054	Mus musculus DBA/1	3558	7 to 10 week	7 to 10 week
+56 years	10000119	Homo sapiens Caucasian	3559	56 year	56 year
+6 to 8 weeks or 18 to 24 months	10000000	Mus musculus BALB/c	3560	6 to 8 week or 18 to 24 month	6 to 8 week or 18 to 24 month
+7 to 8 week	10000067	Mus musculus C57BL/6	3561	7 to 8 week	7 to 8 week
+1-8 mos	10000067	Mus musculus C57BL/6	3562	1-8 month	1-8 month
+NULL	10001347	Mus musculus 129/Sv	3563	null	null
+NULL	10001406	Mus musculus MLR/lpr	3564	null	null
+7-15 weeks	10000067	Mus musculus C57BL/6	3565	7-15 week	7-15 week
+11-13 weeks	10001406	Mus musculus MLR/lpr	3566	11-13 week	11-13 week
+6-8 weeks	10002221	Mus musculus L9.6 TCR Tg	3567	6-8 week	6-8 week
+4 months	10000067	Mus musculus C57BL/6	3568	4 month	4 month
+7-10 weeks	10000595	Mus musculus HLA-B7 Tg	3569	7-10 week	7-10 week
+7-10 weeks	10000594	Mus musculus HLA-B27 Tg	3570	7-10 week	7-10 week
+7-10 weeks	10000582	Mus musculus HLA-A2 Tg	3571	7-10 week	7-10 week
+18-19 weeks	10000067	Mus musculus C57BL/6	3572	18-19 week	18-19 week
+32-39 weeks	10001405	Mus musculus NZB X NZW	3573	32-39 week	32-39 week
+8-14 weeks	10001405	Mus musculus NZB X NZW	3574	8-14 week	8-14 week
+6 to 8 weeks	10000607	Mus musculus HLA-DR3 Tg	3575	6 to 8 week	6 to 8 week
+31-39 years old	9606	Homo sapiens (human)	3576	31-39 year old	31-39 year
+5-6 weeks	10000619	Mus musculus ICR X Swiss	3577	5-6 week	5-6 week
+> 2 months	10000252	Mus musculus A.SW	3578	> 2 month	> 2 month
+8-16 weeks	10000255	Mus musculus AKR	3579	8-16 week	8-16 week
+6 week old	10000067	Mus musculus C57BL/6	3580	6 week old	6 week
+21-66 years	9606	Homo sapiens (human)	3581	21-66 year	21-66 year
+2-12 months	10001358	Mus musculus CWB	3582	2-12 month	2-12 month
+2-12 months	10000973	Mus musculus 129	3583	2-12 month	2-12 month
+24-82 years	9606	Homo sapiens (human)	3584	24-82 year	24-82 year
+21-51 years	9606	Homo sapiens (human)	3585	21-51 year	21-51 year
+at least 7 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3586	at least 7 week	at least 7 week
+at least 7 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3587	at least 7 week	at least 7 week
+8.9 to 18.7 years	9606	Homo sapiens (human)	3588	8.9 to 18.7 year	8.9 to 18.7 year
+8 to 10 weeks	10001468	Oryctolagus cuniculus New Zealand White HLA-A*0201 Tg	3589	8 to 10 week	8 to 10 week
+20-73 years	9606	Homo sapiens (human)	3590	20-73 year	20-73 year
+48-75 years	9606	Homo sapiens (human)	3591	48-75 year	48-75 year
+23 to 69 years	9606	Homo sapiens (human)	3592	23 to 69 year	23 to 69 year
+6 to 12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3593	6 to 12 week	6 to 12 week
+33 to 49 years	9606	Homo sapiens (human)	3594	33 to 49 year	33 to 49 year
+8 weeks	10001280	Mus musculus RIP-CD80 LCMV-GP Tg	3595	8 week	8 week
+6 to 10 weeks	10001989	Mus musculus HLA-A*01:01 Tg	3596	6 to 10 week	6 to 10 week
+6 to 10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3597	6 to 10 week	6 to 10 week
+35 to 50 years	9606	Homo sapiens (human)	3598	35 to 50 year	35 to 50 year
+30-51 years	9606	Homo sapiens (human)	3599	30-51 year	30-51 year
+6 motnhs to 15 years	9606	Homo sapiens (human)	3600	6 motnhs to 15 year	6 motnhs to 15 year
+30 to 70 years	9606	Homo sapiens (human)	3601	30 to 70 year	30 to 70 year
+12 weeks	10000105	Mus musculus TRAMP Tg	3602	12 week	12 week
+51-78 years	9606	Homo sapiens (human)	3603	51-78 year	51-78 year
+6-8 weeks	10001623	Mus musculus AG129	3604	6-8 week	6-8 week
+75-77 years	9606	Homo sapiens (human)	3605	75-77 year	75-77 year
+3-32 weeks	10000635	Mus musculus NOD/Lt	3606	3-32 week	3-32 week
+28 to 60 years	9606	Homo sapiens (human)	3607	28 to 60 year	28 to 60 year
+70	9606	Homo sapiens (human)	3608	70	70
+6 to 12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3609	6 to 12 week	6 to 12 week
+>50 years-old	9606	Homo sapiens (human)	3610	>50 year-old	>50 year
+> 6 weeks	10000067	Mus musculus C57BL/6	3611	> 6 week	> 6 week
+23 to 73 years	9606	Homo sapiens (human)	3612	23 to 73 year	23 to 73 year
+8 to 10 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3613	8 to 10 week	8 to 10 week
+9-12 weeks	9823	Sus scrofa (pig)	3614	9-12 week	9-12 week
+4 to 6 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3615	4 to 6 week	4 to 6 week
+12 weeks	10000187	Sus scrofa Landrace X Large White	3616	12 week	12 week
+27 +/- 6 years	9606	Homo sapiens (human)	3617	27 ± 6 year	27 ± 6 year
+median age = 27 years	9606	Homo sapiens (human)	3618	median age = 27 year	median age = 27 year
+6-8 weeks	10002078	Mus musculus HLA-DP2 Tg	3619	6-8 week	6-8 week
+6 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3620	6 week	6 week
+6 weeks	10001998	Mus musculus CD1	3621	6 week	6 week
+19-76 years	9606	Homo sapiens (human)	3622	19-76 year	19-76 year
+5-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3623	5-8 week	5-8 week
+8-10 weeks	10001634	Mus musculus IFNR null	3624	8-10 week	8-10 week
+8 to 10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3625	8 to 10 week	8 to 10 week
+17 +/- 6 years	9606	Homo sapiens (human)	3626	17 ± 6 year	17 ± 6 year
+26-57 years	9606	Homo sapiens (human)	3627	26-57 year	26-57 year
+5-62 years	9606	Homo sapiens (human)	3628	5-62 year	5-62 year
+55.2 +/- 20.1 years	9606	Homo sapiens (human)	3629	55.2 ± 20.1 year	55.2 ± 20.1 year
+8-14 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3630	8-14 week	8-14 week
+46.1 +/- 14.8 years	9606	Homo sapiens (human)	3631	46.1 ± 14.8 year	46.1 ± 14.8 year
+21-76 years	9606	Homo sapiens (human)	3632	21-76 year	21-76 year
+3 weeks	10000241	Gallus gallus H.B15	3633	3 week	3 week
+27-72 years	9606	Homo sapiens (human)	3634	27-72 year	27-72 year
+18-77 years	9606	Homo sapiens (human)	3635	18-77 year	18-77 year
+18-81 years	9606	Homo sapiens (human)	3636	18-81 year	18-81 year
+30-53 years old	9606	Homo sapiens (human)	3637	30-53 year old	30-53 year
+5-7 weeks	10002842	Mus musculus HLA-A*33:03 Tg	3638	5-7 week	5-7 week
+20-58 years-old	9606	Homo sapiens (human)	3639	20-58 year-old	20-58 year
+29-62	9606	Homo sapiens (human)	3640	29-62	29-62
+21-48 years-old	9606	Homo sapiens (human)	3641	21-48 year-old	21-48 year
+> 8 weeks	10000067	Mus musculus C57BL/6	3642	> 8 week	> 8 week
+4 to 7 weeks	10090	Mus musculus (mouse)	3643	4 to 7 week	4 to 7 week
+25-77 years	9606	Homo sapiens (human)	3644	25-77 year	25-77 year
+8-10 weeks	10000061	Mus musculus FVB	3645	8-10 week	8-10 week
+4-13 years	9606	Homo sapiens (human)	3646	4-13 year	4-13 year
+5 to 12 weeks	10000000	Mus musculus BALB/c	3647	5 to 12 week	5 to 12 week
+64	9606	Homo sapiens (human)	3648	64	64
+4-6 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3649	4-6 week	4-6 week
+6-20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3650	6-20 week	6-20 week
+8-12 weeks	10002229	Mus musculus CTL-9 TCR Tg	3651	8-12 week	8-12 week
+25-49 years	9606	Homo sapiens (human)	3652	25-49 year	25-49 year
+4 months	10000667	Rattus norvegicus Sprague-Dawley	3653	4 month	4 month
+8-44	9606	Homo sapiens (human)	3654	8-44	8-44
+8 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3655	8 week	8 week
+22 to 32 years	9606	Homo sapiens (human)	3656	22 to 32 year	22 to 32 year
+3-5 months	10001218	Mus musculus B10.A x A.BY	3657	3-5 month	3-5 month
+29-36 years	9606	Homo sapiens (human)	3658	29-36 year	29-36 year
+2-8 months	10001405	Mus musculus NZB X NZW	3659	2-8 month	2-8 month
+21-59 years-old	9606	Homo sapiens (human)	3660	21-59 year-old	21-59 year
+22-48 years-old	9606	Homo sapiens (human)	3661	22-48 year-old	22-48 year
+12-20 weeks	10001220	Mus musculus OT-II TCR Tg	3662	12-20 week	12-20 week
+35-95 years	9606	Homo sapiens (human)	3663	35-95 year	35-95 year
+6 to 10 weeks	10000055	Mus musculus DBA/2	3664	6 to 10 week	6 to 10 week
+6-20 weeks	10090	Mus musculus (mouse)	3665	6-20 week	6-20 week
+22-55 years-old	9606	Homo sapiens (human)	3666	22-55 year-old	22-55 year
+8 to 12 weeks	10000064	Mus musculus C57BL/10.Q	3667	8 to 12 week	8 to 12 week
+22-66 years	9606	Homo sapiens (human)	3668	22-66 year	22-66 year
+22-59 years-old	9606	Homo sapiens (human)	3669	22-59 year-old	22-59 year
+23-59 years-old	9606	Homo sapiens (human)	3670	23-59 year-old	23-59 year
+2 years 8 months to 3 years 9 months	9544	Macaca mulatta (rhesus macaque)	3671	2 year 8 month to 3 year 9 month	2 year 8 month to 3 year 9 month
+<55 years	9606	Homo sapiens (human)	3672	<55 year	<55 year
+58.5 +/- 18.2 years	9606	Homo sapiens (human)	3673	58.5 ± 18.2 year	58.5 ± 18.2 year
+8-44 years	9606	Homo sapiens (human)	3674	8-44 year	8-44 year
+22-25 years	9606	Homo sapiens (human)	3675	22-25 year	22-25 year
+1 to 12 years	9606	Homo sapiens (human)	3676	1 to 12 year	1 to 12 year
+25-55 years-old	9606	Homo sapiens (human)	3677	25-55 year-old	25-55 year
+8 to 12 weeks	10001297	Mus musculus HLA-DRA*01:01/DRB1*04:04 Tg	3678	8 to 12 week	8 to 12 week
+21-53 years-old	9606	Homo sapiens (human)	3679	21-53 year-old	21-53 year
+31-59 years-old	9606	Homo sapiens (human)	3680	31-59 year-old	31-59 year
+32-56 years-old	9606	Homo sapiens (human)	3681	32-56 year-old	32-56 year
+31-55 years-old	9606	Homo sapiens (human)	3682	31-55 year-old	31-55 year
+6-9 weeks	10000635	Mus musculus NOD/Lt	3683	6-9 week	6-9 week
+NULL	10001098	Mus musculus RAG-1 null	3684	null	null
+21-56 years-old	9606	Homo sapiens (human)	3685	21-56 year-old	21-56 year
+32-35 years-old	9606	Homo sapiens (human)	3686	32-35 year-old	32-35 year
+19-54 years-old	9606	Homo sapiens (human)	3687	19-54 year-old	19-54 year
+6 to 10 weeks	10000582	Mus musculus HLA-A2 Tg	3688	6 to 10 week	6 to 10 week
+5 to 8 weeks	10000000	Mus musculus BALB/c	3689	5 to 8 week	5 to 8 week
+NULL	10001483	Mus musculus HLA-A*0201/DRB1*0101	3690	null	null
+25-58 years-old	9606	Homo sapiens (human)	3691	25-58 year-old	25-58 year
+21-54 years-old	9606	Homo sapiens (human)	3692	21-54 year-old	21-54 year
+4-8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3693	4-8 week	4-8 week
+30-55 years old	9606	Homo sapiens (human)	3694	30-55 year old	30-55 year
+25-59 years-old	9606	Homo sapiens (human)	3695	25-59 year-old	25-59 year
+6 to 8 weeks	10002070	Mus musculus C57BL/6 HBV1.3 HBV	3696	6 to 8 week	6 to 8 week
+8-12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	3697	8-12 week	8-12 week
+22-49 years-old	9606	Homo sapiens (human)	3698	22-49 year-old	22-49 year
+25-43 years-old	9606	Homo sapiens (human)	3699	25-43 year-old	25-43 year
+29-62 years	9606	Homo sapiens (human)	3700	29-62 year	29-62 year
+4-6 weeks	10000595	Mus musculus HLA-B7 Tg	3701	4-6 week	4-6 week
+6 to 8 weeks	10000575	Mus musculus HBV(adr) transgenic BALB/c	3702	6 to 8 week	6 to 8 week
+8 to 10 weeks	10001998	Mus musculus CD1	3703	8 to 10 week	8 to 10 week
+30-55 years-old	9606	Homo sapiens (human)	3704	30-55 year-old	30-55 year
+33-53 years old	9606	Homo sapiens (human)	3705	33-53 year old	33-53 year
+32-53 years old	9606	Homo sapiens (human)	3706	32-53 year old	32-53 year
+35-53 years-old	9606	Homo sapiens (human)	3707	35-53 year-old	35-53 year
+33-41 years old	9606	Homo sapiens (human)	3708	33-41 year old	33-41 year
+prenatal	9606	Homo sapiens (human)	3709	prenatal	prenatal
+33-55 years-old	9606	Homo sapiens (human)	3710	33-55 year-old	33-55 year
+31-53 years old	9606	Homo sapiens (human)	3711	31-53 year old	31-53 year
+33-55 years old	9606	Homo sapiens (human)	3712	33-55 year old	33-55 year
+40-53 years-old	9606	Homo sapiens (human)	3713	40-53 year-old	40-53 year
+32-53 years-old	9606	Homo sapiens (human)	3714	32-53 year-old	32-53 year
+32-40 years old	9606	Homo sapiens (human)	3715	32-40 year old	32-40 year
+32-47 years-old	9606	Homo sapiens (human)	3716	32-47 year-old	32-47 year
+31-56 years-old	9606	Homo sapiens (human)	3717	31-56 year-old	31-56 year
+33-48 years-old	9606	Homo sapiens (human)	3718	33-48 year-old	33-48 year
+22-51 years-old	9606	Homo sapiens (human)	3719	22-51 year-old	22-51 year
+30-48 years-old	9606	Homo sapiens (human)	3720	30-48 year-old	30-48 year
+30-53 years-old	9606	Homo sapiens (human)	3721	30-53 year-old	30-53 year
+33-53 years-old	9606	Homo sapiens (human)	3722	33-53 year-old	33-53 year
+33-40 years old	9606	Homo sapiens (human)	3723	33-40 year old	33-40 year
+32-44 years-old	9606	Homo sapiens (human)	3724	32-44 year-old	32-44 year
+31-48 years-old	9606	Homo sapiens (human)	3725	31-48 year-old	31-48 year
+31-55 years old	9606	Homo sapiens (human)	3726	31-55 year old	31-55 year
+43-55 years-old	9606	Homo sapiens (human)	3727	43-55 year-old	43-55 year
+32-55 years old	9606	Homo sapiens (human)	3728	32-55 year old	32-55 year
+32-59 years-old	9606	Homo sapiens (human)	3729	32-59 year-old	32-59 year
+33-34 years-old	9606	Homo sapiens (human)	3730	33-34 year-old	33-34 year
+32-48 years old	9606	Homo sapiens (human)	3731	32-48 year old	32-48 year
+39-53 years old	9606	Homo sapiens (human)	3732	39-53 year old	39-53 year
+32-47 years old	9606	Homo sapiens (human)	3733	32-47 year old	32-47 year
+22-47 years-old	9606	Homo sapiens (human)	3734	22-47 year-old	22-47 year
+21-45 years-old	9606	Homo sapiens (human)	3735	21-45 year-old	21-45 year
+22-53 years-old	9606	Homo sapiens (human)	3736	22-53 year-old	22-53 year
+21-47 years-old	9606	Homo sapiens (human)	3737	21-47 year-old	21-47 year
+22-54 years-old	9606	Homo sapiens (human)	3738	22-54 year-old	22-54 year
+32-49 years-old	9606	Homo sapiens (human)	3739	32-49 year-old	32-49 year
+21-24 days	10001248	Mus musculus NOD.Cg-Tg	3740	21-24 days	21-24 days
+31-54 years-old	9606	Homo sapiens (human)	3741	31-54 year-old	31-54 year
+12 to 15 weeks	10000067	Mus musculus C57BL/6	3742	12 to 15 week	12 to 15 week
+22-44 years-old	9606	Homo sapiens (human)	3743	22-44 year-old	22-44 year
+23-45 years-old	9606	Homo sapiens (human)	3744	23-45 year-old	23-45 year
+NULL	10002228	Mus musculus TRBV13-2 TCR Tg	3745	null	null
+3 years old	9544	Macaca mulatta (rhesus macaque)	3746	3 year old	3 year
+35-55 years-old	9606	Homo sapiens (human)	3747	35-55 year-old	35-55 year
+4-8 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3748	4-8 week	4-8 week
+21-32 years-old	9606	Homo sapiens (human)	3749	21-32 year-old	21-32 year
+> 8 weeks	10000000	Mus musculus BALB/c	3750	> 8 week	> 8 week
+21-52 years-old	9606	Homo sapiens (human)	3751	21-52 year-old	21-52 year
+27-53 years-old	9606	Homo sapiens (human)	3752	27-53 year-old	27-53 year
+4 and 12 weeks	10002071	Mus musculus LLO56 TCR Tg	3753	4 and 12 week	4 and 12 week
+4 and 12 weeks	10002072	Mus musculus LLO118 TCR Tg	3754	4 and 12 week	4 and 12 week
+22-43 years-old	9606	Homo sapiens (human)	3755	22-43 year-old	22-43 year
+23-44 years-old	9606	Homo sapiens (human)	3756	23-44 year-old	23-44 year
+10 to 12 weeks	10000067	Mus musculus C57BL/6	3757	10 to 12 week	10 to 12 week
+NULL	10002206	Mus musculus 5CC7 TCR Tg	3758	null	null
+21-49 years-old	9606	Homo sapiens (human)	3759	21-49 year-old	21-49 year
+6 to 14 weeks	10000067	Mus musculus C57BL/6	3760	6 to 14 week	6 to 14 week
+23-60 years	9606	Homo sapiens (human)	3761	23-60 year	23-60 year
+10 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	3762	10 week	10 week
+12-16 weeks	10001271	Mus musculus NOD-PI/NOD8.3	3763	12-16 week	12-16 week
+8-12 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3764	8-12 week	8-12 week
+25 to 82 years	9606	Homo sapiens (human)	3765	25 to 82 year	25 to 82 year
+25 to 81 years	9606	Homo sapiens (human)	3766	25 to 81 year	25 to 81 year
+39 to 57 years	9606	Homo sapiens (human)	3767	39 to 57 year	39 to 57 year
+23-48 years-old	9606	Homo sapiens (human)	3768	23-48 year-old	23-48 year
+25-54 years-old	9606	Homo sapiens (human)	3769	25-54 year-old	25-54 year
+27-55 years-old	9606	Homo sapiens (human)	3770	27-55 year-old	27-55 year
+16 weeks	10000632	Mus musculus NOD	3771	16 week	16 week
+6 to 8 weeks	9544	Macaca mulatta (rhesus macaque)	3772	6 to 8 week	6 to 8 week
+44-45 years old	9606	Homo sapiens (human)	3773	44-45 year old	44-45 year
+31-45 years-old	9606	Homo sapiens (human)	3774	31-45 year-old	31-45 year
+12-71 years	9606	Homo sapiens (human)	3775	12-71 year	12-71 year
+25 years	9598	Pan troglodytes (chimpanzee)	3776	25 year	25 year
+10 weeks or 23 weeks	10000067	Mus musculus C57BL/6	3777	10 week or 23 week	10 week or 23 week
+8-9 months	10000067	Mus musculus C57BL/6	3778	8-9 month	8-9 month
+8 to 10 months	10000067	Mus musculus C57BL/6	3779	8 to 10 month	8 to 10 month
+28-57 years	9606	Homo sapiens (human)	3780	28-57 year	28-57 year
+8-10 weeks	10000227	Mus musculus OT-1 TCR Tg	3781	8-10 week	8-10 week
+8-10 weeks	10001220	Mus musculus OT-II TCR Tg	3782	8-10 week	8-10 week
+17 to 59 years	9606	Homo sapiens (human)	3783	17 to 59 year	17 to 59 year
+8-10 weeks or 18-22 months	10000067	Mus musculus C57BL/6	3784	8-10 week or 18-22 month	8-10 week or 18-22 month
+7-66 years	9606	Homo sapiens (human)	3785	7-66 year	7-66 year
+6 weeks	10001347	Mus musculus 129/Sv	3786	6 week	6 week
+19-41 years	9606	Homo sapiens (human)	3787	19-41 year	19-41 year
+6 weeks	10000582	Mus musculus HLA-A2 Tg	3788	6 week	6 week
+10-63 years	9606	Homo sapiens (human)	3789	10-63 year	10-63 year
+19-54 years	9606	Homo sapiens (human)	3790	19-54 year	19-54 year
+20-61 years	9606	Homo sapiens (human)	3791	20-61 year	20-61 year
+22-39	9606	Homo sapiens (human)	3792	22-39	22-39
+5 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3793	5 week	5 week
+4-6 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3794	4-6 week	4-6 week
+24-108 months	9606	Homo sapiens (human)	3795	24-108 month	24-108 month
+8 to 12 weeks	10000103	Mus musculus C57BL/6 RIP-LCMV-NP Tg	3796	8 to 12 week	8 to 12 week
+embryonic day 15	10000067	Mus musculus C57BL/6	3797	embryonic day 15	embryonic day 15
+22-56 years	9606	Homo sapiens (human)	3798	22-56 year	22-56 year
+7 to 8 weeks	10000000	Mus musculus BALB/c	3799	7 to 8 week	7 to 8 week
+7 to 8 weeks	10000649	Mus musculus SJL	3800	7 to 8 week	7 to 8 week
+22-64 years	9606	Homo sapiens (human)	3801	22-64 year	22-64 year
+8 to 12 weeks	10002224	Mus musculus mB29b TCR Tg	3802	8 to 12 week	8 to 12 week
+18 to 56 years	10000119	Homo sapiens Caucasian	3803	18 to 56 year	18 to 56 year
+9 to 56 years	10000119	Homo sapiens Caucasian	3804	9 to 56 year	9 to 56 year
+18-40 years, 65 years and over.	9606	Homo sapiens (human)	3805	18-40 year, 65 year and over.	18-40 year, 65 year and over.
+8-12 weeks	10000597	Mus musculus HLA-DQ6 Tg	3806	8-12 week	8-12 week
+12 to 16 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3807	12 to 16 week	12 to 16 week
+3-15 weeks	10000632	Mus musculus NOD	3808	3-15 week	3-15 week
+16 to 18 months	10000067	Mus musculus C57BL/6	3809	16 to 18 month	16 to 18 month
+4 to 6 weeks	10000632	Mus musculus NOD	3810	4 to 6 week	4 to 6 week
+3 to 5 weeks	10000000	Mus musculus BALB/c	3811	3 to 5 week	3 to 5 week
+12-15 weeks	10000067	Mus musculus C57BL/6	3812	12-15 week	12-15 week
+8 weeks	10000275	Mus musculus B10.RIII	3813	8 week	8 week
+53-78 years	9606	Homo sapiens (human)	3814	53-78 year	53-78 year
+8 to 12 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	3815	8 to 12 week	8 to 12 week
+8 to 12 weeks	10001299	Mus musculus HLA-DRB1*04:02 Tg	3816	8 to 12 week	8 to 12 week
+10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	3817	10 week	10 week
+18 to 77 years	9606	Homo sapiens (human)	3818	18 to 77 year	18 to 77 year
+18 to 60 years	9606	Homo sapiens (human)	3819	18 to 60 year	18 to 60 year
+15-16 weeks	10000632	Mus musculus NOD	3820	15-16 week	15-16 week
+1 day, 7-8 days or adult	10000067	Mus musculus C57BL/6	3821	1 day, 7-8 days or adult	1 day, 7-8 days or adult
+6 weeks	10001983	Mus musculus HLA-DRB1*03:01 Tg	3822	6 week	6 week
+5-8 weeks	10000632	Mus musculus NOD	3823	5-8 week	5-8 week
+5-8 weeks	10000024	Mus musculus Biozzi	3824	5-8 week	5-8 week
+5-8 weeks	10000649	Mus musculus SJL	3825	5-8 week	5-8 week
+4 to 6 weeks	10047	Meriones unguiculatus (Mongolian jird)	3826	4 to 6 week	4 to 6 week
+23-72 years	9606	Homo sapiens (human)	3827	23-72 year	23-72 year
+22-29 years	9606	Homo sapiens (human)	3828	22-29 year	22-29 year
+23-27 years	9606	Homo sapiens (human)	3829	23-27 year	23-27 year
+22-26 years	9606	Homo sapiens (human)	3830	22-26 year	22-26 year
+NULL	10001626	Mus musculus beta2m null	3831	null	null
+47-76 years	9606	Homo sapiens (human)	3832	47-76 year	47-76 year
+6 months to 18 years	9606	Homo sapiens (human)	3833	6 month to 18 year	6 month to 18 year
+13 and 21 years	9606	Homo sapiens (human)	3834	13 and 21 year	13 and 21 year
+1-15 years	9606	Homo sapiens (human)	3835	1-15 year	1-15 year
+26 to 53 months	9483	Callithrix jacchus (common marmoset)	3836	26 to 53 month	26 to 53 month
+27 to 52 years	9606	Homo sapiens (human)	3837	27 to 52 year	27 to 52 year
+13 to 21 years	9606	Homo sapiens (human)	3838	13 to 21 year	13 to 21 year
+9 to 38 years	9606	Homo sapiens (human)	3839	9 to 38 year	9 to 38 year
+22 to 68 years	9606	Homo sapiens (human)	3840	22 to 68 year	22 to 68 year
+22 and 68 years	9606	Homo sapiens (human)	3841	22 and 68 year	22 and 68 year
+3-5 weeks	10000632	Mus musculus NOD	3842	3-5 week	3-5 week
+6-16 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	3843	6-16 week	6-16 week
+13 to 28 years	9606	Homo sapiens (human)	3844	13 to 28 year	13 to 28 year
+3 to 5 weeks	10000632	Mus musculus NOD	3845	3 to 5 week	3 to 5 week
+6 to 20 weeks	10000632	Mus musculus NOD	3846	6 to 20 week	6 to 20 week
+mean age 35 +/- 11 years	9606	Homo sapiens (human)	3847	mean age 35 ± 11 year	mean age 35 ± 11 year
+6 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3848	6 week	6 week
+23 weeks	10000067	Mus musculus C57BL/6	3849	23 week	23 week
+8 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3850	8 week	8 week
+13 to 38 years	9606	Homo sapiens (human)	3851	13 to 38 year	13 to 38 year
+28-66 years	9606	Homo sapiens (human)	3852	28-66 year	28-66 year
+3-18 years	9606	Homo sapiens (human)	3853	3-18 year	3-18 year
+10 weeks	9825	Sus scrofa domesticus (domestic pig)	3854	10 week	10 week
+15 to 41 years	9606	Homo sapiens (human)	3855	15 to 41 year	15 to 41 year
+6 to 12 weeks	10000274	Mus musculus B10.PL	3856	6 to 12 week	6 to 12 week
+20 to 25 years	9606	Homo sapiens (human)	3857	20 to 25 year	20 to 25 year
+6-10 weeks	10002237	Mus musculus TCR3 Rg	3858	6-10 week	6-10 week
+53-63 yeras	9606	Homo sapiens (human)	3859	53-63 year	53-63 year
+average age = 4.38 years	9606	Homo sapiens (human)	3860	average age = 4.38 year	average age = 4.38 year
+6 to 8 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3861	6 to 8 week	6 to 8 week
+6 to 8 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3862	6 to 8 week	6 to 8 week
+NULL	10001487	Mus musculus Apolipoprotein E null	3863	null	null
+22 to 63 years	9606	Homo sapiens (human)	3864	22 to 63 year	22 to 63 year
+25-78 years	9606	Homo sapiens (human)	3865	25-78 year	25-78 year
+2 weeks	10000000	Mus musculus BALB/c	3866	2 week	2 week
+11-80 years	9606	Homo sapiens (human)	3867	11-80 year	11-80 year
+41 +/- 11 years	9606	Homo sapiens (human)	3868	41 ± 11 year	41 ± 11 year
+33-55 years	9606	Homo sapiens (human)	3869	33-55 year	33-55 year
+51-67 years	9606	Homo sapiens (human)	3870	51-67 year	51-67 year
+33-59 years-old	9606	Homo sapiens (human)	3871	33-59 year-old	33-59 year
+10 to 27 years	9606	Homo sapiens (human)	3872	10 to 27 year	10 to 27 year
+21 to 74 years	10000119	Homo sapiens Caucasian	3873	21 to 74 year	21 to 74 year
+25 to 73 years	9606	Homo sapiens (human)	3874	25 to 73 year	25 to 73 year
+20 to 55 years	9606	Homo sapiens (human)	3875	20 to 55 year	20 to 55 year
+47-64 years	9606	Homo sapiens (human)	3876	47-64 year	47-64 year
+1 day	10000067	Mus musculus C57BL/6	3877	1 day	1 day
+28-59 years	9606	Homo sapiens (human)	3878	28-59 year	28-59 year
+58-68 years	9606	Homo sapiens (human)	3879	58-68 year	58-68 year
+45-65 years	9606	Homo sapiens (human)	3880	45-65 year	45-65 year
+44-68 years	9606	Homo sapiens (human)	3881	44-68 year	44-68 year
+39-65 years	9606	Homo sapiens (human)	3882	39-65 year	39-65 year
+> 14 weeks	10000047	Mus musculus C57BL/10	3883	> 14 week	> 14 week
+64 yeras	9606	Homo sapiens (human)	3884	64 year	64 year
+average age=36.5 years	9606	Homo sapiens (human)	3885	average age=36.5 year	average age=36.5 year
+6-27 weeks	10000028	Mus musculus C3H	3886	6-27 week	6-27 week
+22 to 76 years	9606	Homo sapiens (human)	3887	22 to 76 year	22 to 76 year
+NULL	10002223	Mus musculus RSV-M187 TCR Tg	3888	null	null
+3 months	10002050	Mus musculus HLA-DQB1*03:02 Tg	3889	3 month	3 month
+6-8 weeks	10001220	Mus musculus OT-II TCR Tg	3890	6-8 week	6-8 week
+18-21 years	9606	Homo sapiens (human)	3891	18-21 year	18-21 year
+14-18 months	9606	Homo sapiens (human)	3892	14-18 month	14-18 month
+5-6 weeks	10000635	Mus musculus NOD/Lt	3893	5-6 week	5-6 week
+9 months to 81 years	9606	Homo sapiens (human)	3894	9 month to 81 year	9 month to 81 year
+average age = 48 years	9606	Homo sapiens (human)	3895	average age = 48 year	average age = 48 year
+42 to 61 years	9606	Homo sapiens (human)	3896	42 to 61 year	42 to 61 year
+7 -11 years	9606	Homo sapiens (human)	3897	7 -11 year	7 -11 year
+7 - 11 years	9606	Homo sapiens (human)	3898	7 - 11 year	7 - 11 year
+6-12 years	9606	Homo sapiens (human)	3899	6-12 year	6-12 year
+5-6 weeks	10001347	Mus musculus 129/Sv	3900	5-6 week	5-6 week
+30-48 years old	9606	Homo sapiens (human)	3901	30-48 year old	30-48 year
+32-44 years old	9606	Homo sapiens (human)	3902	32-44 year old	32-44 year
+4 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3903	4 week	4 week
+23 to 57 years	9606	Homo sapiens (human)	3904	23 to 57 year	23 to 57 year
+4 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3905	4 week	4 week
+19-65 years-old	9606	Homo sapiens (human)	3906	19-65 year-old	19-65 year
+44-55 years	9606	Homo sapiens (human)	3907	44-55 year	44-55 year
+37-63 years	9606	Homo sapiens (human)	3908	37-63 year	37-63 year
+10 to 21 years	9606	Homo sapiens (human)	3909	10 to 21 year	10 to 21 year
+18+ years	9606	Homo sapiens (human)	3910	18+ year	18+ year
+19 to 61 years	9606	Homo sapiens (human)	3911	19 to 61 year	19 to 61 year
+30 to 49 years	9606	Homo sapiens (human)	3912	30 to 49 year	30 to 49 year
+> 6 weeks	10000582	Mus musculus HLA-A2 Tg	3913	> 6 week	> 6 week
+7 days	9031	Gallus gallus (chicken)	3914	7 days	7 days
+20 to 80 years	9606	Homo sapiens (human)	3915	20 to 80 year	20 to 80 year
+26.2 +/- 4.8 years	9606	Homo sapiens (human)	3916	26.2 ± 4.8 year	26.2 ± 4.8 year
+12 to 14 weeks	10000576	Mus musculus HLA-A*02:01 Tg	3917	12 to 14 week	12 to 14 week
+15 to 72 years	9606	Homo sapiens (human)	3918	15 to 72 year	15 to 72 year
+median 41.7 years	9606	Homo sapiens (human)	3919	median 41.7 year	median 41.7 year
+27 to 64 years	9606	Homo sapiens (human)	3920	27 to 64 year	27 to 64 year
+18 to 51 years	9606	Homo sapiens (human)	3921	18 to 51 year	18 to 51 year
+9 to 65 years	9606	Homo sapiens (human)	3922	9 to 65 year	9 to 65 year
+23 to 60 years	9606	Homo sapiens (human)	3923	23 to 60 year	23 to 60 year
+21 to 60 years	9606	Homo sapiens (human)	3924	21 to 60 year	21 to 60 year
+21 to 44 years	9606	Homo sapiens (human)	3925	21 to 44 year	21 to 44 year
+6 to 8 months	10002166	Bos taurus Japanese Black	3926	6 to 8 month	6 to 8 month
+average age=32 years	9606	Homo sapiens (human)	3927	average age=32 year	average age=32 year
+2 months	10000200	Oryctolagus cuniculus Chinchilla	3928	2 month	2 month
+19 weeks	10000632	Mus musculus NOD	3929	19 week	19 week
+8 weeks	10000227	Mus musculus OT-1 TCR Tg	3930	8 week	8 week
+3 weeks	10000920	Gallus gallus Leghorn	3931	3 week	3 week
+8 to 12 weeks	10001397	Mus musculus MOG null	3932	8 to 12 week	8 to 12 week
+21-68 years	9606	Homo sapiens (human)	3933	21-68 year	21-68 year
+39-69 years	9606	Homo sapiens (human)	3934	39-69 year	39-69 year
+12 +/- 2 weeks	9913	Bos taurus (bovine)	3935	12 ± 2 week	12 ± 2 week
+23-85 years	9606	Homo sapiens (human)	3936	23-85 year	23-85 year
+3 weeks	9823	Sus scrofa (pig)	3937	3 week	3 week
+18-58 years	9606	Homo sapiens (human)	3938	18-58 year	18-58 year
+1-25 years	9606	Homo sapiens (human)	3939	1-25 year	1-25 year
+6 weeks	10001248	Mus musculus NOD.Cg-Tg	3940	6 week	6 week
+6 to 8 weeks	10000973	Mus musculus 129	3941	6 to 8 week	6 to 8 week
+22-46 years	9606	Homo sapiens (human)	3942	22-46 year	22-46 year
+20 to 70 years	9606	Homo sapiens (human)	3943	20 to 70 year	20 to 70 year
+22 to 60 yeras	9606	Homo sapiens (human)	3944	22 to 60 year	22 to 60 year
+6 to 10 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	3945	6 to 10 week	6 to 10 week
+27.5 to 32.5 months	9541	Macaca fascicularis (crab eating macaque)	3946	27.5 to 32.5 month	27.5 to 32.5 month
+17-47 years	9606	Homo sapiens (human)	3947	17-47 year	17-47 year
+25–87 years	9606	Homo sapiens (human)	3948	2587 year	2587 year
+6-8	10000582	Mus musculus HLA-A2 Tg	3949	6-8	6-8
+24–88 years	9606	Homo sapiens (human)	3950	2488 year	2488 year
+24–87 years	9606	Homo sapiens (human)	3951	2487 year	2487 year
+25–88 years	9606	Homo sapiens (human)	3952	2588 year	2588 year
+8 to 12 weeks	10000635	Mus musculus NOD/Lt	3953	8 to 12 week	8 to 12 week
+24-88 years	9606	Homo sapiens (human)	3954	24-88 year	24-88 year
+24-87 years	9606	Homo sapiens (human)	3955	24-87 year	24-87 year
+27 to 59 years	9606	Homo sapiens (human)	3956	27 to 59 year	27 to 59 year
+young adults	10000615	Mus musculus HLA-DRB1*01:01 Tg	3957	young adults	young adults
+young adults	10000616	Mus musculus HLA-DRB1*04:01 Tg	3958	young adults	young adults
+young adults	10001399	Mus musculus HLA-DQB1*06:02 Tg	3959	young adults	young adults
+young adults	10002050	Mus musculus HLA-DQB1*03:02 Tg	3960	young adults	young adults
+32-85 years	9606	Homo sapiens (human)	3961	32-85 year	32-85 year
+6 to 10 weeks	10002177	Mus musculus HLA-B*40:01 Tg	3962	6 to 10 week	6 to 10 week
+17-41 years	9606	Homo sapiens (human)	3963	17-41 year	17-41 year
+8-12 weeks	10000225	Mus musculus C57BL/6N	3964	8-12 week	8-12 week
+young adults	10001400	Mus musculus HLA-DRB1*15:02 Tg	3965	young adults	young adults
+young adults	10001381	Mus musculus HLA-DRB1*15:01 Tg	3966	young adults	young adults
+< 6 weeks	10000632	Mus musculus NOD	3967	< 6 week	< 6 week
+> 6 weeks	10000632	Mus musculus NOD	3968	> 6 week	> 6 week
+6 and 12 weeks	10000632	Mus musculus NOD	3969	6 and 12 week	6 and 12 week
+5 to 6 weeks	10001782	Mus musculus HLA-B*07:02 Tg	3970	5 to 6 week	5 to 6 week
+19 to 65 years	9606	Homo sapiens (human)	3971	19 to 65 year	19 to 65 year
+6 to 7 weeks	10000661	Rattus norvegicus Fischer 344	3972	6 to 7 week	6 to 7 week
+12 months	9823	Sus scrofa (pig)	3973	12 month	12 month
+3 to 8 months	10000601	Mus musculus HLA-DR1 Tg	3974	3 to 8 month	3 to 8 month
+3 to 8 months	10000610	Mus musculus HLA-DR4 Tg	3975	3 to 8 month	3 to 8 month
+calf	10000193	Bos taurus Holstein	3976	calf	calf
+6 weeks	10001634	Mus musculus IFNR null	3977	6 week	6 week
+11 weeks	10001221	Mus musculus C57BL/6 x SJL	3978	11 week	11 week
+53 to 83 years	9606	Homo sapiens (human)	3979	53 to 83 year	53 to 83 year
+32 to 78 years	9606	Homo sapiens (human)	3980	32 to 78 year	32 to 78 year
+2-3 months	10090	Mus musculus (mouse)	3981	2-3 month	2-3 month
+8 to 12 weeks	10001220	Mus musculus OT-II TCR Tg	3982	8 to 12 week	8 to 12 week
+41 to 75 years	9606	Homo sapiens (human)	3983	41 to 75 year	41 to 75 year
+40 to 73 years	9606	Homo sapiens (human)	3984	40 to 73 year	40 to 73 year
+21 to 77 years	9606	Homo sapiens (human)	3985	21 to 77 year	21 to 77 year
+6 to 59 years	9606	Homo sapiens (human)	3986	6 to 59 year	6 to 59 year
+≥ 18 years	9606	Homo sapiens (human)	3987	 18 year	 18 year
+6 weeks	10001062	Mus musculus HLA-A*24:02 Tg	3988	6 week	6 week
+10-14 months	10000188	Sus scrofa NIH miniature pig	3989	10-14 month	10-14 month
+4-6 weeks	10000607	Mus musculus HLA-DR3 Tg	3990	4-6 week	4-6 week
+36 to 59 years	9606	Homo sapiens (human)	3991	36 to 59 year	36 to 59 year
+58	9606	Homo sapiens (human)	3992	58	58
+21-92 years	9606	Homo sapiens (human)	3993	21-92 year	21-92 year
+18-22 weeks	10000067	Mus musculus C57BL/6	3994	18-22 week	18-22 week
+9-14 weeks	10000067	Mus musculus C57BL/6	3995	9-14 week	9-14 week
+6 weeks	10001001	Rattus norvegicus WKAH	3996	6 week	6 week
+6 weeks	10002763	Mus musculus HLA-A*11:01 Tg	3997	6 week	6 week
+14-38 years	9606	Homo sapiens (human)	3998	14-38 year	14-38 year
+8 to 10 weeks	10000072	Mus musculus C57BL/6 Db null Kb null	3999	8 to 10 week	8 to 10 week
+5 weeks	10001001	Rattus norvegicus WKAH	4000	5 week	5 week
+2-5 months	10000276	Mus musculus B10.S	4001	2-5 month	2-5 month
+2-6 months	10001656	Mus musculus HNT TCR Tg	4002	2-6 month	2-6 month
+38 to 52 years	9606	Homo sapiens (human)	4003	38 to 52 year	38 to 52 year
+8-60 years	9606	Homo sapiens (human)	4004	8-60 year	8-60 year
+20-39 years	9606	Homo sapiens (human)	4005	20-39 year	20-39 year
+23.3 to 45.9 years	9606	Homo sapiens (human)	4006	23.3 to 45.9 year	23.3 to 45.9 year
+31.2 to 63.0 years	9606	Homo sapiens (human)	4007	31.2 to 63.0 year	31.2 to 63.0 year
+14 to 19 years	9606	Homo sapiens (human)	4008	14 to 19 year	14 to 19 year
+23 to 74 years	9606	Homo sapiens (human)	4009	23 to 74 year	23 to 74 year
+5-60 years	9606	Homo sapiens (human)	4010	5-60 year	5-60 year
+7.3 to 60.0 years	9606	Homo sapiens (human)	4011	7.3 to 60.0 year	7.3 to 60.0 year
+7.4 to 22.9 years	9606	Homo sapiens (human)	4012	7.4 to 22.9 year	7.4 to 22.9 year
+6-12 weeks	10001347	Mus musculus 129/Sv	4013	6-12 week	6-12 week
+47-66 years	9606	Homo sapiens (human)	4014	47-66 year	47-66 year
+29-39 years	9606	Homo sapiens (human)	4015	29-39 year	29-39 year
+28-71 years	9606	Homo sapiens (human)	4016	28-71 year	28-71 year
+6 to 12 weeks	10001326	Mus musculus Tg4 TCR Tg	4017	6 to 12 week	6 to 12 week
+23-31 years	9606	Homo sapiens (human)	4018	23-31 year	23-31 year
+8-12 weeks	10001301	Mus musculus HLA-DR15 Tg	4019	8-12 week	8-12 week
+16-34 years	9606	Homo sapiens (human)	4020	16-34 year	16-34 year
+54-73 years	9606	Homo sapiens (human)	4021	54-73 year	54-73 year
+6 to 8 weeks	10001438	Mus musculus BALB/cAnN	4022	6 to 8 week	6 to 8 week
+8-10 weeks	10001539	Mus musculus TCR transgenic	4023	8-10 week	8-10 week
+11-78 months	9606	Homo sapiens (human)	4024	11-78 month	11-78 month
+18-38 months	9606	Homo sapiens (human)	4025	18-38 month	18-38 month
+21 to 61 years	9606	Homo sapiens (human)	4026	21 to 61 year	21 to 61 year
+12 to 68 years	9606	Homo sapiens (human)	4027	12 to 68 year	12 to 68 year
+13-45 years	9606	Homo sapiens (human)	4028	13-45 year	13-45 year
+46-83 years	9606	Homo sapiens (human)	4029	46-83 year	46-83 year
+52-83 years	9606	Homo sapiens (human)	4030	52-83 year	52-83 year
+34-61 years	9606	Homo sapiens (human)	4031	34-61 year	34-61 year
+46-65 years	9606	Homo sapiens (human)	4032	46-65 year	46-65 year
+12 weeks	10000662	Rattus norvegicus Lewis	4033	12 week	12 week
+6-7 weeks	10001166	Mus musculus HLA-A24 Tg	4034	6-7 week	6-7 week
+37-58 years	9606	Homo sapiens (human)	4035	37-58 year	37-58 year
+2-6 months	10000253	Mus musculus A/J	4036	2-6 month	2-6 month
+30.9 to 42.1 years	9606	Homo sapiens (human)	4037	30.9 to 42.1 year	30.9 to 42.1 year
+36 to 88 years	9606	Homo sapiens (human)	4038	36 to 88 year	36 to 88 year
+25-69 years	9606	Homo sapiens (human)	4039	25-69 year	25-69 year
+4-6 weeks	10000287	Mus musculus P14 TCR Tg	4040	4-6 week	4-6 week
+8-9 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4041	8-9 week	8-9 week
+2-3 years	9823	Sus scrofa (pig)	4042	2-3 year	2-3 year
+7 to 8 weeks	10000067	Mus musculus C57BL/6	4043	7 to 8 week	7 to 8 week
+19 to 36 years	9606	Homo sapiens (human)	4044	19 to 36 year	19 to 36 year
+12 to 36 years	9606	Homo sapiens (human)	4045	12 to 36 year	12 to 36 year
+12 to 18 years	9606	Homo sapiens (human)	4046	12 to 18 year	12 to 18 year
+63-79 days	9823	Sus scrofa (pig)	4047	63-79 days	63-79 days
+91 days	9823	Sus scrofa (pig)	4048	91 days	91 days
+5 to 25 years	9606	Homo sapiens (human)	4049	5 to 25 year	5 to 25 year
+25 days	8839	Anas platyrhynchos (duck)	4050	25 days	25 days
+41-59 years	9606	Homo sapiens (human)	4051	41-59 year	41-59 year
+23-61 years	9606	Homo sapiens (human)	4052	23-61 year	23-61 year
+18-70 years	9606	Homo sapiens (human)	4053	18-70 year	18-70 year
+NULL	10000105	Mus musculus TRAMP Tg	4054	null	null
+24-74 years	9606	Homo sapiens (human)	4055	24-74 year	24-74 year
+32-64 years	9606	Homo sapiens (human)	4056	32-64 year	32-64 year
+10 to 15 years	9606	Homo sapiens (human)	4057	10 to 15 year	10 to 15 year
+11 to 27 years	9606	Homo sapiens (human)	4058	11 to 27 year	11 to 27 year
+>18 years	9606	Homo sapiens (human)	4059	>18 year	>18 year
+27-53 years	9606	Homo sapiens (human)	4060	27-53 year	27-53 year
+61-81 years	9606	Homo sapiens (human)	4061	61-81 year	61-81 year
+59-71 years	9606	Homo sapiens (human)	4062	59-71 year	59-71 year
+22-75 years	9606	Homo sapiens (human)	4063	22-75 year	22-75 year
+22-71 years	9606	Homo sapiens (human)	4064	22-71 year	22-71 year
+8-16 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4065	8-16 week	8-16 week
+8-16 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	4066	8-16 week	8-16 week
+8-16 weeks	10001256	Mus musculus GAD286 TCR Tg	4067	8-16 week	8-16 week
+8 to 24 years	9606	Homo sapiens (human)	4068	8 to 24 year	8 to 24 year
+8-16 weeks	10001261	Mus musculus G9Calpha –/ –.NOD	4069	8-16 week	8-16 week
+9 to 23 years	9606	Homo sapiens (human)	4070	9 to 23 year	9 to 23 year
+13 to 35 years	9606	Homo sapiens (human)	4071	13 to 35 year	13 to 35 year
+6 to 8 weeks	10001347	Mus musculus 129/Sv	4072	6 to 8 week	6 to 8 week
+2 months	9940	Ovis aries (domestic sheep)	4073	2 month	2 month
+12 to 18 weeks	10002220	Mus musculus P25 TCR Tg	4074	12 to 18 week	12 to 18 week
+49-61 years	9606	Homo sapiens (human)	4075	49-61 year	49-61 year
+18 years	10000119	Homo sapiens Caucasian	4076	18 year	18 year
+Neonates (3 or 7 days)	10000067	Mus musculus C57BL/6	4077	neonates (3 or 7 days)	neonates (3 or 7 days)
+16-86 years	9606	Homo sapiens (human)	4078	16-86 year	16-86 year
+8 to 16 weeks	10000610	Mus musculus HLA-DR4 Tg	4079	8 to 16 week	8 to 16 week
+8-12 months	10002063	Ovis aries Merino	4080	8-12 month	8-12 month
+NULL	10002277	Mus musculus MOG-specific TCR beta-chain Tg	4081	null	null
+7 to 10 weeks	10000096	Mus musculus C57BL/6 IL-10 null	4082	7 to 10 week	7 to 10 week
+Neonates (3 days)	10000067	Mus musculus C57BL/6	4083	neonates (3 days)	neonates (3 days)
+adult	10000227	Mus musculus OT-1 TCR Tg	4084	adult	adult
+6-11 weeks	10000067	Mus musculus C57BL/6	4085	6-11 week	6-11 week
+6-11 weeks	10001363	Mus musculus 2D2 TCR Tg	4086	6-11 week	6-11 week
+8 to 12 weeks	10002220	Mus musculus P25 TCR Tg	4087	8 to 12 week	8 to 12 week
+6-8 weeks	10001979	Mus musculus class II null	4088	6-8 week	6-8 week
+40-58 years	9606	Homo sapiens (human)	4089	40-58 year	40-58 year
+Infant	9606	Homo sapiens (human)	4090	infant	infant
+4 week	10000635	Mus musculus NOD/Lt	4091	4 week	4 week
+5 to 6 weeks	10000253	Mus musculus A/J	4092	5 to 6 week	5 to 6 week
+17 to 40 years	9606	Homo sapiens (human)	4093	17 to 40 year	17 to 40 year
+29 and 53 years	9606	Homo sapiens (human)	4094	29 and 53 year	29 and 53 year
+30 days	8855	Cairina moschata (muscovy)	4095	30 days	30 days
+20-60 years	9606	Homo sapiens (human)	4096	20-60 year	20-60 year
+37-74	9606	Homo sapiens (human)	4097	37-74	37-74
+8-16 weeks	10001802	Mus musculus NY8.3 TCR Tg	4098	8-16 week	8-16 week
+12 to 62 years	9606	Homo sapiens (human)	4099	12 to 62 year	12 to 62 year
+24 to 42 years	9606	Homo sapiens (human)	4100	24 to 42 year	24 to 42 year
+NULL	10001758	Mus musculus 6218 TCR Tg	4101	null	null
+26-39 years	9606	Homo sapiens (human)	4102	26-39 year	26-39 year
+26-62 years	9606	Homo sapiens (human)	4103	26-62 year	26-62 year
+2-12 months	10000282	Mus musculus B6(C)-H2-Ab1bm12	4104	2-12 month	2-12 month
+8-18 weeks	10000067	Mus musculus C57BL/6	4105	8-18 week	8-18 week
+6 to 53 years	9606	Homo sapiens (human)	4106	6 to 53 year	6 to 53 year
+6 yo 8 weeks	10000000	Mus musculus BALB/c	4107	6 year 8 week	6 year 8 week
+6 yo 8 weeks	10000067	Mus musculus C57BL/6	4108	6 year 8 week	6 year 8 week
+53-71 years	9606	Homo sapiens (human)	4109	53-71 year	53-71 year
+23-33 years	9606	Homo sapiens (human)	4110	23-33 year	23-33 year
+46 to 64 years	9606	Homo sapiens (human)	4111	46 to 64 year	46 to 64 year
+8 to 16 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4112	8 to 16 week	8 to 16 week
+8 to 16 weeks	10000632	Mus musculus NOD	4113	8 to 16 week	8 to 16 week
+55 to 70 years	9606	Homo sapiens (human)	4114	55 to 70 year	55 to 70 year
+8 to 16 weeks	10001310	Mus musculus BDC12-4.1 TCR Tg	4115	8 to 16 week	8 to 16 week
+8 to 16 weeks	10001802	Mus musculus NY8.3 TCR Tg	4116	8 to 16 week	8 to 16 week
+21.6 to 60.6 years	9606	Homo sapiens (human)	4117	21.6 to 60.6 year	21.6 to 60.6 year
+6 weeks	10000975	Mus musculus FVB Db Tg	4118	6 week	6 week
+Pediatric	9606	Homo sapiens (human)	4119	pediatric	pediatric
+27-82 years	9606	Homo sapiens (human)	4120	27-82 year	27-82 year
+12-18 weeks	10000253	Mus musculus A/J	4121	12-18 week	12-18 week
+3-65 years	9606	Homo sapiens (human)	4122	3-65 year	3-65 year
+6-8 weeks	10001438	Mus musculus BALB/cAnN	4123	6-8 week	6-8 week
+45 to 72 years	9606	Homo sapiens (human)	4124	45 to 72 year	45 to 72 year
+6 weeks	10000618	Mus musculus ICR	4125	6 week	6 week
+55	9606	Homo sapiens (human)	4126	55	55
+7-21 years	9606	Homo sapiens (human)	4127	7-21 year	7-21 year
+5 to 8 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4128	5 to 8 week	5 to 8 week
+18 to 43 years	9606	Homo sapiens (human)	4129	18 to 43 year	18 to 43 year
+19 to 59 years	9606	Homo sapiens (human)	4130	19 to 59 year	19 to 59 year
+2.5 to 17 years	9606	Homo sapiens (human)	4131	2.5 to 17 year	2.5 to 17 year
+10 to 14 weeks	10002763	Mus musculus HLA-A*11:01 Tg	4132	10 to 14 week	10 to 14 week
+62 years	9606	Homo sapiens (human)	4133	62 year	62 year
+8-12 weeks	10002274	Mus musculus CD1a	4134	8-12 week	8-12 week
+22 to >60 years	9606	Homo sapiens (human)	4135	22 to >60 year	22 to >60 year
+65-78 years	9606	Homo sapiens (human)	4136	65-78 year	65-78 year
+28 to 69 years	9606	Homo sapiens (human)	4137	28 to 69 year	28 to 69 year
+77 years	9606	Homo sapiens (human)	4138	77 year	77 year
+14-16 weeks	10000067	Mus musculus C57BL/6	4139	14-16 week	14-16 week
+65-72 years	9606	Homo sapiens (human)	4140	65-72 year	65-72 year
+5 weeks	10001487	Mus musculus Apolipoprotein E null	4141	5 week	5 week
+6 months	10000191	Bos taurus Hereford	4142	6 month	6 month
+>40 years	9606	Homo sapiens (human)	4143	>40 year	>40 year
+9-64 years	9606	Homo sapiens (human)	4144	9-64 year	9-64 year
+Adult	9615	Canis lupus familiaris (dogs)	4145	adult	adult
+7-14 weeks	10000067	Mus musculus C57BL/6	4146	7-14 week	7-14 week
+8-10 weeks	10001512	Mus musculus C57BL/6 GalNAc Transferase null	4147	8-10 week	8-10 week
+6 to 7 months	10000105	Mus musculus TRAMP Tg	4148	6 to 7 month	6 to 7 month
+9 weeks	10001933	Mus musculus C57BL/6 Aire null	4149	9 week	9 week
+12-16 weeks or 18-22 months	10000067	Mus musculus C57BL/6	4150	12-16 week or 18-22 month	12-16 week or 18-22 month
+5–10 weeks old	10000106	Mus musculus HY-A1 TCR beta chain Tg	4151	510 week old	510 week
+10 to 41 years	9606	Homo sapiens (human)	4152	10 to 41 year	10 to 41 year
+9 to 64 years	9606	Homo sapiens (human)	4153	9 to 64 year	9 to 64 year
+8 to 62 years	9606	Homo sapiens (human)	4154	8 to 62 year	8 to 62 year
+24 to 34 years	9606	Homo sapiens (human)	4155	24 to 34 year	24 to 34 year
+12 to 18 weeks	10000067	Mus musculus C57BL/6	4156	12 to 18 week	12 to 18 week
+8 to 64 years	9606	Homo sapiens (human)	4157	8 to 64 year	8 to 64 year
+10-12 weeks	10001634	Mus musculus IFNR null	4158	10-12 week	10-12 week
+6 to 9 months	10000067	Mus musculus C57BL/6	4159	6 to 9 month	6 to 9 month
+0-6 years	9606	Homo sapiens (human)	4160	0-6 year	0-6 year
+35-51 years	9606	Homo sapiens (human)	4161	35-51 year	35-51 year
+38-51 years	9606	Homo sapiens (human)	4162	38-51 year	38-51 year
+39-41 years	9606	Homo sapiens (human)	4163	39-41 year	39-41 year
+10 to 56 years	9606	Homo sapiens (human)	4164	10 to 56 year	10 to 56 year
+18 years or older	9606	Homo sapiens (human)	4165	18 year or older	18 year or older
+8 to 47 years	9606	Homo sapiens (human)	4166	8 to 47 year	8 to 47 year
+12 to 61 years	9606	Homo sapiens (human)	4167	12 to 61 year	12 to 61 year
+29 to 56 years	9606	Homo sapiens (human)	4168	29 to 56 year	29 to 56 year
+8-10 weeks	10001301	Mus musculus HLA-DR15 Tg	4169	8-10 week	8-10 week
+32 to 56 years	9606	Homo sapiens (human)	4170	32 to 56 year	32 to 56 year
+4-5 weeks	10001328	Mus musculus PLP TCR Tg	4171	4-5 week	4-5 week
+7 to 16 weeks	10000067	Mus musculus C57BL/6	4172	7 to 16 week	7 to 16 week
+8 to 12 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	4173	8 to 12 week	8 to 12 week
+4 to 15 weeks	10000632	Mus musculus NOD	4174	4 to 15 week	4 to 15 week
+4 to 15 weeks	10000596	Mus musculus HLA-DQ Transgenic	4175	4 to 15 week	4 to 15 week
+4 to 15 weeks	10001258	Mus musculus C57BL/6-H-2g7	4176	4 to 15 week	4 to 15 week
+3 to 67 years	9606	Homo sapiens (human)	4177	3 to 67 year	3 to 67 year
+10 to 63 years	9606	Homo sapiens (human)	4178	10 to 63 year	10 to 63 year
+7-62 years	9606	Homo sapiens (human)	4179	7-62 year	7-62 year
+27-60 years	9606	Homo sapiens (human)	4180	27-60 year	27-60 year
+24	9606	Homo sapiens (human)	4181	24	24
+5-7 weeks	10000253	Mus musculus A/J	4182	5-7 week	5-7 week
+8 weeks	10001098	Mus musculus RAG-1 null	4183	8 week	8 week
+1-55 years	9606	Homo sapiens (human)	4184	1-55 year	1-55 year
+12-14 weeks	10000055	Mus musculus DBA/2	4185	12-14 week	12-14 week
+19 to 68 years	9606	Homo sapiens (human)	4186	19 to 68 year	19 to 68 year
+5 months	10002166	Bos taurus Japanese Black	4187	5 month	5 month
+42 and 43 years	9606	Homo sapiens (human)	4188	42 and 43 year	42 and 43 year
+8-10 weeks	10001414	Mus musculus 172.10 TCR Tg	4189	8-10 week	8-10 week
+10 to 12 weeks	10000632	Mus musculus NOD	4190	10 to 12 week	10 to 12 week
+6 weeks	10000915	Mus musculus Kunming	4191	6 week	6 week
+31-63 years	9606	Homo sapiens (human)	4192	31-63 year	31-63 year
+15-53 years	9606	Homo sapiens (human)	4193	15-53 year	15-53 year
+24-75	9606	Homo sapiens (human)	4194	24-75	24-75
+2 months	10000043	Mus musculus C3HeB/FeJ	4195	2 month	2 month
+27-71 years	9606	Homo sapiens (human)	4196	27-71 year	27-71 year
+12 weeks - 22 months	10000067	Mus musculus C57BL/6	4197	12 week - 22 month	12 week - 22 month
+NULL	10001623	Mus musculus AG129	4198	null	null
+36-75 years	10000119	Homo sapiens Caucasian	4199	36-75 year	36-75 year
+7-13 months	10000194	Bos taurus Holstein-Friesian	4200	7-13 month	7-13 month
+19-46 years	9606	Homo sapiens (human)	4201	19-46 year	19-46 year
+21 -54 years	9606	Homo sapiens (human)	4202	21 -54 year	21 -54 year
+35-47 years	9606	Homo sapiens (human)	4203	35-47 year	35-47 year
+25 weeks	10001487	Mus musculus Apolipoprotein E null	4204	25 week	25 week
+21-38 years	9606	Homo sapiens (human)	4205	21-38 year	21-38 year
+52-71 years	9606	Homo sapiens (human)	4206	52-71 year	52-71 year
+59-84 years	9606	Homo sapiens (human)	4207	59-84 year	59-84 year
+19-71 years	9606	Homo sapiens (human)	4208	19-71 year	19-71 year
+36 to 85 years	9606	Homo sapiens (human)	4209	36 to 85 year	36 to 85 year
+26 to 34 years	9606	Homo sapiens (human)	4210	26 to 34 year	26 to 34 year
+6-8 weeks	10001366	Mus musculus Foxp3gfp.KI	4211	6-8 week	6-8 week
+2 months	10000922	Sus scrofa German Landrace	4212	2 month	2 month
+29-74 years	9606	Homo sapiens (human)	4213	29-74 year	29-74 year
+23-62 years	9606	Homo sapiens (human)	4214	23-62 year	23-62 year
+8 to 50 years	9606	Homo sapiens (human)	4215	8 to 50 year	8 to 50 year
+6-8 weeks	10002220	Mus musculus P25 TCR Tg	4216	6-8 week	6-8 week
+3.8 to 18.7 years	9606	Homo sapiens (human)	4217	3.8 to 18.7 year	3.8 to 18.7 year
+32 or 34 years	9606	Homo sapiens (human)	4218	32 or 34 year	32 or 34 year
+14-28 years	9606	Homo sapiens (human)	4219	14-28 year	14-28 year
+4 weeks	10002172	Sus scrofa Large White X Duroc	4220	4 week	4 week
+2 to 14 years	9606	Homo sapiens (human)	4221	2 to 14 year	2 to 14 year
+6 to 34 years	9606	Homo sapiens (human)	4222	6 to 34 year	6 to 34 year
+19-45	9606	Homo sapiens (human)	4223	19-45	19-45
+5 weeks-old	10000038	Mus musculus C3H/He	4224	5 week-old	5 week
+12 weeks to 20 months	10000067	Mus musculus C57BL/6	4225	12 week to 20 month	12 week to 20 month
+6 weeks to 20 months	10000067	Mus musculus C57BL/6	4226	6 week to 20 month	6 week to 20 month
+12-24 years	9606	Homo sapiens (human)	4227	12-24 year	12-24 year
+8-9 weeks	10000649	Mus musculus SJL	4228	8-9 week	8-9 week
+45-71 years	9606	Homo sapiens (human)	4229	45-71 year	45-71 year
+3-4 years	9544	Macaca mulatta (rhesus macaque)	4230	3-4 year	3-4 year
+28-54 years	9606	Homo sapiens (human)	4231	28-54 year	28-54 year
+46-86 years	9606	Homo sapiens (human)	4232	46-86 year	46-86 year
+39-75 years	9606	Homo sapiens (human)	4233	39-75 year	39-75 year
+5 to 12 weeks	10002072	Mus musculus LLO118 TCR Tg	4234	5 to 12 week	5 to 12 week
+9-52 years	9606	Homo sapiens (human)	4235	9-52 year	9-52 year
+3 to 5 weeks	10000274	Mus musculus B10.PL	4236	3 to 5 week	3 to 5 week
+20 to 74 years	9606	Homo sapiens (human)	4237	20 to 74 year	20 to 74 year
+24 to 37 years	9606	Homo sapiens (human)	4238	24 to 37 year	24 to 37 year
+15 to 27 years	9606	Homo sapiens (human)	4239	15 to 27 year	15 to 27 year
+8 months	10000067	Mus musculus C57BL/6	4240	8 month	8 month
+19-63 years	9606	Homo sapiens (human)	4241	19-63 year	19-63 year
+16-74 years	9606	Homo sapiens (human)	4242	16-74 year	16-74 year
+14-45 years	9606	Homo sapiens (human)	4243	14-45 year	14-45 year
+36-84 years	9606	Homo sapiens (human)	4244	36-84 year	36-84 year
+21 to 53 years	9606	Homo sapiens (human)	4245	21 to 53 year	21 to 53 year
+NULL	10000037	Mus musculus C3H/FeJ X C57BL/6	4246	null	null
+8-10 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4247	8-10 week	8-10 week
+6-12 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4248	6-12 week	6-12 week
+22-46	9606	Homo sapiens (human)	4249	22-46	22-46
+29-83	9606	Homo sapiens (human)	4250	29-83	29-83
+6-10 weeks	10001237	Mus musculus HLA-B*35:01 Tg	4251	6-10 week	6-10 week
+58.8 (average)	9606	Homo sapiens (human)	4252	58.8 (average)	58.8 (average)
+6-10 weeks	10001782	Mus musculus HLA-B*07:02 Tg	4253	6-10 week	6-10 week
+18-73 years	9606	Homo sapiens (human)	4254	18-73 year	18-73 year
+19 to 27 years	9606	Homo sapiens (human)	4255	19 to 27 year	19 to 27 year
+6-10 weeks	10001166	Mus musculus HLA-A24 Tg	4256	6-10 week	6-10 week
+20-66 years	9606	Homo sapiens (human)	4257	20-66 year	20-66 year
+37 to 61 years old	9606	Homo sapiens (human)	4258	37 to 61 year old	37 to 61 year
+21 to 66 years	9606	Homo sapiens (human)	4259	21 to 66 year	21 to 66 year
+12-24 months	10000193	Bos taurus Holstein	4260	12-24 month	12-24 month
+7-53 years	9606	Homo sapiens (human)	4261	7-53 year	7-53 year
+5-15 years	9606	Homo sapiens (human)	4262	5-15 year	5-15 year
+8-17 years	9606	Homo sapiens (human)	4263	8-17 year	8-17 year
+20 to 72 years	9606	Homo sapiens (human)	4264	20 to 72 year	20 to 72 year
+NULL	10000104	Mus musculus C57BL/6 TAP null	4265	null	null
+50-80 years	9606	Homo sapiens (human)	4266	50-80 year	50-80 year
+6-12 weeks	10001601	Mus musculus C57BL/6 X 129	4267	6-12 week	6-12 week
+6-12 weeks	10000225	Mus musculus C57BL/6N	4268	6-12 week	6-12 week
+9-10 weeks	10002306	Mus musculus NOD.InsY16A Tg	4269	9-10 week	9-10 week
+47-58 years	9606	Homo sapiens (human)	4270	47-58 year	47-58 year
+8-10 weeks	10002306	Mus musculus NOD.InsY16A Tg	4271	8-10 week	8-10 week
+14 to 38 years	9606	Homo sapiens (human)	4272	14 to 38 year	14 to 38 year
+10 weeks or older	10000632	Mus musculus NOD	4273	10 week or older	10 week or older
+20 to 41 years	9606	Homo sapiens (human)	4274	20 to 41 year	20 to 41 year
+5 to 20 weeks	10002232	Mus musculus BDC2.5 TCR Tg	4275	5 to 20 week	5 to 20 week
+20-77 years	9606	Homo sapiens (human)	4276	20-77 year	20-77 year
+14-53 years	9606	Homo sapiens (human)	4277	14-53 year	14-53 year
+24-81 years	9606	Homo sapiens (human)	4278	24-81 year	24-81 year
+0-2 years	9544	Macaca mulatta (rhesus macaque)	4279	0-2 year	0-2 year
+3-4 weeks	10001998	Mus musculus CD1	4280	3-4 week	3-4 week
+20 to 58 years	9606	Homo sapiens (human)	4281	20 to 58 year	20 to 58 year
+5 weeks	10000615	Mus musculus HLA-DRB1*01:01 Tg	4282	5 week	5 week
+14-56	9606	Homo sapiens (human)	4283	14-56	14-56
+NULL	10000667	Rattus norvegicus Sprague-Dawley	4284	null	null
+5-70 years	9606	Homo sapiens (human)	4285	5-70 year	5-70 year
+15-44 years	9606	Homo sapiens (human)	4286	15-44 year	15-44 year
+26-78 years	9606	Homo sapiens (human)	4287	26-78 year	26-78 year
+21-81 years	9606	Homo sapiens (human)	4288	21-81 year	21-81 year
+27-65 years	9606	Homo sapiens (human)	4289	27-65 year	27-65 year
+30.1 to 59.1 years	9606	Homo sapiens (human)	4290	30.1 to 59.1 year	30.1 to 59.1 year
+2-56 years	9606	Homo sapiens (human)	4291	2-56 year	2-56 year
+2-43 years	9606	Homo sapiens (human)	4292	2-43 year	2-43 year
+33	9606	Homo sapiens (human)	4293	33	33
+6 to 8 weeks	10000217	Mus musculus C57BL/6 X BALB/c-H2dm2	4294	6 to 8 week	6 to 8 week
+6 to 8 weeks	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	4295	6 to 8 week	6 to 8 week
+24 to 82 years	9606	Homo sapiens (human)	4296	24 to 82 year	24 to 82 year
+73 years	9606	Homo sapiens (human)	4297	73 year	73 year
+6 to 10 weeks	10000656	Mus musculus VM X DBA/2	4298	6 to 10 week	6 to 10 week
+40 to 62.1 years	9606	Homo sapiens (human)	4299	40 to 62.1 year	40 to 62.1 year
+35-73 Years	9606	Homo sapiens (human)	4300	35-73 year	35-73 year
+6-14 weeks	10000067	Mus musculus C57BL/6	4301	6-14 week	6-14 week
+44-60 years	9606	Homo sapiens (human)	4302	44-60 year	44-60 year
+> 50 years	9606	Homo sapiens (human)	4303	> 50 year	> 50 year
+mean 34.59 years	9606	Homo sapiens (human)	4304	mean 34.59 year	mean 34.59 year
+32-74 years	9606	Homo sapiens (human)	4305	32-74 year	32-74 year
+57-79 years	9606	Homo sapiens (human)	4306	57-79 year	57-79 year
+6 to 10 weeks	10001347	Mus musculus 129/Sv	4307	6 to 10 week	6 to 10 week
+5 to 6 weeks	10001097	Sus scrofa Yorkshire	4308	5 to 6 week	5 to 6 week
+46 to 84 years	9606	Homo sapiens (human)	4309	46 to 84 year	46 to 84 year
+4-8 years	9544	Macaca mulatta (rhesus macaque)	4310	4-8 year	4-8 year
+2-6 months	10000649	Mus musculus SJL	4311	2-6 month	2-6 month
+2-6 months	10000047	Mus musculus C57BL/10	4312	2-6 month	2-6 month
+15-21 years	9606	Homo sapiens (human)	4313	15-21 year	15-21 year
+2-6 months	10000274	Mus musculus B10.PL	4314	2-6 month	2-6 month
+6-10 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4315	6-10 week	6-10 week
+22-58 years	9606	Homo sapiens (human)	4316	22-58 year	22-58 year
+18-69 years	9606	Homo sapiens (human)	4317	18-69 year	18-69 year
+6 ± 2 weeks	10000067	Mus musculus C57BL/6	4318	6  2 week	6  2 week
+6 to 10 months	10000194	Bos taurus Holstein-Friesian	4319	6 to 10 month	6 to 10 month
+25-41 years	9606	Homo sapiens (human)	4320	25-41 year	25-41 year
+15-38 years	9606	Homo sapiens (human)	4321	15-38 year	15-38 year
+25-82 years	9606	Homo sapiens (human)	4322	25-82 year	25-82 year
+48-79 years	9606	Homo sapiens (human)	4323	48-79 year	48-79 year
+18-52 years	9606	Homo sapiens (human)	4324	18-52 year	18-52 year
+41-78 years	9606	Homo sapiens (human)	4325	41-78 year	41-78 year
+13-75 years	9606	Homo sapiens (human)	4326	13-75 year	13-75 year
+36-56 years	9606	Homo sapiens (human)	4327	36-56 year	36-56 year
+7 to 62 years	9606	Homo sapiens (human)	4328	7 to 62 year	7 to 62 year
+22 to 45 years	9606	Homo sapiens (human)	4329	22 to 45 year	22 to 45 year
+19 to 44 years	9606	Homo sapiens (human)	4330	19 to 44 year	19 to 44 year
+6 to 10 weeks	10001301	Mus musculus HLA-DR15 Tg	4331	6 to 10 week	6 to 10 week
+over 5 weeks	10000067	Mus musculus C57BL/6	4332	over 5 week	over 5 week
+36 to 68.2 years	9606	Homo sapiens (human)	4333	36 to 68.2 year	36 to 68.2 year
+19.9 to 22.1 years	9606	Homo sapiens (human)	4334	19.9 to 22.1 year	19.9 to 22.1 year
+6-10 weeks	10001098	Mus musculus RAG-1 null	4335	6-10 week	6-10 week
+7-10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4336	7-10 week	7-10 week
+29-45 years	9606	Homo sapiens (human)	4337	29-45 year	29-45 year
+12-48 years	9606	Homo sapiens (human)	4338	12-48 year	12-48 year
+21, 25 and 44 years	9606	Homo sapiens (human)	4339	21, 25 and 44 year	21, 25 and 44 year
+21-70 years	9606	Homo sapiens (human)	4340	21-70 year	21-70 year
+18-46 years	9606	Homo sapiens (human)	4341	18-46 year	18-46 year
+8-12 weeks	10001539	Mus musculus TCR transgenic	4342	8-12 week	8-12 week
+7 to 48 years	9606	Homo sapiens (human)	4343	7 to 48 year	7 to 48 year
+51-53 years	9606	Homo sapiens (human)	4344	51-53 year	51-53 year
+38-73 years	9606	Homo sapiens (human)	4345	38-73 year	38-73 year
+12-62 years	9606	Homo sapiens (human)	4346	12-62 year	12-62 year
+22.5-35.5	9606	Homo sapiens (human)	4347	22.5-35.5	22.5-35.5
+< 10 weeks	10000632	Mus musculus NOD	4348	< 10 week	< 10 week
+21 and 44 years	9606	Homo sapiens (human)	4349	21 and 44 year	21 and 44 year
+62	9606	Homo sapiens (human)	4350	62	62
+16 and 44 years	9606	Homo sapiens (human)	4351	16 and 44 year	16 and 44 year
+18 to 39 years	9606	Homo sapiens (human)	4352	18 to 39 year	18 to 39 year
+38 and 48 years	9606	Homo sapiens (human)	4353	38 and 48 year	38 and 48 year
+38 and 44 years	9606	Homo sapiens (human)	4354	38 and 44 year	38 and 44 year
+47-83 years	9606	Homo sapiens (human)	4355	47-83 year	47-83 year
+20 to 60 years	9606	Homo sapiens (human)	4356	20 to 60 year	20 to 60 year
+6 weeks	10002128	Mus musculus SKH-1	4357	6 week	6 week
+6-10 weeks	10000225	Mus musculus C57BL/6N	4358	6-10 week	6-10 week
+4-6 weeks	10001217	Mus musculus pmel-1 TCR Tg	4359	4-6 week	4-6 week
+20-46 years	9606	Homo sapiens (human)	4360	20-46 year	20-46 year
+47 to 57 years	9606	Homo sapiens (human)	4361	47 to 57 year	47 to 57 year
+47 to 63 years	9606	Homo sapiens (human)	4362	47 to 63 year	47 to 63 year
+16-71 years	9606	Homo sapiens (human)	4363	16-71 year	16-71 year
+17 to 58 years	9606	Homo sapiens (human)	4364	17 to 58 year	17 to 58 year
+4 weeks	10000582	Mus musculus HLA-A2 Tg	4365	4 week	4 week
+12 weeks	10000582	Mus musculus HLA-A2 Tg	4366	12 week	12 week
+4-8 weeks	10000000	Mus musculus BALB/c	4367	4-8 week	4-8 week
+11 years	9606	Homo sapiens (human)	4368	11 year	11 year
+17-56	9606	Homo sapiens (human)	4369	17-56	17-56
+15 to 37 years	9606	Homo sapiens (human)	4370	15 to 37 year	15 to 37 year
+2 months	10000632	Mus musculus NOD	4371	2 month	2 month
+24-55	9606	Homo sapiens (human)	4372	24-55	24-55
+40-76 years	9606	Homo sapiens (human)	4373	40-76 year	40-76 year
+23-41 years	9606	Homo sapiens (human)	4374	23-41 year	23-41 year
+6-12 weeks	10000601	Mus musculus HLA-DR1 Tg	4375	6-12 week	6-12 week
+21-66  years	9606	Homo sapiens (human)	4376	21-66  year	21-66  year
+32-47 years	9606	Homo sapiens (human)	4377	32-47 year	32-47 year
+18 to 30 years	9606	Homo sapiens (human)	4378	18 to 30 year	18 to 30 year
+< 5 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4379	< 5 week	< 5 week
+> 9 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4380	> 9 week	> 9 week
+16-56 years	9606	Homo sapiens (human)	4381	16-56 year	16-56 year
+52-78 years	9606	Homo sapiens (human)	4382	52-78 year	52-78 year
+8-12 weeks	10002847	Mus musculus HLA-DPA1*01:03/DPB1*04:01 Tg	4383	8-12 week	8-12 week
+56 to 79 years	9606	Homo sapiens (human)	4384	56 to 79 year	56 to 79 year
+59 to 79 years	9606	Homo sapiens (human)	4385	59 to 79 year	59 to 79 year
+68 to 75 years	9606	Homo sapiens (human)	4386	68 to 75 year	68 to 75 year
+13-77 years	9606	Homo sapiens (human)	4387	13-77 year	13-77 year
+6-33 years	9606	Homo sapiens (human)	4388	6-33 year	6-33 year
+42-65 years	9606	Homo sapiens (human)	4389	42-65 year	42-65 year
+19-58 years	9606	Homo sapiens (human)	4390	19-58 year	19-58 year
+6 to 10 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4391	6 to 10 week	6 to 10 week
+4 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4392	4 week	4 week
+9 weeks	10000187	Sus scrofa Landrace X Large White	4393	9 week	9 week
+59 to 82 years	9606	Homo sapiens (human)	4394	59 to 82 year	59 to 82 year
+7-8 weeks	42414	Sigmodon (cotton rat)	4395	7-8 week	7-8 week
+24 weeks	10000632	Mus musculus NOD	4396	24 week	24 week
+35-48 years	9606	Homo sapiens (human)	4397	35-48 year	35-48 year
+35-59 years	9606	Homo sapiens (human)	4398	35-59 year	35-59 year
+35-49 years	9606	Homo sapiens (human)	4399	35-49 year	35-49 year
+25-45 years	9606	Homo sapiens (human)	4400	25-45 year	25-45 year
+median 66.5 years	9606	Homo sapiens (human)	4401	median 66.5 year	median 66.5 year
+24 to 38 years	9606	Homo sapiens (human)	4402	24 to 38 year	24 to 38 year
+6-8 weeks	10000092	Mus musculus gBT-I TCR Tg	4403	6-8 week	6-8 week
+35-37 years	9606	Homo sapiens (human)	4404	35-37 year	35-37 year
+32-87 years	9606	Homo sapiens (human)	4405	32-87 year	32-87 year
+20 to 59 years	9606	Homo sapiens (human)	4406	20 to 59 year	20 to 59 year
+6 weeks	10000653	Mus musculus Swiss	4407	6 week	6 week
+Mean age of 32.2 years with a range from 18 to 49 years	9606	Homo sapiens (human)	4408	mean age of 32.2 year with a range from 18 to 49 year	mean age of 32.2 year with a range from 18 to 49 year
+46-73 years	9606	Homo sapiens (human)	4409	46-73 year	46-73 year
+46-48 months	9544	Macaca mulatta (rhesus macaque)	4410	46-48 month	46-48 month
+6-10 weeks	10000651	Mus musculus SMARTA TCR Tg	4411	6-10 week	6-10 week
+28-67 years	9606	Homo sapiens (human)	4412	28-67 year	28-67 year
+18 to 61 years	9606	Homo sapiens (human)	4413	18 to 61 year	18 to 61 year
+12 to 13 weeks	10000632	Mus musculus NOD	4414	12 to 13 week	12 to 13 week
+1-54 years	9606	Homo sapiens (human)	4415	1-54 year	1-54 year
+12 to 20 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4416	12 to 20 week	12 to 20 week
+57-60 years	9606	Homo sapiens (human)	4417	57-60 year	57-60 year
+41	9606	Homo sapiens (human)	4418	41	41
+79	9606	Homo sapiens (human)	4419	79	79
+53	9606	Homo sapiens (human)	4420	53	53
+2 to 3 years	10002352	Sus scrofa Babraham	4421	2 to 3 year	2 to 3 year
+4-5 weeks old	10000067	Mus musculus C57BL/6	4422	4-5 week old	4-5 week
+22 to 71 years	9606	Homo sapiens (human)	4423	22 to 71 year	22 to 71 year
+54 to 89 years	9606	Homo sapiens (human)	4424	54 to 89 year	54 to 89 year
+6 weeks	10002328	Mus musculus TCR<sup>mini</sup>	4425	6 week	6 week
+21-90 years	9606	Homo sapiens (human)	4426	21-90 year	21-90 year
+17-59 years	9606	Homo sapiens (human)	4427	17-59 year	17-59 year
+12.5 to 25.6 years	9606	Homo sapiens (human)	4428	12.5 to 25.6 year	12.5 to 25.6 year
+14.2 to 24.2 years	9606	Homo sapiens (human)	4429	14.2 to 24.2 year	14.2 to 24.2 year
+21-64 years	9606	Homo sapiens (human)	4430	21-64 year	21-64 year
+12.4 to 50.8 years	9606	Homo sapiens (human)	4431	12.4 to 50.8 year	12.4 to 50.8 year
+38-65 years	9606	Homo sapiens (human)	4432	38-65 year	38-65 year
+24 to 60 years	9606	Homo sapiens (human)	4433	24 to 60 year	24 to 60 year
+24 to 78 years	9606	Homo sapiens (human)	4434	24 to 78 year	24 to 78 year
+23	9606	Homo sapiens (human)	4435	23	23
+67 years	9606	Homo sapiens (human)	4436	67 year	67 year
+6 to 7 weeks	10000227	Mus musculus OT-1 TCR Tg	4437	6 to 7 week	6 to 7 week
+NULL	10000600	Mus musculus HLA-DR Transgenic	4438	null	null
+58.8 ± 17.4	9606	Homo sapiens (human)	4439	58.8  17.4	58.8  17.4
+43-68 years	9606	Homo sapiens (human)	4440	43-68 year	43-68 year
+22.8 to 58.9 years	9606	Homo sapiens (human)	4441	22.8 to 58.9 year	22.8 to 58.9 year
+11 to 71 years	9606	Homo sapiens (human)	4442	11 to 71 year	11 to 71 year
+NULL	10001476	Mus musculus HA 518-526 TCR Tg	4443	null	null
+62-65 years	9606	Homo sapiens (human)	4444	62-65 year	62-65 year
+65	9606	Homo sapiens (human)	4445	65	65
+21 to 70 years	9606	Homo sapiens (human)	4446	21 to 70 year	21 to 70 year
+24 to 27 years	9606	Homo sapiens (human)	4447	24 to 27 year	24 to 27 year
+18 to 71 years	9606	Homo sapiens (human)	4448	18 to 71 year	18 to 71 year
+46.6 to 63.4 years	9606	Homo sapiens (human)	4449	46.6 to 63.4 year	46.6 to 63.4 year
+43-52 years	9606	Homo sapiens (human)	4450	43-52 year	43-52 year
+29 to 52 years	9606	Homo sapiens (human)	4451	29 to 52 year	29 to 52 year
+3 months- 17 years	9606	Homo sapiens (human)	4452	3 month- 17 year	3 month- 17 year
+1-33 years	9606	Homo sapiens (human)	4453	1-33 year	1-33 year
+26-75 years	9606	Homo sapiens (human)	4454	26-75 year	26-75 year
+4 weeks	10001446	Rattus norvegicus Wistar Kyoto	4455	4 week	4 week
+1.8-3.3 years	9606	Homo sapiens (human)	4456	1.8-3.3 year	1.8-3.3 year
+8-9 weeks	9823	Sus scrofa (pig)	4457	8-9 week	8-9 week
+21-26	9606	Homo sapiens (human)	4458	21-26	21-26
+NULL	10002263	Mus musculus C7 TCR Tg	4459	null	null
+3-5 weeks	10000649	Mus musculus SJL	4460	3-5 week	3-5 week
+32-39 years	9606	Homo sapiens (human)	4461	32-39 year	32-39 year
+51-58 years	9606	Homo sapiens (human)	4462	51-58 year	51-58 year
+10-11 weeks	10000662	Rattus norvegicus Lewis	4463	10-11 week	10-11 week
+18-72 years	9606	Homo sapiens (human)	4464	18-72 year	18-72 year
+32-59 years	9606	Homo sapiens (human)	4465	32-59 year	32-59 year
+63-67 years	9606	Homo sapiens (human)	4466	63-67 year	63-67 year
+21.9 to 29.3 years	9606	Homo sapiens (human)	4467	21.9 to 29.3 year	21.9 to 29.3 year
+24.6 to 44.2 years	9606	Homo sapiens (human)	4468	24.6 to 44.2 year	24.6 to 44.2 year
+21.1 to 43 years	9606	Homo sapiens (human)	4469	21.1 to 43 year	21.1 to 43 year
+9-12 weeks	10000187	Sus scrofa Landrace X Large White	4470	9-12 week	9-12 week
+34 to 70 years	9606	Homo sapiens (human)	4471	34 to 70 year	34 to 70 year
+13-26	9606	Homo sapiens (human)	4472	13-26	13-26
+23-65 years	9606	Homo sapiens (human)	4473	23-65 year	23-65 year
+13-17	9606	Homo sapiens (human)	4474	13-17	13-17
+12 to 14 weeks	10000635	Mus musculus NOD/Lt	4475	12 to 14 week	12 to 14 week
+2 weeks	10000919	Gallus gallus White Leghorn	4476	2 week	2 week
+7 days	10000919	Gallus gallus White Leghorn	4477	7 days	7 days
+18-80 years	9606	Homo sapiens (human)	4478	18-80 year	18-80 year
+6 weeks	10000225	Mus musculus C57BL/6N	4479	6 week	6 week
+35-57 years	9606	Homo sapiens (human)	4480	35-57 year	35-57 year
+22-73 years	9606	Homo sapiens (human)	4481	22-73 year	22-73 year
+17-72 years	9606	Homo sapiens (human)	4482	17-72 year	17-72 year
+60 to 70 years	9606	Homo sapiens (human)	4483	60 to 70 year	60 to 70 year
+34 to 56 years	9606	Homo sapiens (human)	4484	34 to 56 year	34 to 56 year
+9-10 weeks	10000632	Mus musculus NOD	4485	9-10 week	9-10 week
+5 to 19 years	9606	Homo sapiens (human)	4486	5 to 19 year	5 to 19 year
+7 to 35 years	9606	Homo sapiens (human)	4487	7 to 35 year	7 to 35 year
+11 to 72 years	9606	Homo sapiens (human)	4488	11 to 72 year	11 to 72 year
+67	9606	Homo sapiens (human)	4489	67	67
+52	9606	Homo sapiens (human)	4490	52	52
+66	9606	Homo sapiens (human)	4491	66	66
+7 to 8 weeks	10000632	Mus musculus NOD	4492	7 to 8 week	7 to 8 week
+71	9606	Homo sapiens (human)	4493	71	71
+17 weeks	10000105	Mus musculus TRAMP Tg	4494	17 week	17 week
+12 to 13 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4495	12 to 13 week	12 to 13 week
+59-62 years	9606	Homo sapiens (human)	4496	59-62 year	59-62 year
+NULL	10002072	Mus musculus LLO118 TCR Tg	4497	null	null
+> 3 years	9544	Macaca mulatta (rhesus macaque)	4498	> 3 year	> 3 year
+85 years	9606	Homo sapiens (human)	4499	85 year	85 year
+27 to 49 years	9606	Homo sapiens (human)	4500	27 to 49 year	27 to 49 year
+27 to 39 years	9606	Homo sapiens (human)	4501	27 to 39 year	27 to 39 year
+26 to 47 years	9606	Homo sapiens (human)	4502	26 to 47 year	26 to 47 year
+mean 55 years	9606	Homo sapiens (human)	4503	mean 55 year	mean 55 year
+NULL	10002367	Mus musculus C57BL/6 DQ2.5-glia-omega2 TCR transgenic	4504	null	null
+NULL	10002369	Mus musculus C57BL/6 DQ2.5-glia-gamma1 TCR transgenic	4505	null	null
+7-8 weeks	10001546	Mus musculus C57BL/6 HLA transgenic	4506	7-8 week	7-8 week
+21-79 years	9606	Homo sapiens (human)	4507	21-79 year	21-79 year
+30 to 61 years	9606	Homo sapiens (human)	4508	30 to 61 year	30 to 61 year
+22-40 years	9606	Homo sapiens (human)	4509	22-40 year	22-40 year
+12-16 weeks	10000632	Mus musculus NOD	4510	12-16 week	12-16 week
+38 to 72 years	9606	Homo sapiens (human)	4511	38 to 72 year	38 to 72 year
+Mean age = 68 years	9606	Homo sapiens (human)	4512	mean age = 68 year	mean age = 68 year
+3-16 years	9606	Homo sapiens (human)	4513	3-16 year	3-16 year
+30-37 years	9606	Homo sapiens (human)	4514	30-37 year	30-37 year
+26-55 years	9606	Homo sapiens (human)	4515	26-55 year	26-55 year
+5 to 72 years	9606	Homo sapiens (human)	4516	5 to 72 year	5 to 72 year
+15 weeks	10090	Mus musculus (mouse)	4517	15 week	15 week
+9-12 weeks	9825	Sus scrofa domesticus (domestic pig)	4518	9-12 week	9-12 week
+median 58 years	9606	Homo sapiens (human)	4519	median 58 year	median 58 year
+40-42 years	9606	Homo sapiens (human)	4520	40-42 year	40-42 year
+23-80 years	9606	Homo sapiens (human)	4521	23-80 year	23-80 year
+12 to 14 weeks	10001248	Mus musculus NOD.Cg-Tg	4522	12 to 14 week	12 to 14 week
+42.9 to 73.7 years	9606	Homo sapiens (human)	4523	42.9 to 73.7 year	42.9 to 73.7 year
+6-8 weeks	10000952	Mus musculus B6.129P2-B2m tm1Unc/J	4524	6-8 week	6-8 week
+66.6 to 84.6 years	9606	Homo sapiens (human)	4525	66.6 to 84.6 year	66.6 to 84.6 year
+59-78 years	9606	Homo sapiens (human)	4526	59-78 year	59-78 year
+56	9606	Homo sapiens (human)	4527	56	56
+1 day to 40 years	9606	Homo sapiens (human)	4528	1 day to 40 year	1 day to 40 year
+7 to 11 weeks	10000000	Mus musculus BALB/c	4529	7 to 11 week	7 to 11 week
+8 to 68 years	9606	Homo sapiens (human)	4530	8 to 68 year	8 to 68 year
+28-72 years	9606	Homo sapiens (human)	4531	28-72 year	28-72 year
+> 20 weeks	10000632	Mus musculus NOD	4532	> 20 week	> 20 week
+63-92 years	9606	Homo sapiens (human)	4533	63-92 year	63-92 year
+8-10 weeks	10000601	Mus musculus HLA-DR1 Tg	4534	8-10 week	8-10 week
+31-77 years	9606	Homo sapiens (human)	4535	31-77 year	31-77 year
+38-75 years	9606	Homo sapiens (human)	4536	38-75 year	38-75 year
+31-70 years	9606	Homo sapiens (human)	4537	31-70 year	31-70 year
+30-79 years	9606	Homo sapiens (human)	4538	30-79 year	30-79 year
+12-81 years	9606	Homo sapiens (human)	4539	12-81 year	12-81 year
+13-88 years	9606	Homo sapiens (human)	4540	13-88 year	13-88 year
+2 to 4 months	10000017	Mus musculus BALB/c X DBA/2	4541	2 to 4 month	2 to 4 month
+40-80 years	9606	Homo sapiens (human)	4542	40-80 year	40-80 year
+72	9606	Homo sapiens (human)	4543	72	72
+18 to 68 years	9606	Homo sapiens (human)	4544	18 to 68 year	18 to 68 year
+20 to 75 years	9606	Homo sapiens (human)	4545	20 to 75 year	20 to 75 year
+NULL	10002368	Mus musculus C57BL/6 DQ2.5-glia-alpha2 TCR transgenic	4546	null	null
+34-60 years	9606	Homo sapiens (human)	4547	34-60 year	34-60 year
+31 to 53 years	9606	Homo sapiens (human)	4548	31 to 53 year	31 to 53 year
+48.5 to 68.9 years	9606	Homo sapiens (human)	4549	48.5 to 68.9 year	48.5 to 68.9 year
+24-79 years	9606	Homo sapiens (human)	4550	24-79 year	24-79 year
+16 to 55 years	9606	Homo sapiens (human)	4551	16 to 55 year	16 to 55 year
+68 years old	9606	Homo sapiens (human)	4552	68 year old	68 year
+10-17 years	9606	Homo sapiens (human)	4553	10-17 year	10-17 year
+6-16 years	9606	Homo sapiens (human)	4554	6-16 year	6-16 year
+22-91 years	9606	Homo sapiens (human)	4555	22-91 year	22-91 year
+56 to 66	9606	Homo sapiens (human)	4556	56 to 66	56 to 66
+22-71	9606	Homo sapiens (human)	4557	22-71	22-71
+56-66	9606	Homo sapiens (human)	4558	56-66	56-66
+25-81 years	9606	Homo sapiens (human)	4559	25-81 year	25-81 year
+19-68 years	9606	Homo sapiens (human)	4560	19-68 year	19-68 year
+22	9606	Homo sapiens (human)	4561	22	22
+NULL	9031	Gallus gallus (chicken)	4562	null	null
+19-81 years	9606	Homo sapiens (human)	4563	19-81 year	19-81 year
+20-24 weeks	10000067	Mus musculus C57BL/6	4564	20-24 week	20-24 week
+44 to 59 years	9606	Homo sapiens (human)	4565	44 to 59 year	44 to 59 year
+10 -17 years	9606	Homo sapiens (human)	4566	10 -17 year	10 -17 year
+86 years	9606	Homo sapiens (human)	4567	86 year	86 year
+80 years	9606	Homo sapiens (human)	4568	80 year	80 year
+82 years	9606	Homo sapiens (human)	4569	82 year	82 year
+83 years	9606	Homo sapiens (human)	4570	83 year	83 year
+84 years	9606	Homo sapiens (human)	4571	84 year	84 year
+NULL	10002078	Mus musculus HLA-DP2 Tg	4572	null	null
+87 years	9606	Homo sapiens (human)	4573	87 year	87 year
+88 years	9606	Homo sapiens (human)	4574	88 year	88 year
+51-77 years	9606	Homo sapiens (human)	4575	51-77 year	51-77 year
+19-40 years	9606	Homo sapiens (human)	4576	19-40 year	19-40 year
+79 years	9606	Homo sapiens (human)	4577	79 year	79 year
+74	9606	Homo sapiens (human)	4578	74	74
+10 to 18 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4579	10 to 18 week	10 to 18 week
+78 years	9606	Homo sapiens (human)	4580	78 year	78 year
+8-14 weeks	10000610	Mus musculus HLA-DR4 Tg	4581	8-14 week	8-14 week
+69	9606	Homo sapiens (human)	4582	69	69
+69-70	9606	Homo sapiens (human)	4583	69-70	69-70
+56-69	9606	Homo sapiens (human)	4584	56-69	56-69
+7 years	9606	Homo sapiens (human)	4585	7 year	7 year
+70-71	9606	Homo sapiens (human)	4586	70-71	70-71
+42-53 years	9606	Homo sapiens (human)	4587	42-53 year	42-53 year
+78 to 84 years	9606	Homo sapiens (human)	4588	78 to 84 year	78 to 84 year
+40 to 60 years	9606	Homo sapiens (human)	4589	40 to 60 year	40 to 60 year
+29-76 years	9606	Homo sapiens (human)	4590	29-76 year	29-76 year
+NULL	10001720	Mus musculus Influenza A HA TCR Tg	4591	null	null
+9 weeks old	10000000	Mus musculus BALB/c	4592	9 week old	9 week
+NULL	10002848	Mus musculus HLA-DPw4 Tg	4593	null	null
+38-48 years	9606	Homo sapiens (human)	4594	38-48 year	38-48 year
+24-31 years	9606	Homo sapiens (human)	4595	24-31 year	24-31 year
+9 - 12 weeks	10000067	Mus musculus C57BL/6	4596	9 - 12 week	9 - 12 week
+28-69 years	9606	Homo sapiens (human)	4597	28-69 year	28-69 year
+55-77 years	9606	Homo sapiens (human)	4598	55-77 year	55-77 year
+50–81	9606	Homo sapiens (human)	4599	5081	5081
+54 to 85 years	9606	Homo sapiens (human)	4600	54 to 85 year	54 to 85 year
+27-69 years	9606	Homo sapiens (human)	4601	27-69 year	27-69 year
+44-50 years	9606	Homo sapiens (human)	4602	44-50 year	44-50 year
+40-54 years	9606	Homo sapiens (human)	4603	40-54 year	40-54 year
+5 weeks	10000187	Sus scrofa Landrace X Large White	4604	5 week	5 week
+42-70 years	9606	Homo sapiens (human)	4605	42-70 year	42-70 year
+43-50 years	9606	Homo sapiens (human)	4606	43-50 year	43-50 year
+37-54 years	9606	Homo sapiens (human)	4607	37-54 year	37-54 year
+3.3 -54 years	9606	Homo sapiens (human)	4608	3.3 -54 year	3.3 -54 year
+NULL	10002400	Mus musculus HLA-DRB1*15:03 Tg	4609	null	null
+8.4-27.3 years	9606	Homo sapiens (human)	4610	8.4-27.3 year	8.4-27.3 year
+40-50 years	9606	Homo sapiens (human)	4611	40-50 year	40-50 year
+30-80 years	9606	Homo sapiens (human)	4612	30-80 year	30-80 year
+20-90 years	9606	Homo sapiens (human)	4613	20-90 year	20-90 year
+30-90 years	9606	Homo sapiens (human)	4614	30-90 year	30-90 year
+20-80 years	9606	Homo sapiens (human)	4615	20-80 year	20-80 year
+30-40 years	9606	Homo sapiens (human)	4616	30-40 year	30-40 year
+70-80 years	9606	Homo sapiens (human)	4617	70-80 year	70-80 year
+24-27 years	9606	Homo sapiens (human)	4618	24-27 year	24-27 year
+20.6-50.1 years	9606	Homo sapiens (human)	4619	20.6-50.1 year	20.6-50.1 year
+29 to 82 years	9606	Homo sapiens (human)	4620	29 to 82 year	29 to 82 year
+4 to 6 weeks old	10000576	Mus musculus HLA-A*02:01 Tg	4621	4 to 6 week old	4 to 6 week
+23- 51 years	9606	Homo sapiens (human)	4622	23- 51 year	23- 51 year
+24 -49 years	9606	Homo sapiens (human)	4623	24 -49 year	24 -49 year
+2-32 years	9606	Homo sapiens (human)	4624	2-32 year	2-32 year
+26-40 years	9606	Homo sapiens (human)	4625	26-40 year	26-40 year
+20-48 years	9606	Homo sapiens (human)	4626	20-48 year	20-48 year
+19- 53 years	9606	Homo sapiens (human)	4627	19- 53 year	19- 53 year
+52-75 years	9606	Homo sapiens (human)	4628	52-75 year	52-75 year
+24-59 years	9606	Homo sapiens (human)	4629	24-59 year	24-59 year
+6-12 weeks	10001166	Mus musculus HLA-A24 Tg	4630	6-12 week	6-12 week
+8 -10 weeks	10000000	Mus musculus BALB/c	4631	8 -10 week	8 -10 week
+12 weeks	10002839	Mus musculus HLA-B*57:01 Tg	4632	12 week	12 week
+8-10 weeks	10000019	Mus musculus BALB/cByJ	4633	8-10 week	8-10 week
+54–77	9606	Homo sapiens (human)	4634	5477	5477
+21-50 years	9606	Homo sapiens (human)	4635	21-50 year	21-50 year
+< 45 years	9606	Homo sapiens (human)	4636	< 45 year	< 45 year
+41-70 years	9606	Homo sapiens (human)	4637	41-70 year	41-70 year
+19-67 years	9606	Homo sapiens (human)	4638	19-67 year	19-67 year
+37 to 90 years	9606	Homo sapiens (human)	4639	37 to 90 year	37 to 90 year
+NULL	10002352	Sus scrofa Babraham	4640	null	null
+5.5 weeks	10002352	Sus scrofa Babraham	4641	5.5 week	5.5 week
+60-74	9606	Homo sapiens (human)	4642	60-74	60-74
+8-10 weeks	10000978	Mus musculus C57BL/6 X BALB/cByJ	4643	8-10 week	8-10 week
+66-73	9606	Homo sapiens (human)	4644	66-73	66-73
+58-84 years	9606	Homo sapiens (human)	4645	58-84 year	58-84 year
+50-76 years	9606	Homo sapiens (human)	4646	50-76 year	50-76 year
+54-78 years	9606	Homo sapiens (human)	4647	54-78 year	54-78 year
+41-56 years	9606	Homo sapiens (human)	4648	41-56 year	41-56 year
+8 - 12 weeks	10001381	Mus musculus HLA-DRB1*15:01 Tg	4649	8 - 12 week	8 - 12 week
+6-13 years	9606	Homo sapiens (human)	4650	6-13 year	6-13 year
+over 12 weeks	10000632	Mus musculus NOD	4651	over 12 week	over 12 week
+51-80 years	9606	Homo sapiens (human)	4652	51-80 year	51-80 year
+51 to 83 years	9606	Homo sapiens (human)	4653	51 to 83 year	51 to 83 year
+30-45 years	9606	Homo sapiens (human)	4654	30-45 year	30-45 year
+12 weeks	10001399	Mus musculus HLA-DQB1*06:02 Tg	4655	12 week	12 week
+19-28 years	9606	Homo sapiens (human)	4656	19-28 year	19-28 year
+7-8 months	9913	Bos taurus (bovine)	4657	7-8 month	7-8 month
+24-95 years	9606	Homo sapiens (human)	4658	24-95 year	24-95 year
+60+ years	9606	Homo sapiens (human)	4659	60+ year	60+ year
+20- 54 years	9606	Homo sapiens (human)	4660	20- 54 year	20- 54 year
+20-53 years	9606	Homo sapiens (human)	4661	20-53 year	20-53 year
+25- 49 years	9606	Homo sapiens (human)	4662	25- 49 year	25- 49 year
+25- 54 years	9606	Homo sapiens (human)	4663	25- 54 year	25- 54 year
+25- 27 years	9606	Homo sapiens (human)	4664	25- 27 year	25- 27 year
+19-73 years	9606	Homo sapiens (human)	4665	19-73 year	19-73 year
+9-12 weeks	10000653	Mus musculus Swiss	4666	9-12 week	9-12 week
+7 months to 44 years	9606	Homo sapiens (human)	4667	7 month to 44 year	7 month to 44 year
+14 to 72 years	9606	Homo sapiens (human)	4668	14 to 72 year	14 to 72 year
+6 to 74 years	9606	Homo sapiens (human)	4669	6 to 74 year	6 to 74 year
+28 to 65 years	9606	Homo sapiens (human)	4670	28 to 65 year	28 to 65 year
+18 to 62 years	9606	Homo sapiens (human)	4671	18 to 62 year	18 to 62 year
+6-10 weeks	10000582	Mus musculus HLA-A2 Tg	4672	6-10 week	6-10 week
+6-12 Weeks	10001782	Mus musculus HLA-B*07:02 Tg	4673	6-12 week	6-12 week
+57-74 years	9606	Homo sapiens (human)	4674	57-74 year	57-74 year
+5-8 weeks	10000582	Mus musculus HLA-A2 Tg	4675	5-8 week	5-8 week
+17 weeks	10000649	Mus musculus SJL	4676	17 week	17 week
+4-8 months	246437	Tupaia chinensis (Chinese tree shrew)	4677	4-8 month	4-8 month
+2 days old	10002232	Mus musculus BDC2.5 TCR Tg	4678	2 days old	2 days old
+6 to 10 week-old	10000610	Mus musculus HLA-DR4 Tg	4679	6 to 10 week-old	6 to 10 week
+15-23 years	9606	Homo sapiens (human)	4680	15-23 year	15-23 year
+45 to 82 years	9606	Homo sapiens (human)	4681	45 to 82 year	45 to 82 year
+49-77 years	9606	Homo sapiens (human)	4682	49-77 year	49-77 year
+21- 75 years	9606	Homo sapiens (human)	4683	21- 75 year	21- 75 year
+> 24 weeks	10000105	Mus musculus TRAMP Tg	4684	> 24 week	> 24 week
+five week old	10000067	Mus musculus C57BL/6	4685	5 week old	5 week
+5 to 12 weeks	10000067	Mus musculus C57BL/6	4686	5 to 12 week	5 to 12 week
+6-8 Weeks	10001217	Mus musculus pmel-1 TCR Tg	4687	6-8 week	6-8 week
+27-68 years	9606	Homo sapiens (human)	4688	27-68 year	27-68 year
+7-8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	4689	7-8 week	7-8 week
+63-68 years	9606	Homo sapiens (human)	4690	63-68 year	63-68 year
+54-57 years	9606	Homo sapiens (human)	4691	54-57 year	54-57 year
+21-58 years	9606	Homo sapiens (human)	4692	21-58 year	21-58 year
+53-81 years	9606	Homo sapiens (human)	4693	53-81 year	53-81 year
+50 days	10002503	Sus scrofa Duroc X Large White X Landrace	4694	50 days	50 days
+18-26 years	9606	Homo sapiens (human)	4695	18-26 year	18-26 year
+23-53 years	9606	Homo sapiens (human)	4696	23-53 year	23-53 year
+37-47 years	9606	Homo sapiens (human)	4697	37-47 year	37-47 year
+27-48 years	9606	Homo sapiens (human)	4698	27-48 year	27-48 year
+22- 66 years	9606	Homo sapiens (human)	4699	22- 66 year	22- 66 year
+18 to 75 years	9606	Homo sapiens (human)	4700	18 to 75 year	18 to 75 year
+58-90 years	9606	Homo sapiens (human)	4701	58-90 year	58-90 year
+33-68 years	9606	Homo sapiens (human)	4702	33-68 year	33-68 year
+46-84 years	9606	Homo sapiens (human)	4703	46-84 year	46-84 year
+41-75 years	9606	Homo sapiens (human)	4704	41-75 year	41-75 year
+59-76 years	9606	Homo sapiens (human)	4705	59-76 year	59-76 year
+1 day	10001436	Gallus gallus P2a	4706	1 day	1 day
+1 day	10002711	Gallus gallus line N	4707	1 day	1 day
+67-75 years	9606	Homo sapiens (human)	4708	67-75 year	67-75 year
+25 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4709	25 week	25 week
+23- 70 years	9606	Homo sapiens (human)	4710	23- 70 year	23- 70 year
+22- 67 years	9606	Homo sapiens (human)	4711	22- 67 year	22- 67 year
+58-81 years	9606	Homo sapiens (human)	4712	58-81 year	58-81 year
+30-57 years	9606	Homo sapiens (human)	4713	30-57 year	30-57 year
+mean 58 years	9606	Homo sapiens (human)	4714	mean 58 year	mean 58 year
+14 months	10000000	Mus musculus BALB/c	4715	14 month	14 month
+10-15 weeks	10000632	Mus musculus NOD	4716	10-15 week	10-15 week
+23-39 years	9606	Homo sapiens (human)	4717	23-39 year	23-39 year
+30-59 years	9606	Homo sapiens (human)	4718	30-59 year	30-59 year
+20-51 years	9606	Homo sapiens (human)	4719	20-51 year	20-51 year
+7 days	8839	Anas platyrhynchos (duck)	4720	7 days	7 days
+mean 39.7 years	9606	Homo sapiens (human)	4721	mean 39.7 year	mean 39.7 year
+44 to 81 years	9606	Homo sapiens (human)	4722	44 to 81 year	44 to 81 year
+40–74 years	9606	Homo sapiens (human)	4723	4074 year	4074 year
+5-8 weeks	10002763	Mus musculus HLA-A*11:01 Tg	4724	5-8 week	5-8 week
+6 weeks	10000105	Mus musculus TRAMP Tg	4725	6 week	6 week
+37-65 years	9606	Homo sapiens (human)	4726	37-65 year	37-65 year
+NULL	9825	Sus scrofa domesticus (domestic pig)	4727	null	null
+68	9606	Homo sapiens (human)	4728	68	68
+2 day old	10002232	Mus musculus BDC2.5 TCR Tg	4729	2 day old	2 day
+4-5  weeks	10000576	Mus musculus HLA-A*02:01 Tg	4730	4-5  week	4-5  week
+1 day old	10000632	Mus musculus NOD	4731	1 day old	1 day
+32-82 years	9606	Homo sapiens (human)	4732	32-82 year	32-82 year
+>50 years	9606	Homo sapiens (human)	4733	>50 year	>50 year
+33 to 55 years	9606	Homo sapiens (human)	4734	33 to 55 year	33 to 55 year
+40 to 55 years	9606	Homo sapiens (human)	4735	40 to 55 year	40 to 55 year
+21-82 years	9606	Homo sapiens (human)	4736	21-82 year	21-82 year
+23-95 years	9606	Homo sapiens (human)	4737	23-95 year	23-95 year
+5-8 weeks	10002764	Mus musculus HLA-B*44:01 Tg	4738	5-8 week	5-8 week
+7 -8 weeks	10000601	Mus musculus HLA-DR1 Tg	4739	7 -8 week	7 -8 week
+24 to 65 years	9606	Homo sapiens (human)	4740	24 to 65 year	24 to 65 year
+48-80 years	9606	Homo sapiens (human)	4741	48-80 year	48-80 year
+10-15 weeks	10000067	Mus musculus C57BL/6	4742	10-15 week	10-15 week
+8.4	9606	Homo sapiens (human)	4743	8.4	8.4
+46-72 years	9606	Homo sapiens (human)	4744	46-72 year	46-72 year
+4 - 6 weeks	10000000	Mus musculus BALB/c	4745	4 - 6 week	4 - 6 week
+2 years	9606	Homo sapiens (human)	4746	2 year	2 year
+18-40 years old	9606	Homo sapiens (human)	4747	18-40 year old	18-40 year
+mean 29.7 years	9606	Homo sapiens (human)	4748	mean 29.7 year	mean 29.7 year
+43- 79 years	9606	Homo sapiens (human)	4749	43- 79 year	43- 79 year
+5-8 weeks	10001166	Mus musculus HLA-A24 Tg	4750	5-8 week	5-8 week
+6-20 weeks	10001166	Mus musculus HLA-A24 Tg	4751	6-20 week	6-20 week
+6-20 weeks	10000582	Mus musculus HLA-A2 Tg	4752	6-20 week	6-20 week
+6-20 weeks	10001782	Mus musculus HLA-B*07:02 Tg	4753	6-20 week	6-20 week
+mean 18.75 years	9606	Homo sapiens (human)	4754	mean 18.75 year	mean 18.75 year
+6-20 weeks	10001237	Mus musculus HLA-B*35:01 Tg	4755	6-20 week	6-20 week
+60-75 years	9606	Homo sapiens (human)	4756	60-75 year	60-75 year
+50-96 years	9606	Homo sapiens (human)	4757	50-96 year	50-96 year
+42 to 58 years	9606	Homo sapiens (human)	4758	42 to 58 year	42 to 58 year
+66 to 77 years	9606	Homo sapiens (human)	4759	66 to 77 year	66 to 77 year
+58 to 67 years	9606	Homo sapiens (human)	4760	58 to 67 year	58 to 67 year
+56 to 81 years	9606	Homo sapiens (human)	4761	56 to 81 year	56 to 81 year
+33-74 years	9606	Homo sapiens (human)	4762	33-74 year	33-74 year
+7-8 weeks	10000601	Mus musculus HLA-DR1 Tg	4763	7-8 week	7-8 week
+48- 74 years	9606	Homo sapiens (human)	4764	48- 74 year	48- 74 year
+1 month	9823	Sus scrofa (pig)	4765	1 month	1 month
+23-40 years	9606	Homo sapiens (human)	4766	23-40 year	23-40 year
+83-86	9606	Homo sapiens (human)	4767	83-86	83-86
+23 to 39 years	9606	Homo sapiens (human)	4768	23 to 39 year	23 to 39 year
+NULL	10002819	Rattus norvegicus HLA-B27 Tg	4769	null	null
+6-8 weels	10000000	Mus musculus BALB/c	4770	6-8 week	6-8 week
+9 years	9606	Homo sapiens (human)	4771	9 year	9 year
+4-18+ years	9606	Homo sapiens (human)	4772	4-18+ year	4-18+ year
+23 to 26 years	9606	Homo sapiens (human)	4773	23 to 26 year	23 to 26 year
+83	9606	Homo sapiens (human)	4774	83	83
+19- 95 years	9606	Homo sapiens (human)	4775	19- 95 year	19- 95 year
+55 years (mean)	9606	Homo sapiens (human)	4776	55 year (mean)	55 year (mean)
+6 to 8 weeks	10001217	Mus musculus pmel-1 TCR Tg	4777	6 to 8 week	6 to 8 week
+31 to 59 years	9606	Homo sapiens (human)	4778	31 to 59 year	31 to 59 year
+5 weeks	9823	Sus scrofa (pig)	4779	5 week	5 week
+8 to 12 weeks	10002848	Mus musculus HLA-DPw4 Tg	4780	8 to 12 week	8 to 12 week
+4-5  weeks	10002763	Mus musculus HLA-A*11:01 Tg	4781	4-5  week	4-5  week
+44 to 74 years	9606	Homo sapiens (human)	4782	44 to 74 year	44 to 74 year
+8 to 12 weeks	10000610	Mus musculus HLA-DR4 Tg	4783	8 to 12 week	8 to 12 week
+NULL	10002843	Mus musculus HLA-DRA*01:01/DRB1*15:01 Tg	4784	null	null
+24-70 years	9606	Homo sapiens (human)	4785	24-70 year	24-70 year
+50-70 years	9606	Homo sapiens (human)	4786	50-70 year	50-70 year
+5 days	9823	Sus scrofa (pig)	4787	5 days	5 days
+40-49 years	9606	Homo sapiens (human)	4788	40-49 year	40-49 year
+NULL	10002279	mus musculus VelocImmune	4789	null	null
+40-81 years	9606	Homo sapiens (human)	4790	40-81 year	40-81 year
+24 to 75 years	9606	Homo sapiens (human)	4791	24 to 75 year	24 to 75 year
+35- 70 years	9606	Homo sapiens (human)	4792	35- 70 year	35- 70 year
+54-79 years	9606	Homo sapiens (human)	4793	54-79 year	54-79 year
+29 to 65 years	9606	Homo sapiens (human)	4794	29 to 65 year	29 to 65 year
+30 to 67 years	9606	Homo sapiens (human)	4795	30 to 67 year	30 to 67 year
+8 to 9 weeks	10000067	Mus musculus C57BL/6	4796	8 to 9 week	8 to 9 week
+mean 56 years	9606	Homo sapiens (human)	4797	mean 56 year	mean 56 year
+32-66 years	9606	Homo sapiens (human)	4798	32-66 year	32-66 year
+49-88 years	9606	Homo sapiens (human)	4799	49-88 year	49-88 year
+24 - 46 years	9606	Homo sapiens (human)	4800	24 - 46 year	24 - 46 year
+47-88 years	9606	Homo sapiens (human)	4801	47-88 year	47-88 year
+8 week old	10000610	Mus musculus HLA-DR4 Tg	4802	8 week old	8 week
+30-39 years	9606	Homo sapiens (human)	4803	30-39 year	30-39 year
+59 to 64 years	9606	Homo sapiens (human)	4804	59 to 64 year	59 to 64 year
+NULL	10002292	Mus musculus BoyJ	4805	null	null
+30 to 79 years	9606	Homo sapiens (human)	4806	30 to 79 year	30 to 79 year
+65-70 years	9606	Homo sapiens (human)	4807	65-70 year	65-70 year
+57 years	9606	Homo sapiens	4808	57 year	57 year
+43 years	9606	Homo sapiens	4809	43 year	43 year
+28-64 years	9606	Homo sapiens (human)	4810	28-64 year	28-64 year
+27-75 years	9606	Homo sapiens (human)	4811	27-75 year	27-75 year
+53 years	9606	Homo sapiens	4812	53 year	53 year
+NULL	10001625	Mus musculus BALB/c HA(110-120)-specific TCR Tg/ Flu  HA Tg	4813	null	null
+37-90 years	9606	Homo sapiens (human)	4814	37-90 year	37-90 year
+51 to 84 years	9606	Homo sapiens (human)	4815	51 to 84 year	51 to 84 year
+55 to 87 years	9606	Homo sapiens (human)	4816	55 to 87 year	55 to 87 year
+31 to 83 years	9606	Homo sapiens (human)	4817	31 to 83 year	31 to 83 year
+41-86 years	9606	Homo sapiens (human)	4818	41-86 year	41-86 year
+7-12 weeks	10000576	Mus musculus HLA-A*02:01 Tg	4819	7-12 week	7-12 week
+NULL	10002847	Mus musculus HLA-DPA1*01:03/DPB1*04:01 Tg	4820	null	null
+16-21 years	9606	Homo sapiens (human)	4821	16-21 year	16-21 year
+44 to 66 years	9606	Homo sapiens (human)	4822	44 to 66 year	44 to 66 year
+45-82 years	9606	Homo sapiens (human)	4823	45-82 year	45-82 year
+37- 88 years	9606	Homo sapiens (human)	4824	37- 88 year	37- 88 year
+30-85 years	9606	Homo sapiens (human)	4825	30-85 year	30-85 year
+51-85 years	9606	Homo sapiens (human)	4826	51-85 year	51-85 year
+1-75 years	9606	Homo sapiens (human)	4827	1-75 year	1-75 year
+6-8 week-old	10000047	Mus musculus C57BL/10	4828	6-8 week-old	6-8 week
+NULL	10000207	Oryctolagus cuniculus Sandy Half-Lop	4829	null	null
+1-5 years old	9606	Homo sapiens (human)	4830	1-5 year old	1-5 year
+average age 54	9606	Homo sapiens (human)	4831	average age 54	average age 54
+16-Feb	9606	Homo sapiens (human)	4832	16-feb	16-feb
+7-9 wks	10000649	Mus musculus SJL	4833	7-9 week	7-9 week
+4-10 weeks	447135	Myodes glareolus (bank vole)	4834	4-10 week	4-10 week
+2-3 weeks	9823	Sus scrofa (pig)	4835	2-3 week	2-3 week
+90 days	10000000	Mus musculus BALB/c	4836	90 days	90 days
+6-12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	4837	6-12 week	6-12 week
+4-10 weeks	10000263	Mus musculus B10.BR	4838	4-10 week	4-10 week
+14 and younger	9606	Homo sapiens (human)	4839	14 and younger	14 and younger
+2-6 years	9606	Homo sapiens (human)	4840	2-6 year	2-6 year
+8-10 weeks	9823	Sus scrofa (pig)	4841	8-10 week	8-10 week
+12-24 month old	10000193	Bos taurus Holstein	4842	12-24 month old	12-24 month
+Ponies	9796	Equus caballus (domestic horse)	4843	ponies	ponies
+1-84 years old	9606	Homo sapiens (human)	4844	1-84 year old	1-84 year
+6 months	10000203	Oryctolagus cuniculus Groot Chinchilla	4845	6 month	6 month
+1-17 years	9606	Homo sapiens (human)	4846	1-17 year	1-17 year
+4-6 weeks	10000647	Mus musculus Quackenbush	4847	4-6 week	4-6 week
+NULL	10001673	Homo sapiens Australian Aboriginal	4848	null	null
+4 to 7 week-old	10000000	Mus musculus BALB/c	4849	4 to 7 week-old	4 to 7 week
+8 wekks-old	10000000	Mus musculus BALB/c	4850	8 week-old	8 week
+NULL	447135	Myodes glareolus (bank vole)	4851	null	null
+4-8-week-old	10000253	Mus musculus A/J	4852	4-8-week-old	4-8 week
+2-month-old	10000201	Oryctolagus cuniculus Fauve de Bourgogne	4853	2-month-old	2 month
+4-10 weeks	10000051	Mus musculus C57BL/10 X DBA/2	4854	4-10 week	4-10 week
+7-9 wks	10000000	Mus musculus BALB/c	4855	7-9 week	7-9 week
+More than 15 years	9606	Homo sapiens (human)	4856	more than 15 year	more than 15 year
+20-31 years	9606	Homo sapiens (human)	4857	20-31 year	20-31 year
+4-10 weeks old	447135	Myodes glareolus (bank vole)	4858	4-10 week old	4-10 week
+6 weeks old	10000206	Oryctolagus cuniculus New Zealand White	4859	6 week old	6 week
+5-6 weeks-old	10000000	Mus musculus BALB/c	4860	5-6 week-old	5-6 week
+2-4 years-old	9544	Macaca mulatta (rhesus macaque)	4861	2-4 year-old	2-4 year
+Adutls	9606	Homo sapiens (human)	4862	adults	adults
+3 weeks old	10000920	Gallus gallus Leghorn	4863	3 week old	3 week
+6-7 weeks-old	10000000	Mus musculus BALB/c	4864	6-7 week-old	6-7 week
+One week	10000654	Mus musculus Swiss albino	4865	1 week	1 week
+6-7-week-old	10000000	Mus musculus BALB/c	4866	6-7-week-old	6-7 week
+6 month	10000206	Oryctolagus cuniculus New Zealand White	4867	6 month	6 month
+28-92 years	9606	Homo sapiens (human)	4868	28-92 year	28-92 year
+6-8 weeks-old	10000038	Mus musculus C3H/He	4869	6-8 week-old	6-8 week
+2-day to 6-week old	10000000	Mus musculus BALB/c	4870	2-day to 6-week old	2 day to 6 week
+8-12 weeks old	10000263	Mus musculus B10.BR	4871	8-12 week old	8-12 week
+NULL	10000630	Mus musculus NHI Swiss	4872	null	null
+3 days	8839	Anas platyrhynchos (duck)	4873	3 days	3 days
+6-7 wks	10090	Mus musculus (mouse)	4874	6-7 week	6-7 week
+NULL	10000200	Oryctolagus cuniculus Chinchilla	4875	null	null
+6-24 mo of age	9606	Homo sapiens (human)	4876	6-24 month of age	6-24 month of age
+Adults	10000119	Homo sapiens Caucasian	4877	adults	adults
+7 weeks old	10000028	Mus musculus C3H	4878	7 week old	7 week
+6-7 weeks	10000647	Mus musculus Quackenbush	4879	6-7 week	6-7 week
+6-8 weeks	10000023	Mus musculus BDF1	4880	6-8 week	6-8 week
+4-6 weeks	10000216	Mus musculus C57BL/6 X BALB/c	4881	4-6 week	4-6 week
+NULL	10000023	Mus musculus BDF1	4882	null	null
+NULL	9505	Aotus trivirgatus (night monkey)	4883	null	null
+3 month old	9986	Oryctolagus cuniculus (rabbit)	4884	3 month old	3 month
+8-10 wo	10000000	Mus musculus BALB/c	4885	8-10 week	8-10 week
+5-7 months old	10000206	Oryctolagus cuniculus New Zealand White	4886	5-7 month old	5-7 month
+5 weeks	10000618	Mus musculus ICR	4887	5 week	5 week
+8-16 week	10000067	Mus musculus C57BL/6	4888	8-16 week	8-16 week
+6-10 weeks-old	10000019	Mus musculus BALB/cByJ	4889	6-10 week-old	6-10 week
+3.5-15 years	9606	Homo sapiens (human)	4890	3.5-15 year	3.5-15 year
+NULL	10000186	Mustela vison Black	4891	null	null
+0-12 months	9606	Homo sapiens (human)	4892	0-12 month	0-12 month
+6-8 months	9915	Bos indicus (Indicine cattle)	4893	6-8 month	6-8 month
+56.3 +/- 12.8 years	9606	Homo sapiens (human)	4894	56.3 ± 12.8 year	56.3 ± 12.8 year
+6 - 8 mo	9913	Bos taurus (bovine)	4895	6 - 8 month	6 - 8 month
+6-15 weeks	10090	Mus musculus (mouse)	4896	6-15 week	6-15 week
+9 weeks	8839	Anas platyrhynchos (duck)	4897	9 week	9 week
+6-8 weeks old	10000271	Mus musculus B10.M	4898	6-8 week old	6-8 week
+5-8 weeks	10000187	Sus scrofa Landrace X Large White	4899	5-8 week	5-8 week
+10 to 65 years	9606	Homo sapiens (human)	4900	10 to 65 year	10 to 65 year
+2 to >20 years	9606	Homo sapiens (human)	4901	2 to >20 year	2 to >20 year
+22-41 years	9606	Homo sapiens (human)	4902	22-41 year	22-41 year
+53-63 years	9606	Homo sapiens (human)	4903	53-63 year	53-63 year
+6 months old	10000206	Oryctolagus cuniculus New Zealand White	4904	6 month old	6 month
+8 weeks old	10000209	Mesocricetus auratus HsdHan:Aura	4905	8 week old	8 week
+4 to 70 years old	9606	Homo sapiens (human)	4906	4 to 70 year old	4 to 70 year
+1 to 6 years	9606	Homo sapiens (human)	4907	1 to 6 year	1 to 6 year
+NULL	9844	Lama glama (llama)	4908	null	null
+15-72	9606	Homo sapiens (human)	4909	15-72	15-72
+12-44 years	9606	Homo sapiens (human)	4910	12-44 year	12-44 year
+25-43 years	9606	Homo sapiens (human)	4911	25-43 year	25-43 year
+adult	10000206	Oryctolagus cuniculus New Zealand White	4912	adult	adult
+NULL	10000197	Oryctolagus cuniculus albino	4913	null	null
+14-85 years	9606	Homo sapiens (human)	4914	14-85 year	14-85 year
+12 weeks	9823	Sus scrofa (pig)	4915	12 week	12 week
+NULL	10114	Rattus (rat)	4916	null	null
+4 to 45 years-old	9606	Homo sapiens (human)	4917	4 to 45 year-old	4 to 45 year
+4-60 years old	9606	Homo sapiens (human)	4918	4-60 year old	4-60 year
+6 to 24 months	10000195	Capra hircus Saanen	4919	6 to 24 month	6 to 24 month
+NULL	10000657	Mus musculus Xenomouse	4920	null	null
+6 weeks	9823	Sus scrofa (pig)	4921	6 week	6 week
+8 to 9 weeks	10000000	Mus musculus BALB/c	4922	8 to 9 week	8 to 9 week
+16-70 years	9606	Homo sapiens (human)	4923	16-70 year	16-70 year
+12 weeks	10141	Cavia porcellus (guinea pig)	4924	12 week	12 week
+17-81 years	9606	Homo sapiens (human)	4925	17-81 year	17-81 year
+12-54 years	9606	Homo sapiens (human)	4926	12-54 year	12-54 year
+4 weeks	9031	Gallus gallus (chicken)	4927	4 week	4 week
+8-9 weeks	10000047	Mus musculus C57BL/10	4928	8-9 week	8-9 week
+NULL	10000920	Gallus gallus Leghorn	4929	null	null
+2 months	10000024	Mus musculus Biozzi	4930	2 month	2 month
+4 month old	9685	Felis catus (cat)	4931	4 month old	4 month
+35-40 days	10000669	Cavia porcellus Hartley	4932	35-40 days	35-40 days
+5 weeks old	10000662	Rattus norvegicus Lewis	4933	5 week old	5 week
+22 wk	10000639	Mus musculus NZB	4934	22 week	22 week
+608 weeks	10000000	Mus musculus BALB/c	4935	608 week	608 week
+NULL	10001151	Oryctolagus cuniculus Chinchilla Bastard	4936	null	null
+14-57	9606	Homo sapiens (human)	4937	14-57	14-57
+NULL	10000239	Mus musculus CF-1 X BALB/c	4938	null	null
+NULL	10001117	Oryctolagus cuniculus Blanc de Bouscat	4939	null	null
+17-42 years-old	9606	Homo sapiens (human)	4940	17-42 year-old	17-42 year
+NULL	74940	Oncorhynchus tshawytscha (king salmon)	4941	null	null
+6 weeks	10000919	Gallus gallus White Leghorn	4942	6 week	6 week
+6 weeks old	10000228	Mus musculus CBA	4943	6 week old	6 week
+2-65 years-old	9606	Homo sapiens (human)	4944	2-65 year-old	2-65 year
+43 days	10000667	Rattus norvegicus Sprague-Dawley	4945	43 days	43 days
+3-4 weeks	10000618	Mus musculus ICR	4946	3-4 week	3-4 week
+8-16 week	10000051	Mus musculus C57BL/10 X DBA/2	4947	8-16 week	8-16 week
+6 week-old	10000000	Mus musculus BALB/c	4948	6 week-old	6 week
+4-6 months	9669	Mustela putorius furo (black ferret)	4949	4-6 month	4-6 month
+6 weeks	10114	Rattus (rat)	4950	6 week	6 week
+6-12 months	9940	Ovis aries (domestic sheep)	4951	6-12 month	6-12 month
+6 weeks	10000019	Mus musculus BALB/cByJ	4952	6 week	6 week
+Adult	10000019	Mus musculus BALB/cByJ	4953	adult	adult
+NULL	10000204	Oryctolagus cuniculus Japanese white	4954	null	null
+NULL	10000093	Mus musculus C57BL/6 human IgCkappa Tg	4955	null	null
+NULL	34839	Chinchilla lanigera (long-tailed chinchilla)	4956	null	null
+8-week old	10000000	Mus musculus BALB/c	4957	8-week old	8 week
+45 day	10116	Rattus norvegicus (brown rat)	4958	45 day	45 day
+10 weeks	9031	Gallus gallus (chicken)	4959	10 week	10 week
+45 to 55 years	9606	Homo sapiens (human)	4960	45 to 55 year	45 to 55 year
+7-10 years	9606	Homo sapiens (human)	4961	7-10 year	7-10 year
+NULL	10000647	Mus musculus Quackenbush	4962	null	null
+12 weeks	10000617	Mus musculus HuMAb (Medarex)	4963	12 week	12 week
+8-74 years	9606	Homo sapiens (human)	4964	8-74 year	8-74 year
+3 months to 7 years	9606	Homo sapiens (human)	4965	3 month to 7 year	3 month to 7 year
+12 to 55 years	9606	Homo sapiens (human)	4966	12 to 55 year	12 to 55 year
+NULL	10000026	Mus musculus BP2	4967	null	null
+8-9-weeks-old	10000629	Mus musculus ND4 Swiss Webster	4968	8-9-week-old	8-9 week
+3 months	10000631	Mus musculus NMRI	4969	3 month	3 month
+18 to 66 years	9606	Homo sapiens (human)	4970	18 to 66 year	18 to 66 year
+up to 12 weeks old	10000047	Mus musculus C57BL/10	4971	up to 12 week old	up to 12 week
+36-55	9606	Homo sapiens (human)	4972	36-55	36-55
+5-6 weeks	10000655	Mus musculus Swiss Webster	4973	5-6 week	5-6 week
+4 months	10000206	Oryctolagus cuniculus New Zealand White	4974	4 month	4 month
+Younger than 35 years	9606	Homo sapiens (human)	4975	younger than 35 year	younger than 35 year
+8 weeks-old	10090	Mus musculus (mouse)	4976	8 week-old	8 week
+NULL	10000248	Mus musculus 129 GIX+	4977	null	null
+45 days	10116	Rattus norvegicus (brown rat)	4978	45 days	45 days
+8 to 12-week-old	10000067	Mus musculus C57BL/6	4979	8 to 12-week-old	8 to 12 week
+18-20 years-old	9606	Homo sapiens (human)	4980	18-20 year-old	18-20 year
+6-8 weeks	10001998	Mus musculus CD1	4981	6-8 week	6-8 week
+3 weeks	10000187	Sus scrofa Landrace X Large White	4982	3 week	3 week
+Adult	34839	Chinchilla lanigera (long-tailed chinchilla)	4983	adult	adult
+3 months	9823	Sus scrofa (pig)	4984	3 month	3 month
+5-8 weeks	10000653	Mus musculus Swiss	4985	5-8 week	5-8 week
+8-10 weeks old	10000655	Mus musculus Swiss Webster	4986	8-10 week old	8-10 week
+NULL	45352	Morone chrysops x Morone saxatilis (white bass x striped sea-bass)	4987	null	null
+6 - 9 months	9913	Bos taurus (bovine)	4988	6 - 9 month	6 - 9 month
+6-9 months	9913	Bos taurus (bovine)	4989	6-9 month	6-9 month
+NULL	10001756	Mus musculus B10.MBR X B10.D2	4990	null	null
+NULL	9542	Macaca fuscata (Japanese monkey)	4991	null	null
+8 weeks	10000023	Mus musculus BDF1	4992	8 week	8 week
+6 weeks	9031	Gallus gallus (chicken)	4993	6 week	6 week
+Children <5 years old	9606	Homo sapiens (human)	4994	children <5 year old	children <5 year
+91-101 years	9606	Homo sapiens (human)	4995	91-101 year	91-101 year
+NULL	13489	Dicentrarchus labrax (European sea bass)	4996	null	null
+4 - 6 weeks	10001998	Mus musculus CD1	4997	4 - 6 week	4 - 6 week
+8 weeks	10000262	Mus musculus B10.A-H2a H2-T18a/SgSnJ	4998	8 week	8 week
+4-5 weeks	10001022	Mus musculus A.BY/SnJ	4999	4-5 week	4-5 week
+1-64 years	9606	Homo sapiens (human)	5000	1-64 year	1-64 year
+8 weeks	10000268	Mus musculus B10.D2-Hc1 H2d H2-T18c/nSn	5001	8 week	8 week
+6 weeks	10000206	Oryctolagus cuniculus New Zealand White	5002	6 week	6 week
+1-6 months	9606	Homo sapiens (human)	5003	1-6 month	1-6 month
+24-34 years	9606	Homo sapiens (human)	5004	24-34 year	24-34 year
+2 - 3 months	10000000	Mus musculus BALB/c	5005	2 - 3 month	2 - 3 month
+10 weeks-old	9823	Sus scrofa (pig)	5006	10 week-old	10 week
+3.5 month	10000206	Oryctolagus cuniculus New Zealand White	5007	3.5 month	3.5 month
+16 to 60 years	9606	Homo sapiens (human)	5008	16 to 60 year	16 to 60 year
+2 month	10000000	Mus musculus BALB/c	5009	2 month	2 month
+8-10 weeks	10116	Rattus norvegicus (brown rat)	5010	8-10 week	8-10 week
+8 weeks or 12 months	10000000	Mus musculus BALB/c	5011	8 week or 12 month	8 week or 12 month
+NULL	9838	Camelus dromedarius (camel)	5012	null	null
+12 weeks	10000668	Cavia porcellus Duncan-Hartley	5013	12 week	12 week
+8 weeks	10000206	Oryctolagus cuniculus New Zealand White	5014	8 week	8 week
+4 weeks	10000914	Mus musculus TO	5015	4 week	4 week
+12 months old	10000191	Bos taurus Hereford	5016	12 month old	12 month
+4-8 weeks	10001998	Mus musculus CD1	5017	4-8 week	4-8 week
+3 weeks	10090	Mus musculus (mouse)	5018	3 week	3 week
+6-7 weeks old	10000067	Mus musculus C57BL/6	5019	6-7 week old	6-7 week
+6-7 weeks old	10000000	Mus musculus BALB/c	5020	6-7 week old	6-7 week
+8 weeks old	10000662	Rattus norvegicus Lewis	5021	8 week old	8 week
+10 weeks	10000206	Oryctolagus cuniculus New Zealand White	5022	10 week	10 week
+6-7 months	10000194	Bos taurus Holstein-Friesian	5023	6-7 month	6-7 month
+Infants	9606	Homo sapiens (human)	5024	infants	infants
+6-8 weeks-old	10000228	Mus musculus CBA	5025	6-8 week-old	6-8 week
+42 days	10000667	Rattus norvegicus Sprague-Dawley	5026	42 days	42 days
+14 weeks old	9825	Sus scrofa domesticus (domestic pig)	5027	14 week old	14 week
+NULL	10000990	Ovis aries Romanov	5028	null	null
+12-14 weeks	10000000	Mus musculus BALB/c	5029	12-14 week	12-14 week
+2 months	10000206	Oryctolagus cuniculus New Zealand White	5030	2 month	2 month
+12 weeks old	10000668	Cavia porcellus Duncan-Hartley	5031	12 week old	12 week
+4-8 months	10000194	Bos taurus Holstein-Friesian	5032	4-8 month	4-8 month
+2 and 64 years	9606	Homo sapiens (human)	5033	2 and 64 year	2 and 64 year
+16-79 years	9606	Homo sapiens (human)	5034	16-79 year	16-79 year
+12 weeks	10000206	Oryctolagus cuniculus New Zealand White	5035	12 week	12 week
+8 weeks	10000618	Mus musculus ICR	5036	8 week	8 week
+38-69 years	9606	Homo sapiens (human)	5037	38-69 year	38-69 year
+NULL	9479	Platyrrhini (New World monkey)	5038	null	null
+3 to 16 years	9796	Equus caballus (domestic horse)	5039	3 to 16 year	3 to 16 year
+16 weeks-40 years	9606	Homo sapiens (human)	5040	16 week-40 year	16 week-40 year
+25-week-old	10000919	Gallus gallus White Leghorn	5041	25-week-old	25 week
+7-8 weeks-old	10000661	Rattus norvegicus Fischer 344	5042	7-8 week-old	7-8 week
+60-90 days old	10000000	Mus musculus BALB/c	5043	60-90 days old	60-90 days old
+7 weeks	10000653	Mus musculus Swiss	5044	7 week	7 week
+NULL	9554	Papio (baboon)	5045	null	null
+3-4 weeks-old	10000000	Mus musculus BALB/c	5046	3-4 week-old	3-4 week
+6 weeks	10000645	Mus musculus PrP null	5047	6 week	6 week
+12 to 66 years-old	9606	Homo sapiens (human)	5048	12 to 66 year-old	12 to 66 year
+3.6-18.6 years	9606	Homo sapiens (human)	5049	3.6-18.6 year	3.6-18.6 year
+NULL	10001097	Sus scrofa Yorkshire	5050	null	null
+4-6 weeks old	10141	Cavia porcellus (guinea pig)	5051	4-6 week old	4-6 week
+8-12 weeks old	10000038	Mus musculus C3H/He	5052	8-12 week old	8-12 week
+2-3 months	10000013	Mus musculus BALB/c X A/J	5053	2-3 month	2-3 month
+NULL	10001099	Mus musculus CF-1	5054	null	null
+NULL	10000659	Rattus norvegicus CD Charles River	5055	null	null
+2-18 years	9606	Homo sapiens (human)	5056	2-18 year	2-18 year
+6-8 weeks	10000914	Mus musculus TO	5057	6-8 week	6-8 week
+7 weeks old	10000000	Mus musculus BALB/c	5058	7 week old	7 week
+6 weeks	10000187	Sus scrofa Landrace X Large White	5059	6 week	6 week
+4-36 month-old	9606	Homo sapiens (human)	5060	4-36 month-old	4-36 month
+6-8 weeks	10000062	Mus musculus FVB/J	5061	6-8 week	6-8 week
+1-90 years	9606	Homo sapiens (human)	5062	1-90 year	1-90 year
+14-88 years	9606	Homo sapiens (human)	5063	14-88 year	14-88 year
+10-12 weeks	10001998	Mus musculus CD1	5064	10-12 week	10-12 week
+7-weeks-old	10000000	Mus musculus BALB/c	5065	7-week-old	7 week
+6 - 8 wo	10000006	Mus musculus BALB/c GalNAc Transferase null	5066	6 - 8 week	6 - 8 week
+8-12 weeks	10000653	Mus musculus Swiss	5067	8-12 week	8-12 week
+8-12 wk	10090	Mus musculus (mouse)	5068	8-12 week	8-12 week
+5 months	9823	Sus scrofa (pig)	5069	5 month	5 month
+4.5 months	10000666	Rattus norvegicus Rowett	5070	4.5 month	4.5 month
+6-10 week	10000000	Mus musculus BALB/c	5071	6-10 week	6-10 week
+1 month	10000241	Gallus gallus H.B15	5072	1 month	1 month
+4 weeks	8839	Anas platyrhynchos (duck)	5073	4 week	4 week
+8 weeks	10000266	Mus musculus B10.BR-H2k H2-T18a/SgSnJ	5074	8 week	8 week
+21 day old	9031	Gallus gallus (chicken)	5075	21 day old	21 day
+4 to 6 week-old	10000000	Mus musculus BALB/c	5076	4 to 6 week-old	4 to 6 week
+6 weeks-old	10000000	Mus musculus BALB/c	5077	6 week-old	6 week
+NULL	10042	Peromyscus maniculatus (North American deer mouse)	5078	null	null
+NULL	10000024	Mus musculus Biozzi	5079	null	null
+49-81 years	9606	Homo sapiens (human)	5080	49-81 year	49-81 year
+NULL	10002076	Sus scrofa Camborough 22	5081	null	null
+NULL	10000617	Mus musculus HuMAb (Medarex)	5082	null	null
+NULL	10000247	Mus musculus (CBA/J X C57BL/6J) human IgH Tg human IgL Tg	5083	null	null
+3-4 months-old	10000206	Oryctolagus cuniculus New Zealand White	5084	3-4 month-old	3-4 month
+8-16 week	10000216	Mus musculus C57BL/6 X BALB/c	5085	8-16 week	8-16 week
+35 years-old	9606	Homo sapiens (human)	5086	35 year-old	35 year
+NULL	168098	Orectolobus maculatus (spotted wobbegong)	5087	null	null
+6- week-old	10000000	Mus musculus BALB/c	5088	6- week-old	6- week
+NULL	10000235	Mus musculus CBA/CaHN-Btkxid/J	5089	null	null
+7 to 77 years	9606	Homo sapiens (human)	5090	7 to 77 year	7 to 77 year
+35.5 +/- 12.8 years	9606	Homo sapiens (human)	5091	35.5 ± 12.8 year	35.5 ± 12.8 year
+26–71 years	9606	Homo sapiens (human)	5092	2671 year	2671 year
+NULL	10000918	Oryctolagus cuniculus California x New Zealand White	5093	null	null
+38 to 50 years	9606	Homo sapiens (human)	5094	38 to 50 year	38 to 50 year
+5 to 7 weeks	10000000	Mus musculus BALB/c	5095	5 to 7 week	5 to 7 week
+5-10 weeks old	10000067	Mus musculus C57BL/6	5096	5-10 week old	5-10 week
+2-13 years	9606	Homo sapiens (human)	5097	2-13 year	2-13 year
+37 average	9606	Homo sapiens (human)	5098	37 average	37 average
+3 months	10000024	Mus musculus Biozzi	5099	3 month	3 month
+8-16 week	10000054	Mus musculus DBA/1	5100	8-16 week	8-16 week
+8 to 12 weeks	10000263	Mus musculus B10.BR	5101	8 to 12 week	8 to 12 week
+NULL	10000574	Mus musculus FVB/N Prp null	5102	null	null
+7-10 weeks	10000253	Mus musculus A/J	5103	7-10 week	7-10 week
+6-8 weeks old	10000273	Mus musculus B10.P	5104	6-8 week old	6-8 week
+20-85 years	9606	Homo sapiens (human)	5105	20-85 year	20-85 year
+2-week old	10000000	Mus musculus BALB/c	5106	2-week old	2 week
+7-9 weeks	10000253	Mus musculus A/J	5107	7-9 week	7-9 week
+NULL	10000240	Gallus gallus Brown leghorn Hisex	5108	null	null
+7 days	9825	Sus scrofa domesticus (domestic pig)	5109	7 days	7 days
+65 and 74 years old	9606	Homo sapiens (human)	5110	65 and 74 year old	65 and 74 year
+6-7 weeks	10090	Mus musculus (mouse)	5111	6-7 week	6-7 week
+1 month	9606	Homo sapiens (human)	5112	1 month	1 month
+3-4 years	9555	Papio anubis (Doguera baboon)	5113	3-4 year	3-4 year
+5-weeks-old	10000618	Mus musculus ICR	5114	5-week-old	5 week
+3 months-old	10116	Rattus norvegicus (brown rat)	5115	3 month-old	3 month
+5-6 weeks	10000047	Mus musculus C57BL/10	5116	5-6 week	5-6 week
+8-16 week	10000047	Mus musculus C57BL/10	5117	8-16 week	8-16 week
+4 years old	9606	Homo sapiens (human)	5118	4 year old	4 year
+8-16 week	10000055	Mus musculus DBA/2	5119	8-16 week	8-16 week
+4 to 6 years	9541	Macaca fascicularis (crab eating macaque)	5120	4 to 6 year	4 to 6 year
+8 to 10 weeks	10001446	Rattus norvegicus Wistar Kyoto	5121	8 to 10 week	8 to 10 week
+6-8 weeks old	10001998	Mus musculus CD1	5122	6-8 week old	6-8 week
+8-12 weeks	10000259	Mus musculus B10.A(3R)	5123	8-12 week	8-12 week
+19-27 years old	9606	Homo sapiens (human)	5124	19-27 year old	19-27 year
+up to 12 weeks old	10000263	Mus musculus B10.BR	5125	up to 12 week old	up to 12 week
+NULL	30538	Vicugna pacos (alpaca)	5126	null	null
+NULL	10000199	Oryctolagus cuniculus Californian	5127	null	null
+NULL	10000923	Ovis aries Merino X Border Leiscester	5128	null	null
+NULL	10000202	Oryctolagus cuniculus Flemish Giant	5129	null	null
+up to 12 weeks old	10090	Mus musculus (mouse)	5130	up to 12 week old	up to 12 week
+6-36-month-old	9606	Homo sapiens (human)	5131	6-36-month-old	6-36 month
+18 to 73 years	9606	Homo sapiens (human)	5132	18 to 73 year	18 to 73 year
+2-3 month old	10000206	Oryctolagus cuniculus New Zealand White	5133	2-3 month old	2-3 month
+12 weeks	10000055	Mus musculus DBA/2	5134	12 week	12 week
+3 to 5 months	10000000	Mus musculus BALB/c	5135	3 to 5 month	3 to 5 month
+6 weeks	10000655	Mus musculus Swiss Webster	5136	6 week	6 week
+1.5-7years	9606	Homo sapiens (human)	5137	1.5-7years	1.5-7years
+4-7 weeks	10000000	Mus musculus BALB/c	5138	4-7 week	4-7 week
+6-8 weeks	10000669	Cavia porcellus Hartley	5139	6-8 week	6-8 week
+14-51 years	9606	Homo sapiens (human)	5140	14-51 year	14-51 year
+6-13 weeks	10090	Mus musculus (mouse)	5141	6-13 week	6-13 week
+18-19 years-old	9606	Homo sapiens (human)	5142	18-19 year-old	18-19 year
+6 weeks-old	10000618	Mus musculus ICR	5143	6 week-old	6 week
+6-8 weeks old	10000208	Mesocricetus auratus DSN	5144	6-8 week old	6-8 week
+6 months	9986	Oryctolagus cuniculus (rabbit)	5145	6 month	6 month
+2 months to 14 years	9606	Homo sapiens (human)	5146	2 month to 14 year	2 month to 14 year
+8 wo	10000000	Mus musculus BALB/c	5147	8 week	8 week
+5 wk	10000618	Mus musculus ICR	5148	5 week	5 week
+NULL	10047	Meriones unguiculatus (Mongolian jird)	5149	null	null
+40-day-old	10000667	Rattus norvegicus Sprague-Dawley	5150	40-day-old	40 day
+6-8 months	9913	Bos taurus (bovine)	5151	6-8 month	6-8 month
+4-6 weeks old	10000028	Mus musculus C3H	5152	4-6 week old	4-6 week
+6 wk	10000000	Mus musculus BALB/c	5153	6 week	6 week
+25 weeks	10000919	Gallus gallus White Leghorn	5154	25 week	25 week
+47-82 years	9606	Homo sapiens (human)	5155	47-82 year	47-82 year
+8 weeks old	10090	Mus musculus (mouse)	5156	8 week old	8 week
+6 weeks old	10000062	Mus musculus FVB/J	5157	6 week old	6 week
+3 months	10000206	Oryctolagus cuniculus New Zealand White	5158	3 month	3 month
+4 weeks	10000915	Mus musculus Kunming	5159	4 week	4 week
+19-60 years	9606	Homo sapiens (human)	5160	19-60 year	19-60 year
+7 wk	10000000	Mus musculus BALB/c	5161	7 week	7 week
+20-35 years	9606	Homo sapiens (human)	5162	20-35 year	20-35 year
+7-10 days	9913	Bos taurus (bovine)	5163	7-10 days	7-10 days
+8 weeks	10000024	Mus musculus Biozzi	5164	8 week	8 week
+2 mo	10000188	Sus scrofa NIH miniature pig	5165	2 month	2 month
+2 mo	10000206	Oryctolagus cuniculus New Zealand White	5166	2 month	2 month
+> 6 months	10000193	Bos taurus Holstein	5167	> 6 month	> 6 month
+4 wk	10000000	Mus musculus BALB/c	5168	4 week	4 week
+8 weeks	10000231	Mus musculus CBA X BALB/c	5169	8 week	8 week
+5 weeks	9031	Gallus gallus (chicken)	5170	5 week	5 week
+25-30 grams	10000000	Mus musculus BALB/c	5171	25-30 grams	25-30 grams
+NULL	10000035	Mus musculus C3H/DiSn	5172	null	null
+8-10 week	10000000	Mus musculus BALB/c	5173	8-10 week	8-10 week
+2 month old	10000000	Mus musculus BALB/c	5174	2 month old	2 month
+8 weeks	10000655	Mus musculus Swiss Webster	5175	8 week	8 week
+8 months	9913	Bos taurus (bovine)	5176	8 month	8 month
+8-10 weeks-old	9823	Sus scrofa (pig)	5177	8-10 week-old	8-10 week
+8-12 weeks old	10000233	Mus musculus CBA/Ca	5178	8-12 week old	8-12 week
+6 to 8 weeks old	10000067	Mus musculus C57BL/6	5179	6 to 8 week old	6 to 8 week
+6 weeks	10000050	Mus musculus C57BL/10 X C3H/HeJ	5180	6 week	6 week
+NULL	10000036	Mus musculus C3H/FeJ	5181	null	null
+3 weeks	10141	Cavia porcellus (guinea pig)	5182	3 week	3 week
+5-7 months-old	10000185	Canis familiaris beagle	5183	5-7 month-old	5-7 month
+8-12 weeks old	10000649	Mus musculus SJL	5184	8-12 week old	8-12 week
+38 days	10000659	Rattus norvegicus CD Charles River	5185	38 days	38 days
+Three-month-old	10000664	Rattus norvegicus LOU/C	5186	3-month-old	3 month
+10 weeks-old	10000206	Oryctolagus cuniculus New Zealand White	5187	10 week-old	10 week
+3-4 weeks old	10000067	Mus musculus C57BL/6	5188	3-4 week old	3-4 week
+23-80	9606	Homo sapiens (human)	5189	23-80	23-80
+35 to 66 years	9606	Homo sapiens (human)	5190	35 to 66 year	35 to 66 year
+NULL	10001597	Mus musculus alpha-galactosyl transferase null	5191	null	null
+2 months	10090	Mus musculus (mouse)	5192	2 month	2 month
+NULL	9669	Mustela putorius furo (black ferret)	5193	null	null
+6 to 8 -week-old	10000000	Mus musculus BALB/c	5194	6 to 8 -week-old	6 to 8 -week
+21 to 59 years	9606	Homo sapiens (human)	5195	21 to 59 year	21 to 59 year
+8-12 weeks-old	10001998	Mus musculus CD1	5196	8-12 week-old	8-12 week
+Four-weeks-old	10000000	Mus musculus BALB/c	5197	4-week-old	4 week
+8-16 week	10000263	Mus musculus B10.BR	5198	8-16 week	8-16 week
+14-15 weeks	10000000	Mus musculus BALB/c	5199	14-15 week	14-15 week
+4-6 weeks old	10001998	Mus musculus CD1	5200	4-6 week old	4-6 week
+37-75 years	9606	Homo sapiens (human)	5201	37-75 year	37-75 year
+7-8 weeks	10000663	Rattus norvegicus LOU	5202	7-8 week	7-8 week
+4-10 weeks old	10000000	Mus musculus BALB/c	5203	4-10 week old	4-10 week
+NULL	9665	Mustela	5204	null	null
+Adult (pregnant)	9606	Homo sapiens (human)	5205	adult (pregnant)	adult (pregnant)
+5-7 weeks	10000624	Mus musculus MF1	5206	5-7 week	5-7 week
+6-8 weeks	10032	Cricetulus migratorius (gray dwarf hamster)	5207	6-8 week	6-8 week
+8 weeks	10000202	Oryctolagus cuniculus Flemish Giant	5208	8 week	8 week
+<20 years	9606	Homo sapiens (human)	5209	<20 year	<20 year
+9-10 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5210	9-10 week	9-10 week
+NULL	10000249	Mus musculus 129/Ola Prp null	5211	null	null
+8-16 week	10000038	Mus musculus C3H/He	5212	8-16 week	8-16 week
+>15 years	9606	Homo sapiens (human)	5213	>15 year	>15 year
+8-16 week	10000000	Mus musculus BALB/c	5214	8-16 week	8-16 week
+6 mos	10000206	Oryctolagus cuniculus New Zealand White	5215	6 month	6 month
+33-71 years	9606	Homo sapiens (human)	5216	33-71 year	33-71 year
+6-8 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5217	6-8 week	6-8 week
+27 to 46 years	9606	Homo sapiens (human)	5218	27 to 46 year	27 to 46 year
+6-8 weeks old	10000206	Oryctolagus cuniculus New Zealand White	5219	6-8 week old	6-8 week
+6 months to 3 years	9606	Homo sapiens (human)	5220	6 month to 3 year	6 month to 3 year
+6 - 8 wo	10000000	Mus musculus BALB/c	5221	6 - 8 week	6 - 8 week
+2-5 months old	9606	Homo sapiens (human)	5222	2-5 month old	2-5 month
+12 weeks	10000024	Mus musculus Biozzi	5223	12 week	12 week
+4-6 weeks	10001998	Mus musculus CD1	5224	4-6 week	4-6 week
+NULL	10002077	Canis familiaris beagle X maltese	5225	null	null
+1 month-old	10000241	Gallus gallus H.B15	5226	1 month-old	1 month
+8-12 weeks	10000261	Mus musculus B10.A(5R)	5227	8-12 week	8-12 week
+NULL	9556	Papio cynocephalus (baboon)	5228	null	null
+51-89 years	9606	Homo sapiens (human)	5229	51-89 year	51-89 year
+birth - 5 years	9606	Homo sapiens (human)	5230	birth - 5 year	birth - 5 year
+5 years	9598	Pan troglodytes (chimpanzee)	5231	5 year	5 year
+3-4 days	10000653	Mus musculus Swiss	5232	3-4 days	3-4 days
+23 to 89 years	9606	Homo sapiens (human)	5233	23 to 89 year	23 to 89 year
+4-8-week-old	10000047	Mus musculus C57BL/10	5234	4-8-week-old	4-8 week
+Neonates (infected mothers or PM)	9606	Homo sapiens (human)	5235	neonates (infected mothers or pm)	neonates (infected mothers or pm)
+1-4 years	9606	Homo sapiens (human)	5236	1-4 year	1-4 year
+3-65 years-old	9606	Homo sapiens (human)	5237	3-65 year-old	3-65 year
+NULL	10000664	Rattus norvegicus LOU/C	5238	null	null
+Juvenile	30538	Vicugna pacos (alpaca)	5239	juvenile	juvenile
+>20 years	9606	Homo sapiens (human)	5240	>20 year	>20 year
+19 to 71 years	9606	Homo sapiens (human)	5241	19 to 71 year	19 to 71 year
+NULL	9557	Papio hamadryas (baboon)	5242	null	null
+1 to 8 years	9606	Homo sapiens (human)	5243	1 to 8 year	1 to 8 year
+19 to 66 years	9606	Homo sapiens (human)	5244	19 to 66 year	19 to 66 year
+27 to 71 years	9606	Homo sapiens (human)	5245	27 to 71 year	27 to 71 year
+6-8 weeks-old	10000019	Mus musculus BALB/cByJ	5246	6-8 week-old	6-8 week
+8-59 years	9606	Homo sapiens (human)	5247	8-59 year	8-59 year
+3-23 years	9606	Homo sapiens (human)	5248	3-23 year	3-23 year
+18-21	9606	Homo sapiens (human)	5249	18-21	18-21
+8-12-week-old	10000275	Mus musculus B10.RIII	5250	8-12-week-old	8-12 week
+6 weeks-old	10000067	Mus musculus C57BL/6	5251	6 week-old	6 week
+6-8 weeks old	10000019	Mus musculus BALB/cByJ	5252	6-8 week old	6-8 week
+3 months old	10000206	Oryctolagus cuniculus New Zealand White	5253	3 month old	3 month
+8 to 12 weeks	10000238	Mus musculus CD1d null	5254	8 to 12 week	8 to 12 week
+8 to 12 weeks	10000621	Mus musculus IL-12 null	5255	8 to 12 week	8 to 12 week
+8 to 12-week-old	10000233	Mus musculus CBA/Ca	5256	8 to 12-week-old	8 to 12 week
+6-8 weeks	10000647	Mus musculus Quackenbush	5257	6-8 week	6-8 week
+1-1.5 years	9544	Macaca mulatta (rhesus macaque)	5258	1-1.5 year	1-1.5 year
+32-70	9606	Homo sapiens (human)	5259	32-70	32-70
+17 to 45 years	9606	Homo sapiens (human)	5260	17 to 45 year	17 to 45 year
+3-5 weeks old	10000067	Mus musculus C57BL/6	5261	3-5 week old	3-5 week
+18-21 years-old	9606	Homo sapiens (human)	5262	18-21 year-old	18-21 year
+3 weeks	10000649	Mus musculus SJL	5263	3 week	3 week
+7-9 weeks old	10090	Mus musculus (mouse)	5264	7-9 week old	7-9 week
+19-43 years	9606	Homo sapiens (human)	5265	19-43 year	19-43 year
+8 to 12 months	10000000	Mus musculus BALB/c	5266	8 to 12 month	8 to 12 month
+Adult (18-49)	9606	Homo sapiens (human)	5267	adult (18-49)	adult (18-49)
+19-40 years old	9606	Homo sapiens (human)	5268	19-40 year old	19-40 year
+12-16 weeks-old	10000065	Mus musculus C57BL/10SnJ	5269	12-16 week-old	12-16 week
+15-64 years old	9606	Homo sapiens (human)	5270	15-64 year old	15-64 year
+6-8 weeks	10000065	Mus musculus C57BL/10SnJ	5271	6-8 week	6-8 week
+20-25 g	10000000	Mus musculus BALB/c	5272	20-25 g	20-25 g
+13-66 years	9606	Homo sapiens (human)	5273	13-66 year	13-66 year
+16-76 years	9606	Homo sapiens (human)	5274	16-76 year	16-76 year
+17-71 years	9606	Homo sapiens (human)	5275	17-71 year	17-71 year
+Adutls	10000119	Homo sapiens Caucasian	5276	adults	adults
+20-88 years	9606	Homo sapiens (human)	5277	20-88 year	20-88 year
+6-8 weeks old	10000062	Mus musculus FVB/J	5278	6-8 week old	6-8 week
+32 years	10000119	Homo sapiens Caucasian	5279	32 year	32 year
+4 weeks	10001309	Mus musculus hTNF Tg	5280	4 week	4 week
+4 months old	10000198	Oryctolagus cuniculus California Satin	5281	4 month old	4 month
+22-61 years	9606	Homo sapiens (human)	5282	22-61 year	22-61 year
+6 weeks old	10000921	Gallus gallus Cobb 500	5283	6 week old	6 week
+NULL	10000652	Mus musculus STU	5284	null	null
+19-35 years	9606	Homo sapiens (human)	5285	19-35 year	19-35 year
+8-12 weeks old	10000047	Mus musculus C57BL/10	5286	8-12 week old	8-12 week
+3-5 weeks	10000067	Mus musculus C57BL/6	5287	3-5 week	3-5 week
+7-9 weeks	10000263	Mus musculus B10.BR	5288	7-9 week	7-9 week
+22-24 years	9606	Homo sapiens (human)	5289	22-24 year	22-24 year
+15-26 years	9606	Homo sapiens (human)	5290	15-26 year	15-26 year
+8 to 12 weeks	10000051	Mus musculus C57BL/10 X DBA/2	5291	8 to 12 week	8 to 12 week
+8 wk	10000000	Mus musculus BALB/c	5292	8 week	8 week
+6 weeks	10000102	Mus musculus C57BL/6 Prp null	5293	6 week	6 week
+NULL	78354	Saguinus midas midas	5294	null	null
+6 weeks old	10000653	Mus musculus Swiss	5295	6 week old	6 week
+>13 years	9606	Homo sapiens (human)	5296	>13 year	>13 year
+1.25-19 years	9606	Homo sapiens (human)	5297	1.25-19 year	1.25-19 year
+7 - 79 years	9606	Homo sapiens (human)	5298	7 - 79 year	7 - 79 year
+4-6 weeks	10000055	Mus musculus DBA/2	5299	4-6 week	4-6 week
+NULL	43777	Pithecia pithecia (Guianan saki)	5300	null	null
+12 weeks	10000618	Mus musculus ICR	5301	12 week	12 week
+10-week-old	9823	Sus scrofa (pig)	5302	10-week-old	10 week
+Adults	292213	Aotus griseimembra	5303	adults	adults
+adult	292213	Aotus griseimembra	5304	adult	adult
+8-24 weeks old	10090	Mus musculus (mouse)	5305	8-24 week old	8-24 week
+9 weeks old	10000206	Oryctolagus cuniculus New Zealand White	5306	9 week old	9 week
+> 20 years	9606	Homo sapiens (human)	5307	> 20 year	> 20 year
+NULL	10000915	Mus musculus Kunming	5308	null	null
+24 days	447135	Myodes glareolus (bank vole)	5309	24 days	24 days
+2-3 months old	9986	Oryctolagus cuniculus (rabbit)	5310	2-3 month old	2-3 month
+5-6 weeks	10000051	Mus musculus C57BL/10 X DBA/2	5311	5-6 week	5-6 week
+mean = 45 years	9606	Homo sapiens (human)	5312	mean = 45 year	mean = 45 year
+6-8 wks	10000038	Mus musculus C3H/He	5313	6-8 week	6-8 week
+8-12 weeks	10000258	Mus musculus B10.A(2R)	5314	8-12 week	8-12 week
+5-64 years	9606	Homo sapiens (human)	5315	5-64 year	5-64 year
+1-34 years	9606	Homo sapiens (human)	5316	1-34 year	1-34 year
+4-6 weeks-old	10000618	Mus musculus ICR	5317	4-6 week-old	4-6 week
+2-4 weeks	10000000	Mus musculus BALB/c	5318	2-4 week	2-4 week
+25 days	10000645	Mus musculus PrP null	5319	25 days	25 days
+8 wk	10090	Mus musculus (mouse)	5320	8 week	8 week
+4 days	8835	Anas (ducks)	5321	4 days	4 days
+15-95 years old	9606	Homo sapiens (human)	5322	15-95 year old	15-95 year
+9-22 months old	9606	Homo sapiens (human)	5323	9-22 month old	9-22 month
+39 +/- 2.4 years	9606	Homo sapiens (human)	5324	39 ± 2.4 year	39 ± 2.4 year
+24-57 years	9606	Homo sapiens (human)	5325	24-57 year	24-57 year
+Child (5-11)	9606	Homo sapiens (human)	5326	child (5-11)	child (5-11)
+18-27 years	9606	Homo sapiens (human)	5327	18-27 year	18-27 year
+6 months to 53 years	9606	Homo sapiens (human)	5328	6 month to 53 year	6 month to 53 year
+Average age of 37 years	9606	Homo sapiens (human)	5329	average age of 37 year	average age of 37 year
+6-8 weeks	10000232	Mus musculus CBA.M523	5330	6-8 week	6-8 week
+4- to 6-week-old	10001998	Mus musculus CD1	5331	4- to 6-week-old	4- to 6 week
+11 weeks	10000067	Mus musculus C57BL/6	5332	11 week	11 week
+NULL	10000020	Mus musculus BALB/cByJ-Rb5Bnr	5333	null	null
+6-8 weeks	10000260	Mus musculus B10.A(4R)	5334	6-8 week	6-8 week
+NULL	10000619	Mus musculus ICR X Swiss	5335	null	null
+7 to 8 weeks	10000655	Mus musculus Swiss Webster	5336	7 to 8 week	7 to 8 week
+8-12-week-old	10000038	Mus musculus C3H/He	5337	8-12-week-old	8-12 week
+8-12 weeks old	10000665	Rattus norvegicus LOU/M	5338	8-12 week old	8-12 week
+3-15 years	9606	Homo sapiens (human)	5339	3-15 year	3-15 year
+0.75-15 years	9606	Homo sapiens (human)	5340	0.75-15 year	0.75-15 year
+2-4 yrs	9544	Macaca mulatta (rhesus macaque)	5341	2-4 year	2-4 year
+4-6 weeks	10000061	Mus musculus FVB	5342	4-6 week	4-6 week
+15-71	9606	Homo sapiens (human)	5343	15-71	15-71
+4-70 years	9606	Homo sapiens (human)	5344	4-70 year	4-70 year
+0.8-78 years	9606	Homo sapiens (human)	5345	0.8-78 year	0.8-78 year
+6-8 weeks old	10000647	Mus musculus Quackenbush	5346	6-8 week old	6-8 week
+8-12 weeks	10000260	Mus musculus B10.A(4R)	5347	8-12 week	8-12 week
+6-8 weeks	10000916	Mus musculus C3H/He-mg	5348	6-8 week	6-8 week
+21 days	10000000	Mus musculus BALB/c	5349	21 days	21 days
+4-8 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5350	4-8 week	4-8 week
+1.8-14.2 years	9606	Homo sapiens (human)	5351	1.8-14.2 year	1.8-14.2 year
+4-26 weeks	10000019	Mus musculus BALB/cByJ	5352	4-26 week	4-26 week
+14-82 years	9606	Homo sapiens (human)	5353	14-82 year	14-82 year
+7 weeks	10000645	Mus musculus PrP null	5354	7 week	7 week
+adult	9838	Camelus dromedarius (camel)	5355	adult	adult
+21 to 45 years	9606	Homo sapiens (human)	5356	21 to 45 year	21 to 45 year
+6-8 weeks	10000574	Mus musculus FVB/N Prp null	5357	6-8 week	6-8 week
+10 to 47 years	9606	Homo sapiens (human)	5358	10 to 47 year	10 to 47 year
+3 months	10001510	Oryctolagus cuniculus Danish White	5359	3 month	3 month
+5-39 years	9606	Homo sapiens (human)	5360	5-39 year	5-39 year
+2-3 months	10032	Cricetulus migratorius (gray dwarf hamster)	5361	2-3 month	2-3 month
+26-48 years	9606	Homo sapiens (human)	5362	26-48 year	26-48 year
+28-68 years	9606	Homo sapiens (human)	5363	28-68 year	28-68 year
+25 to 46 years	9606	Homo sapiens (human)	5364	25 to 46 year	25 to 46 year
+9-12 weeks old	10001470	Mus musculus Factor VIII null	5365	9-12 week old	9-12 week
+5-80 years	9606	Homo sapiens (human)	5366	5-80 year	5-80 year
+8-12 weeks old	10000630	Mus musculus NHI Swiss	5367	8-12 week old	8-12 week
+10-14 years	9606	Homo sapiens (human)	5368	10-14 year	10-14 year
+3-11 years	9606	Homo sapiens (human)	5369	3-11 year	3-11 year
+10-67 years	9606	Homo sapiens (human)	5370	10-67 year	10-67 year
+13 to 82 years	9606	Homo sapiens (human)	5371	13 to 82 year	13 to 82 year
+16 to 20 weeks	10000625	Mus musculus MRL	5372	16 to 20 week	16 to 20 week
+40.0±13.7 years	9606	Homo sapiens (human)	5373	40.013.7 year	40.013.7 year
+14.4±3.8  years	9606	Homo sapiens (human)	5374	14.43.8  year	14.43.8  year
+29 to 47 years	9606	Homo sapiens (human)	5375	29 to 47 year	29 to 47 year
+6.1-36.4 years	9606	Homo sapiens (human)	5376	6.1-36.4 year	6.1-36.4 year
+18-35 years	9606	Homo sapiens (human)	5377	18-35 year	18-35 year
+12 to 13 years	9606	Homo sapiens (human)	5378	12 to 13 year	12 to 13 year
+31-49 years	9606	Homo sapiens (human)	5379	31-49 year	31-49 year
+39.88 ± 10.13	9606	Homo sapiens (human)	5380	39.88  10.13	39.88  10.13
+16-58 years	9606	Homo sapiens (human)	5381	16-58 year	16-58 year
+25 to 77	9606	Homo sapiens (human)	5382	25 to 77	25 to 77
+17-53 years	9606	Homo sapiens (human)	5383	17-53 year	17-53 year
+15-71 years	9606	Homo sapiens (human)	5384	15-71 year	15-71 year
+39.18 ± 6.77	9606	Homo sapiens (human)	5385	39.18  6.77	39.18  6.77
+6-8 weeks	10001512	Mus musculus C57BL/6 GalNAc Transferase null	5386	6-8 week	6-8 week
+4 to 6 weeks	10000667	Rattus norvegicus Sprague-Dawley	5387	4 to 6 week	4 to 6 week
+12 to 78 years	9606	Homo sapiens (human)	5388	12 to 78 year	12 to 78 year
+62 to 87 years	9606	Homo sapiens (human)	5389	62 to 87 year	62 to 87 year
+38 to 66 years	9606	Homo sapiens (human)	5390	38 to 66 year	38 to 66 year
+14 weeks	9823	Sus scrofa (pig)	5391	14 week	14 week
+27-51 years	9606	Homo sapiens (human)	5392	27-51 year	27-51 year
+67-95 years	9606	Homo sapiens (human)	5393	67-95 year	67-95 year
+12 to 69 years	9606	Homo sapiens (human)	5394	12 to 69 year	12 to 69 year
+13 to 29 years	9606	Homo sapiens (human)	5395	13 to 29 year	13 to 29 year
+17-80 years	9606	Homo sapiens (human)	5396	17-80 year	17-80 year
+2-7 months	10000067	Mus musculus C57BL/6	5397	2-7 month	2-7 month
+13-29 years	9606	Homo sapiens (human)	5398	13-29 year	13-29 year
+36-38 years	9606	Homo sapiens (human)	5399	36-38 year	36-38 year
+27.4 ± 16.2 years	9606	Homo sapiens (human)	5400	27.4  16.2 year	27.4  16.2 year
+24-83 years	9606	Homo sapiens (human)	5401	24-83 year	24-83 year
+27 years	9544	Macaca mulatta (rhesus macaque)	5402	27 year	27 year
+NULL	10000919	Gallus gallus White Leghorn	5403	null	null
+43-46 years	9606	Homo sapiens (human)	5404	43-46 year	43-46 year
+NULL	10001605	Oryctolagus cuniculus ELCO	5405	null	null
+NULL	10001664	Rattus norvegicus Albino Oxford	5406	null	null
+NULL	9555	Papio anubis (Doguera baboon)	5407	null	null
+4 to 18 years	9606	Homo sapiens (human)	5408	4 to 18 year	4 to 18 year
+NULL	10001512	Mus musculus C57BL/6 GalNAc Transferase null	5409	null	null
+7 to 54 years	9606	Homo sapiens (human)	5410	7 to 54 year	7 to 54 year
+6 to 69 years	9606	Homo sapiens (human)	5411	6 to 69 year	6 to 69 year
+4 to 45 years	9606	Homo sapiens (human)	5412	4 to 45 year	4 to 45 year
+77	9606	Homo sapiens (human)	5413	77	77
+20-22 weeks	10001405	Mus musculus NZB X NZW	5414	20-22 week	20-22 week
+9 months	10001405	Mus musculus NZB X NZW	5415	9 month	9 month
+16 to 76 years	9606	Homo sapiens (human)	5416	16 to 76 year	16 to 76 year
+8-12 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5417	8-12 week	8-12 week
+44.5-71.5 years	9606	Homo sapiens (human)	5418	44.5-71.5 year	44.5-71.5 year
+20 weeks	10001405	Mus musculus NZB X NZW	5419	20 week	20 week
+5 to 6 years	9598	Pan troglodytes (chimpanzee)	5420	5 to 6 year	5 to 6 year
+9 months	9940	Ovis aries (domestic sheep)	5421	9 month	9 month
+3 to 9 weeks	10000000	Mus musculus BALB/c	5422	3 to 9 week	3 to 9 week
+8-16 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5423	8-16 week	8-16 week
+6-12 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5424	6-12 week	6-12 week
+24 to 61 years	9606	Homo sapiens (human)	5425	24 to 61 year	24 to 61 year
+24 hours	10000000	Mus musculus BALB/c	5426	24 hour	24 hour
+NULL	10001684	Rattus norvegicus WKAH X LEW	5427	null	null
+7 to 10 weeks	10000006	Mus musculus BALB/c GalNAc Transferase null	5428	7 to 10 week	7 to 10 week
+8 mo to 35 years	9606	Homo sapiens (human)	5429	8 month to 35 year	8 month to 35 year
+10-12 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5430	10-12 week	10-12 week
+4-6 months	9615	Canis lupus familiaris (dogs)	5431	4-6 month	4-6 month
+81 years old	9606	Homo sapiens (human)	5432	81 year old	81 year
+7 months to 14 years	9606	Homo sapiens (human)	5433	7 month to 14 year	7 month to 14 year
+NULL	36229	Papio ursinus (baboon)	5434	null	null
+13-96 years	9606	Homo sapiens (human)	5435	13-96 year	13-96 year
+6-8 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5436	6-8 week	6-8 week
+8 to 10 weeks	10000233	Mus musculus CBA/Ca	5437	8 to 10 week	8 to 10 week
+8 to 48 years	9606	Homo sapiens (human)	5438	8 to 48 year	8 to 48 year
+15-69 years	9606	Homo sapiens (human)	5439	15-69 year	15-69 year
+6 to 28 years	9606	Homo sapiens (human)	5440	6 to 28 year	6 to 28 year
+8 to 53 years	9606	Homo sapiens (human)	5441	8 to 53 year	8 to 53 year
+10 to 53 years	9606	Homo sapiens (human)	5442	10 to 53 year	10 to 53 year
+NULL	10001602	Mus musculus RBF	5443	null	null
+18-79 years	9606	Homo sapiens (human)	5444	18-79 year	18-79 year
+10-66 yr	9606	Homo sapiens (human)	5445	10-66 year	10-66 year
+24-55 years	9606	Homo sapiens (human)	5446	24-55 year	24-55 year
+3-4 months	10001221	Mus musculus C57BL/6 x SJL	5447	3-4 month	3-4 month
+3 to 4 months	10001532	Mus musculus NZW X BXSB	5448	3 to 4 month	3 to 4 month
+33 to 61 years	9606	Homo sapiens (human)	5449	33 to 61 year	33 to 61 year
+4-6 weeks	10000276	Mus musculus B10.S	5450	4-6 week	4-6 week
+12-16 weeks old	10000000	Mus musculus BALB/c	5451	12-16 week old	12-16 week
+6 weeks	10001487	Mus musculus Apolipoprotein E null	5452	6 week	6 week
+2 to 3 weeks	9823	Sus scrofa (pig)	5453	2 to 3 week	2 to 3 week
+14 +/- 3 years	10000195	Capra hircus Saanen	5454	14 ± 3 year	14 ± 3 year
+NULL	10001574	Mus musculus C57BL/6 CMAH null	5455	null	null
+>/= 18 years	9606	Homo sapiens (human)	5456	>/= 18 year	>/= 18 year
+9 months	10001487	Mus musculus Apolipoprotein E null	5457	9 month	9 month
+adult	10001605	Oryctolagus cuniculus ELCO	5458	adult	adult
+36 to 75 years	9606	Homo sapiens (human)	5459	36 to 75 year	36 to 75 year
+62.8 ± 10 years	9606	Homo sapiens (human)	5460	62.8  10 year	62.8  10 year
+2 months-12 years	9606	Homo sapiens (human)	5461	2 month-12 year	2 month-12 year
+20-42 years	9606	Homo sapiens (human)	5462	20-42 year	20-42 year
+18-42 years	9606	Homo sapiens (human)	5463	18-42 year	18-42 year
+37 years	10000119	Homo sapiens Caucasian	5464	37 year	37 year
+mean = 34 years	9606	Homo sapiens (human)	5465	mean = 34 year	mean = 34 year
+20-74 years	9606	Homo sapiens (human)	5466	20-74 year	20-74 year
+13 to 79 years	9606	Homo sapiens (human)	5467	13 to 79 year	13 to 79 year
+< 40 years	9606	Homo sapiens (human)	5468	< 40 year	< 40 year
+19-80 years	9606	Homo sapiens (human)	5469	19-80 year	19-80 year
+80-84 years	10000119	Homo sapiens Caucasian	5470	80-84 year	80-84 year
+21-33 years	9606	Homo sapiens (human)	5471	21-33 year	21-33 year
+69 ± 15 years	9606	Homo sapiens (human)	5472	69  15 year	69  15 year
+60 ± 15 years	9606	Homo sapiens (human)	5473	60  15 year	60  15 year
+37 ± 14 years	9606	Homo sapiens (human)	5474	37  14 year	37  14 year
+11-58 years	9606	Homo sapiens (human)	5475	11-58 year	11-58 year
+35 years mean age	9606	Homo sapiens (human)	5476	35 year mean age	35 year mean age
+32-58 years	9606	Homo sapiens (human)	5477	32-58 year	32-58 year
+mean = 71.2 years	9606	Homo sapiens (human)	5478	mean = 71.2 year	mean = 71.2 year
+17-84 years	9606	Homo sapiens (human)	5479	17-84 year	17-84 year
+1 to 11 months	10000639	Mus musculus NZB	5480	1 to 11 month	1 to 11 month
+mean = 65.04 years	9606	Homo sapiens (human)	5481	mean = 65.04 year	mean = 65.04 year
+17-31 years	9606	Homo sapiens (human)	5482	17-31 year	17-31 year
+62 ± 12 years	9606	Homo sapiens (human)	5483	62  12 year	62  12 year
+18 to 67 years	9606	Homo sapiens (human)	5484	18 to 67 year	18 to 67 year
+mean = 72.4 years	9606	Homo sapiens (human)	5485	mean = 72.4 year	mean = 72.4 year
+21 to 43 years	9606	Homo sapiens (human)	5486	21 to 43 year	21 to 43 year
+55 ± 12 years	9606	Homo sapiens (human)	5487	55  12 year	55  12 year
+29-68 years	9606	Homo sapiens (human)	5488	29-68 year	29-68 year
+10-71 years	9606	Homo sapiens (human)	5489	10-71 year	10-71 year
+32 to 72 years	9606	Homo sapiens (human)	5490	32 to 72 year	32 to 72 year
+38.15 ± 6.5	9606	Homo sapiens (human)	5491	38.15  6.5	38.15  6.5
+> 20 weeks	10001406	Mus musculus MLR/lpr	5492	> 20 week	> 20 week
+14.4±3.8 years	9606	Homo sapiens (human)	5493	14.43.8 year	14.43.8 year
+6 to 8 weeks	10001405	Mus musculus NZB X NZW	5494	6 to 8 week	6 to 8 week
+34 to 37 years	9606	Homo sapiens (human)	5495	34 to 37 year	34 to 37 year
+3-4 months	10001532	Mus musculus NZW X BXSB	5496	3-4 month	3-4 month
+17-69 years	9606	Homo sapiens (human)	5497	17-69 year	17-69 year
+25-46 years	9606	Homo sapiens (human)	5498	25-46 year	25-46 year
+6-9 weeks	10001406	Mus musculus MLR/lpr	5499	6-9 week	6-9 week
+12-55 years	9606	Homo sapiens (human)	5500	12-55 year	12-55 year
+15-33 years	9606	Homo sapiens (human)	5501	15-33 year	15-33 year
+26 to 52 years	9606	Homo sapiens (human)	5502	26 to 52 year	26 to 52 year
+17-61 years	9606	Homo sapiens (human)	5503	17-61 year	17-61 year
+20-44 years	9606	Homo sapiens (human)	5504	20-44 year	20-44 year
+18-47 years	9606	Homo sapiens (human)	5505	18-47 year	18-47 year
+22-41	9606	Homo sapiens (human)	5506	22-41	22-41
+39 ± 15	9606	Homo sapiens (human)	5507	39  15	39  15
+14-62 years	9606	Homo sapiens (human)	5508	14-62 year	14-62 year
+8 weeks	10001406	Mus musculus MLR/lpr	5509	8 week	8 week
+21 to 47 years	9606	Homo sapiens (human)	5510	21 to 47 year	21 to 47 year
+21 to 38 years	9606	Homo sapiens (human)	5511	21 to 38 year	21 to 38 year
+Mean age = 41.7 ± 15.1 years	9606	Homo sapiens (human)	5512	mean age = 41.7  15.1 year	mean age = 41.7  15.1 year
+5 to 10 weeks	10000000	Mus musculus BALB/c	5513	5 to 10 week	5 to 10 week
+17-19 years	9606	Homo sapiens (human)	5514	17-19 year	17-19 year
+<16 years	9606	Homo sapiens (human)	5515	<16 year	<16 year
+12 to 16 weeks	10001406	Mus musculus MLR/lpr	5516	12 to 16 week	12 to 16 week
+19-52 years	9606	Homo sapiens (human)	5517	19-52 year	19-52 year
+5 to 8 weeks	10001405	Mus musculus NZB X NZW	5518	5 to 8 week	5 to 8 week
+Mean age = 39.8 ± 13.3 years	9606	Homo sapiens (human)	5519	mean age = 39.8  13.3 year	mean age = 39.8  13.3 year
+subadult	10000193	Bos taurus Holstein	5520	subadult	subadult
+33.7±4.6 years	9606	Homo sapiens (human)	5521	33.74.6 year	33.74.6 year
+39 to 51 years	9606	Homo sapiens (human)	5522	39 to 51 year	39 to 51 year
+19-45 years	9606	Homo sapiens (human)	5523	19-45 year	19-45 year
+12-68 years	9606	Homo sapiens (human)	5524	12-68 year	12-68 year
+31-47 years	9606	Homo sapiens (human)	5525	31-47 year	31-47 year
+26-49 years	9606	Homo sapiens (human)	5526	26-49 year	26-49 year
+42.3 ± 16.4 years	9606	Homo sapiens (human)	5527	42.3  16.4 year	42.3  16.4 year
+18 to 41 years	9606	Homo sapiens (human)	5528	18 to 41 year	18 to 41 year
+33.4±6 years	9606	Homo sapiens (human)	5529	33.46 year	33.46 year
+6 months - 47 years	9606	Homo sapiens (human)	5530	6 month - 47 year	6 month - 47 year
+8 to 12 weeks	10000033	Mus musculus C3H.SW	5531	8 to 12 week	8 to 12 week
+8-79 years	9606	Homo sapiens (human)	5532	8-79 year	8-79 year
+18-39 years	9606	Homo sapiens (human)	5533	18-39 year	18-39 year
+39-67 years	9606	Homo sapiens (human)	5534	39-67 year	39-67 year
+35.5±8.1 years	9606	Homo sapiens (human)	5535	35.58.1 year	35.58.1 year
+15-82 years	9606	Homo sapiens (human)	5536	15-82 year	15-82 year
+13-69 years	9606	Homo sapiens (human)	5537	13-69 year	13-69 year
+37-44 years	9606	Homo sapiens (human)	5538	37-44 year	37-44 year
+14-76 years	9606	Homo sapiens (human)	5539	14-76 year	14-76 year
+16-94 years	9606	Homo sapiens (human)	5540	16-94 year	16-94 year
+11-60 years	9606	Homo sapiens (human)	5541	11-60 year	11-60 year
+29-44 years	9606	Homo sapiens (human)	5542	29-44 year	29-44 year
+12-53 years	9606	Homo sapiens (human)	5543	12-53 year	12-53 year
+73 years	10000119	Homo sapiens Caucasian	5544	73 year	73 year
+37.4-47 years	9606	Homo sapiens (human)	5545	37.4-47 year	37.4-47 year
+40.7-59.3 years	9606	Homo sapiens (human)	5546	40.7-59.3 year	40.7-59.3 year
+8-16 weeks old	10000067	Mus musculus C57BL/6	5547	8-16 week old	8-16 week
+6 week old	10000000	Mus musculus BALB/c	5548	6 week old	6 week
+NULL	10001532	Mus musculus NZW X BXSB	5549	null	null
+15-70 years	9606	Homo sapiens (human)	5550	15-70 year	15-70 year
+mean age of 39.9 years	9606	Homo sapiens (human)	5551	mean age of 39.9 year	mean age of 39.9 year
+20-43 years	9606	Homo sapiens (human)	5552	20-43 year	20-43 year
+13 to 83 years	9606	Homo sapiens (human)	5553	13 to 83 year	13 to 83 year
+20 to 57 years	9606	Homo sapiens (human)	5554	20 to 57 year	20 to 57 year
+17-49 years	9606	Homo sapiens (human)	5555	17-49 year	17-49 year
+17-62 years	9606	Homo sapiens (human)	5556	17-62 year	17-62 year
+28-85 years	9606	Homo sapiens (human)	5557	28-85 year	28-85 year
+6 to 12 weeks	10001998	Mus musculus CD1	5558	6 to 12 week	6 to 12 week
+16-85 years	9606	Homo sapiens (human)	5559	16-85 year	16-85 year
+10-12 weeks old	10001575	Mus musculus C57BL/6 alpha1,3GT null	5560	10-12 week old	10-12 week
+six weeks	10000000	Mus musculus BALB/c	5561	6 week	6 week
+45-85 years	9606	Homo sapiens (human)	5562	45-85 year	45-85 year
+27 to 65 years	9606	Homo sapiens (human)	5563	27 to 65 year	27 to 65 year
+8.5 +/- 3.3 years	9606	Homo sapiens (human)	5564	8.5 ± 3.3 year	8.5 ± 3.3 year
+mean age = 38.7 years	9606	Homo sapiens (human)	5565	mean age = 38.7 year	mean age = 38.7 year
+22-79 years	9606	Homo sapiens (human)	5566	22-79 year	22-79 year
+mean age = 48.94 years	9606	Homo sapiens (human)	5567	mean age = 48.94 year	mean age = 48.94 year
+19 months	30538	Vicugna pacos (alpaca)	5568	19 month	19 month
+7-63 years	9606	Homo sapiens (human)	5569	7-63 year	7-63 year
+adult	9555	Papio anubis (Doguera baboon)	5570	adult	adult
+18 +/- 11 years	9606	Homo sapiens (human)	5571	18 ± 11 year	18 ± 11 year
+46-96 years	9606	Homo sapiens (human)	5572	46-96 year	46-96 year
+48 hours	10001041	Rattus norvegicus Wistar	5573	48 hour	48 hour
+16-20 weeks	10000625	Mus musculus MRL	5574	16-20 week	16-20 week
+12-14 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5575	12-14 week	12-14 week
+5 to 64 years	9606	Homo sapiens (human)	5576	5 to 64 year	5 to 64 year
+4 weeks	10000662	Rattus norvegicus Lewis	5577	4 week	4 week
+6 to 12 weeks	10000253	Mus musculus A/J	5578	6 to 12 week	6 to 12 week
+2 to 39 years	9606	Homo sapiens (human)	5579	2 to 39 year	2 to 39 year
+16 to 87 years	9606	Homo sapiens (human)	5580	16 to 87 year	16 to 87 year
+NULL	7801	Ginglymostoma cirratum (nurse shark)	5581	null	null
+10 weeks	10001487	Mus musculus Apolipoprotein E null	5582	10 week	10 week
+5 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5583	5 week	5 week
+10 weeks	10000655	Mus musculus Swiss Webster	5584	10 week	10 week
+12 weeks	10000190	Bos taurus Friesian	5585	12 week	12 week
+29 to 77 years	9606	Homo sapiens (human)	5586	29 to 77 year	29 to 77 year
+Young	9925	Capra hircus (domestic goat)	5587	young	young
+3-4 months	10001268	Mus musculus 3xTg-AD	5588	3-4 month	3-4 month
+5-81 years	9606	Homo sapiens (human)	5589	5-81 year	5-81 year
+26-43 years	9606	Homo sapiens (human)	5590	26-43 year	26-43 year
+NULL	10032	Cricetulus migratorius (gray dwarf hamster)	5591	null	null
+1-10 years	9606	Homo sapiens (human)	5592	1-10 year	1-10 year
+12 months	9913	Bos taurus (bovine)	5593	12 month	12 month
+19-62 years	9606	Homo sapiens (human)	5594	19-62 year	19-62 year
+2-3 years	9913	Bos taurus (bovine)	5595	2-3 year	2-3 year
+5-6 weeks	10001446	Rattus norvegicus Wistar Kyoto	5596	5-6 week	5-6 week
+>65 years	9606	Homo sapiens (human)	5597	>65 year	>65 year
+2.8 to 4.2	10001584	Sus scrofa alpha1,3GALT null	5598	2.8 to 4.2	2.8 to 4.2
+55 to 90 years	10000119	Homo sapiens Caucasian	5599	55 to 90 year	55 to 90 year
+39-44 years	9606	Homo sapiens (human)	5600	39-44 year	39-44 year
+14 to 65 years	9606	Homo sapiens (human)	5601	14 to 65 year	14 to 65 year
+29 to 59 years	9606	Homo sapiens (human)	5602	29 to 59 year	29 to 59 year
+4 weeks	10000625	Mus musculus MRL	5603	4 week	4 week
+36-66 years	9606	Homo sapiens (human)	5604	36-66 year	36-66 year
+4 to 6 week	10000000	Mus musculus BALB/c	5605	4 to 6 week	4 to 6 week
+21 to 91 years	9606	Homo sapiens (human)	5606	21 to 91 year	21 to 91 year
+2 to 58 years	9606	Homo sapiens (human)	5607	2 to 58 year	2 to 58 year
+4 months	10001406	Mus musculus MLR/lpr	5608	4 month	4 month
+5-6 weeks	10000618	Mus musculus ICR	5609	5-6 week	5-6 week
+24 to 55 years	9606	Homo sapiens (human)	5610	24 to 55 year	24 to 55 year
+22 weeks	10000639	Mus musculus NZB	5611	22 week	22 week
+24 to 87 years	9606	Homo sapiens (human)	5612	24 to 87 year	24 to 87 year
+12-66 years	9606	Homo sapiens (human)	5613	12-66 year	12-66 year
+Mean age = 58±12 years	9606	Homo sapiens (human)	5614	mean age = 5812 year	mean age = 5812 year
+17-56 years	9606	Homo sapiens (human)	5615	17-56 year	17-56 year
+31 to 67 years	9606	Homo sapiens (human)	5616	31 to 67 year	31 to 67 year
+6 to 8 weeks	10001099	Mus musculus CF-1	5617	6 to 8 week	6 to 8 week
+Adult	9534	Chlorocebus aethiops (African green monkey)	5618	adult	adult
+2-3 years old	9544	Macaca mulatta (rhesus macaque)	5619	2-3 year old	2-3 year
+NULL	9835	Camelid	5620	null	null
+1.5 month	10001241	Mus musculus APP	5621	1.5 month	1.5 month
+2-3 months	10000218	Mus musculus C57BL/6 X C3H	5622	2-3 month	2-3 month
+8 to 10 weeks	10001601	Mus musculus C57BL/6 X 129	5623	8 to 10 week	8 to 10 week
+7 to 8 weeks	10000017	Mus musculus BALB/c X DBA/2	5624	7 to 8 week	7 to 8 week
+35-43 years	9606	Homo sapiens (human)	5625	35-43 year	35-43 year
+18-67 years	9606	Homo sapiens (human)	5626	18-67 year	18-67 year
+24-49	9606	Homo sapiens (human)	5627	24-49	24-49
+6 to 15 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5628	6 to 15 week	6 to 15 week
+40 to 44 years	9606	Homo sapiens (human)	5629	40 to 44 year	40 to 44 year
+3-5 months	10001575	Mus musculus C57BL/6 alpha1,3GT null	5630	3-5 month	3-5 month
+4 to 60 months	9606	Homo sapiens (human)	5631	4 to 60 month	4 to 60 month
+8 days	10000220	Mus musculus C57BL/6 X DBA/2	5632	8 days	8 days
+19 weeks	10001657	Mus musculus NZW X BALB/c	5633	19 week	19 week
+60 to 74 years	9606	Homo sapiens (human)	5634	60 to 74 year	60 to 74 year
+3-5 months	10000067	Mus musculus C57BL/6	5635	3-5 month	3-5 month
+8 to 10 weeks	10001626	Mus musculus beta2m null	5636	8 to 10 week	8 to 10 week
+newborns - 29 years	9606	Homo sapiens (human)	5637	newborns - 29 year	newborns - 29 year
+23 to 82 years	10000119	Homo sapiens Caucasian	5638	23 to 82 year	23 to 82 year
+1 year 5 months to 15 years 8 months	9606	Homo sapiens (human)	5639	1 year 5 month to 15 year 8 month	1 year 5 month to 15 year 8 month
+6-8 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5640	6-8 week	6-8 week
+>24 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5641	>24 week	>24 week
+>22 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	5642	>22 week	>22 week
+8-20 weeks	10000228	Mus musculus CBA	5643	8-20 week	8-20 week
+NULL	10001661	Mus musculus alphaGal IgM H Tg	5644	null	null
+33 to 60 years	9606	Homo sapiens (human)	5645	33 to 60 year	33 to 60 year
+16 months	10001240	Mus musculus APPsw	5646	16 month	16 month
+12-15 weeks	10001405	Mus musculus NZB X NZW	5647	12-15 week	12-15 week
+27-55 years	9606	Homo sapiens (human)	5648	27-55 year	27-55 year
+> 65 years	9606	Homo sapiens (human)	5649	> 65 year	> 65 year
+21-78 years	9606	Homo sapiens (human)	5650	21-78 year	21-78 year
+23-79 years	9606	Homo sapiens (human)	5651	23-79 year	23-79 year
+62	10090	Mus musculus (mouse)	5652	62	62
+29-56 years	9606	Homo sapiens (human)	5653	29-56 year	29-56 year
+6 days to 7  months	10000639	Mus musculus NZB	5654	6 days to 7  month	6 days to 7  month
+8 weeks	10001041	Rattus norvegicus Wistar	5655	8 week	8 week
+average= 34.6 years	10000119	Homo sapiens Caucasian	5656	average= 34.6 year	average= 34.6 year
+NULL	9612	Canis lupus (wolf or dog)	5657	null	null
+average= 53.4  years	10000119	Homo sapiens Caucasian	5658	average= 53.4  year	average= 53.4  year
+average= 56.4  years	10000119	Homo sapiens Caucasian	5659	average= 56.4  year	average= 56.4  year
+8 weeks	9031	Gallus gallus (chicken)	5660	8 week	8 week
+70 days	10114	Rattus (rat)	5661	70 days	70 days
+12-80 years	9606	Homo sapiens (human)	5662	12-80 year	12-80 year
+22 years	10000119	Homo sapiens Caucasian	5663	22 year	22 year
+13 years	10000119	Homo sapiens Caucasian	5664	13 year	13 year
+5-59 years	9606	Homo sapiens (human)	5665	5-59 year	5-59 year
+17-132 days	9823	Sus scrofa (pig)	5666	17-132 days	17-132 days
+College age	9606	Homo sapiens (human)	5667	college age	college age
+2 months old	10000024	Mus musculus Biozzi	5668	2 month old	2 month
+NULL	10001124	Mus musculus Porton	5669	null	null
+12 weeks	10000216	Mus musculus C57BL/6 X BALB/c	5670	12 week	12 week
+3 weeks - 6 months	9796	Equus caballus (domestic horse)	5671	3 week - 6 month	3 week - 6 month
+5-6 years	9544	Macaca mulatta (rhesus macaque)	5672	5-6 year	5-6 year
+60-90-days-old	10000000	Mus musculus BALB/c	5673	60-90-days-old	60-90 days-old
+4-5 weeks	10000631	Mus musculus NMRI	5674	4-5 week	4-5 week
+31–83 years	9606	Homo sapiens (human)	5675	3183 year	3183 year
+3-week old	9940	Ovis aries (domestic sheep)	5676	3-week old	3 week
+15 weeks old	10000000	Mus musculus BALB/c	5677	15 week old	15 week
+Adults	34839	Chinchilla lanigera (long-tailed chinchilla)	5678	adults	adults
+3 months to 11 years	9606	Homo sapiens (human)	5679	3 month to 11 year	3 month to 11 year
+8-12 weeks	10000652	Mus musculus STU	5680	8-12 week	8-12 week
+0.9 to 3.7 years	10000195	Capra hircus Saanen	5681	0.9 to 3.7 year	0.9 to 3.7 year
+22–59 years	9606	Homo sapiens (human)	5682	2259 year	2259 year
+4-5 weeks	10000289	Mus musculus BALB.B	5683	4-5 week	4-5 week
+4-5 weeks	10000028	Mus musculus C3H	5684	4-5 week	4-5 week
+6 months	9606	Homo sapiens (human)	5685	6 month	6 month
+22–59	9606	Homo sapiens (human)	5686	2259	2259
+> 18 years old	9606	Homo sapiens (human)	5687	> 18 year old	> 18 year
+6 weeks	10000017	Mus musculus BALB/c X DBA/2	5688	6 week	6 week
+22-70 years	9606	Homo sapiens (human)	5689	22-70 year	22-70 year
+8 weeks	10000652	Mus musculus STU	5690	8 week	8 week
+4-115 months	9606	Homo sapiens (human)	5691	4-115 month	4-115 month
+46-79 years	9606	Homo sapiens (human)	5692	46-79 year	46-79 year
+4-5 weeks	10001537	Mus musculus PL	5693	4-5 week	4-5 week
+5 weeks	10000038	Mus musculus C3H/He	5694	5 week	5 week
+NULL	10001333	Rattus norvegicus LEW.1N	5695	null	null
+NULL	10001337	Rattus norvegicus LEWIS.1W	5696	null	null
+4-5 months	10000000	Mus musculus BALB/c	5697	4-5 month	4-5 month
+3 weeks	10000919	Gallus gallus White Leghorn	5698	3 week	3 week
+1-35 years	9606	Homo sapiens (human)	5699	1-35 year	1-35 year
+8-10 weeks	10000638	Mus musculus Nude	5700	8-10 week	8-10 week
+NULL	10000921	Gallus gallus Cobb 500	5701	null	null
+7 to 8 weeks	10000642	Mus musculus Outbred	5702	7 to 8 week	7 to 8 week
+10-20 weeks	10114	Rattus (rat)	5703	10-20 week	10-20 week
+adult, >32 years	9606	Homo sapiens (human)	5704	adult, >32 year	adult, >32 year
+7 to 11 years	9544	Macaca mulatta (rhesus macaque)	5705	7 to 11 year	7 to 11 year
+8-13 years	9606	Homo sapiens (human)	5706	8-13 year	8-13 year
+NULL	8187	Lates calcarifer (Asian seabass)	5707	null	null
+11-72 years	9606	Homo sapiens (human)	5708	11-72 year	11-72 year
+NULL	10001332	Rattus norvegicus LEW.1AV1	5709	null	null
+median 4 years	9606	Homo sapiens (human)	5710	median 4 year	median 4 year
+8-15 weeks old	10000000	Mus musculus BALB/c	5711	8-15 week old	8-15 week
+8-12 weeks	10000281	Mus musculus B10.WB	5712	8-12 week	8-12 week
+3-15 years old	9606	Homo sapiens (human)	5713	3-15 year old	3-15 year
+Young	9823	Sus scrofa (pig)	5714	young	young
+6 weeks	10000630	Mus musculus NHI Swiss	5715	6 week	6 week
+6-9 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	5716	6-9 week	6-9 week
+40 to 50 days	10000662	Rattus norvegicus Lewis	5717	40 to 50 days	40 to 50 days
+50-85 years	9606	Homo sapiens (human)	5718	50-85 year	50-85 year
+8-14 weeks	10001597	Mus musculus alpha-galactosyl transferase null	5719	8-14 week	8-14 week
+0.1-11 years	9606	Homo sapiens (human)	5720	0.1-11 year	0.1-11 year
+8.9-13.8 years	9615	Canis lupus familiaris (dogs)	5721	8.9-13.8 year	8.9-13.8 year
+Foals	9796	Equus caballus (domestic horse)	5722	foals	foals
+40-75 years	9606	Homo sapiens (human)	5723	40-75 year	40-75 year
+5 to 26	9606	Homo sapiens (human)	5724	5 to 26	5 to 26
+9-81 years	9606	Homo sapiens (human)	5725	9-81 year	9-81 year
+48.6 +/- 13.5 years	9606	Homo sapiens (human)	5726	48.6 ± 13.5 year	48.6 ± 13.5 year
+NULL	38020	marmosets	5727	null	null
+3-4 months	10000653	Mus musculus Swiss	5728	3-4 month	3-4 month
+2 years	9615	Canis lupus familiaris (dogs)	5729	2 year	2 year
+NULL	10001442	Rattus norvegicus Copenhagen	5730	null	null
+1-40 years	9606	Homo sapiens (human)	5731	1-40 year	1-40 year
+18 month old	10000191	Bos taurus Hereford	5732	18 month old	18 month
+37-43 years	9606	Homo sapiens (human)	5733	37-43 year	37-43 year
+14 weeks	10000000	Mus musculus BALB/c	5734	14 week	14 week
+44-86 years	9606	Homo sapiens (human)	5735	44-86 year	44-86 year
+14	9606	Homo sapiens (human)	5736	14	14
+4 to 6 weeks old	10001998	Mus musculus CD1	5737	4 to 6 week old	4 to 6 week
+38 weeks	10000000	Mus musculus BALB/c	5738	38 week	38 week
+10-39 years	9606	Homo sapiens (human)	5739	10-39 year	10-39 year
+20-30 years	9606	Homo sapiens (human)	5740	20-30 year	20-30 year
+6-8 weeks	10001241	Mus musculus APP	5741	6-8 week	6-8 week
+3-4 weeks	10001247	Oryctolagus cuniculus Dutch Half Lop	5742	3-4 week	3-4 week
+NULL	10000006	Mus musculus BALB/c GalNAc Transferase null	5743	null	null
+34-70 years	9606	Homo sapiens (human)	5744	34-70 year	34-70 year
+6 to 8 week	10000054	Mus musculus DBA/1	5745	6 to 8 week	6 to 8 week
+26-30 weeks	10000635	Mus musculus NOD/Lt	5746	26-30 week	26-30 week
+1-31 years	9606	Homo sapiens (human)	5747	1-31 year	1-31 year
+NULL	10001249	Mus musculus B10.A x BALB/c	5748	null	null
+7-14 months	10001240	Mus musculus APPsw	5749	7-14 month	7-14 month
+30 days	9823	Sus scrofa (pig)	5750	30 days	30 days
+55-89 years	9606	Homo sapiens (human)	5751	55-89 year	55-89 year
+0-84 years	9606	Homo sapiens (human)	5752	0-84 year	0-84 year
+9-10 months	10001240	Mus musculus APPsw	5753	9-10 month	9-10 month
+6-8 weeks	10000639	Mus musculus NZB	5754	6-8 week	6-8 week
+3 weeks-15 years	9606	Homo sapiens (human)	5755	3 week-15 year	3 week-15 year
+8 weeks	10001240	Mus musculus APPsw	5756	8 week	8 week
+5-7 weeks	10000635	Mus musculus NOD/Lt	5757	5-7 week	5-7 week
+Mean=8.4 ± 4.3	9606	Homo sapiens (human)	5758	mean=8.4  4.3	mean=8.4  4.3
+24-33 years	9606	Homo sapiens (human)	5759	24-33 year	24-33 year
+7-58 years	9606	Homo sapiens (human)	5760	7-58 year	7-58 year
+26-67 yrs	9606	Homo sapiens (human)	5761	26-67 year	26-67 year
+4-35 years	9606	Homo sapiens (human)	5762	4-35 year	4-35 year
+12-13 months	10001241	Mus musculus APP	5763	12-13 month	12-13 month
+8 to 10 weeks old	10000000	Mus musculus BALB/c	5764	8 to 10 week old	8 to 10 week
+65 days	9606	Homo sapiens (human)	5765	65 days	65 days
+2 months	10001241	Mus musculus APP	5766	2 month	2 month
+5-8 years	9544	Macaca mulatta (rhesus macaque)	5767	5-8 year	5-8 year
+NULL	135760	Maccullochella macquariensis (trout cod)	5768	null	null
+2 months	10001240	Mus musculus APPsw	5769	2 month	2 month
+12 weeks	10000015	Mus musculus BALB/c X C3H	5770	12 week	12 week
+30 to 67	9606	Homo sapiens (human)	5771	30 to 67	30 to 67
+6-11 months	10001240	Mus musculus APPsw	5772	6-11 month	6-11 month
+6 months - 9 years	9606	Homo sapiens (human)	5773	6 month - 9 year	6 month - 9 year
+6 to 84	9606	Homo sapiens (human)	5774	6 to 84	6 to 84
+5 weeks	10000108	Mus musculus C57BL/6 X B10.D2	5775	5 week	5 week
+39-59 years old	9606	Homo sapiens (human)	5776	39-59 year old	39-59 year
+16 months	10001241	Mus musculus APP	5777	16 month	16 month
+32 to 78	9606	Homo sapiens (human)	5778	32 to 78	32 to 78
+6-22.8 years	9606	Homo sapiens (human)	5779	6-22.8 year	6-22.8 year
+2-50 years	9606	Homo sapiens (human)	5780	2-50 year	2-50 year
+6-22.8	9606	Homo sapiens (human)	5781	6-22.8	6-22.8
+>69 years	9606	Homo sapiens (human)	5782	>69 year	>69 year
+33-88 years	9606	Homo sapiens (human)	5783	33-88 year	33-88 year
+8.6-22.8 years	9606	Homo sapiens (human)	5784	8.6-22.8 year	8.6-22.8 year
+18 months	10001268	Mus musculus 3xTg-AD	5785	18 month	18 month
+49.3-69.9 years	9606	Homo sapiens (human)	5786	49.3-69.9 year	49.3-69.9 year
+2 months	10001286	Mus musculus APPswe/PSEN1	5787	2 month	2 month
+9-10 months	10001278	Mus musculus APP751	5788	9-10 month	9-10 month
+4.5-26 years	9606	Homo sapiens (human)	5789	4.5-26 year	4.5-26 year
+8-16 weeks	10001309	Mus musculus hTNF Tg	5790	8-16 week	8-16 week
+adults, >32 years	9606	Homo sapiens (human)	5791	adults, >32 year	adults, >32 year
+19.8 to 38.8	9606	Homo sapiens (human)	5792	19.8 to 38.8	19.8 to 38.8
+15-77 years	9606	Homo sapiens (human)	5793	15-77 year	15-77 year
+elderly > 70 years	9606	Homo sapiens (human)	5794	elderly > 70 year	elderly > 70 year
+27-74 years	9606	Homo sapiens (human)	5795	27-74 year	27-74 year
+14 days	10000187	Sus scrofa Landrace X Large White	5796	14 days	14 days
+3 months to 64 years	9606	Homo sapiens (human)	5797	3 month to 64 year	3 month to 64 year
+8 to 12 weeks old	10000064	Mus musculus C57BL/10.Q	5798	8 to 12 week old	8 to 12 week
+16-72 years	9606	Homo sapiens (human)	5799	16-72 year	16-72 year
+8 months	9838	Camelus dromedarius (camel)	5800	8 month	8 month
+18-78 years	9606	Homo sapiens (human)	5801	18-78 year	18-78 year
+6 weeks	10000638	Mus musculus Nude	5802	6 week	6 week
+56.3 years	9606	Homo sapiens (human)	5803	56.3 year	56.3 year
+7 months - 9 years	9606	Homo sapiens (human)	5804	7 month - 9 year	7 month - 9 year
+12-week-old	10000000	Mus musculus BALB/c	5805	12-week-old	12 week
+3 months to 2 years	9606	Homo sapiens (human)	5806	3 month to 2 year	3 month to 2 year
+6 to 8 months	10000000	Mus musculus BALB/c	5807	6 to 8 month	6 to 8 month
+19-49	9606	Homo sapiens (human)	5808	19-49	19-49
+6-57 years	9606	Homo sapiens (human)	5809	6-57 year	6-57 year
+18-53	9606	Homo sapiens (human)	5810	18-53	18-53
+NULL	10026	Cricetinae (hamsters)	5811	null	null
+1 to 3 years	9606	Homo sapiens (human)	5812	1 to 3 year	1 to 3 year
+16-54 years	9606	Homo sapiens (human)	5813	16-54 year	16-54 year
+5 months	9031	Gallus gallus (chicken)	5814	5 month	5 month
+17-81	9606	Homo sapiens (human)	5815	17-81	17-81
+6 to 8 weeks	10001314	Mus musculus HPV 16 E7 Tg	5816	6 to 8 week	6 to 8 week
+7–8 weeks	10000658	Rattus norvegicus Brown Norway	5817	78 week	78 week
+7–8 weeks	10001041	Rattus norvegicus Wistar	5818	78 week	78 week
+20-82	9606	Homo sapiens (human)	5819	20-82	20-82
+3 months	10001286	Mus musculus APPswe/PSEN1	5820	3 month	3 month
+8 to 24 weeks	10000000	Mus musculus BALB/c	5821	8 to 24 week	8 to 24 week
+10-75 years	9606	Homo sapiens (human)	5822	10-75 year	10-75 year
+4 to 8 weeks	10000000	Mus musculus BALB/c	5823	4 to 8 week	4 to 8 week
+4 to 8 weeks	10001998	Mus musculus CD1	5824	4 to 8 week	4 to 8 week
+8-12 months	9913	Bos taurus (bovine)	5825	8-12 month	8-12 month
+NULL	10000629	Mus musculus ND4 Swiss Webster	5826	null	null
+6 to 8 weeks	10000061	Mus musculus FVB	5827	6 to 8 week	6 to 8 week
+10-week-old	10000000	Mus musculus BALB/c	5828	10-week-old	10 week
+26 to 52 weeks	10001314	Mus musculus HPV 16 E7 Tg	5829	26 to 52 week	26 to 52 week
+8-12 weeks	10000013	Mus musculus BALB/c X A/J	5830	8-12 week	8-12 week
+19-43	9606	Homo sapiens (human)	5831	19-43	19-43
+14 to 41 years	9606	Homo sapiens (human)	5832	14 to 41 year	14 to 41 year
+6-8 weeks	10001537	Mus musculus PL	5833	6-8 week	6-8 week
+2.5-16 years	9606	Homo sapiens (human)	5834	2.5-16 year	2.5-16 year
+6-10 weeks	9544	Macaca mulatta (rhesus macaque)	5835	6-10 week	6-10 week
+4 months-30 years	9606	Homo sapiens (human)	5836	4 month-30 year	4 month-30 year
+3 months	10001272	Cavia porcellus Strain 2	5837	3 month	3 month
+3 months	10001274	Cavia porcellus Strain (2 X 13)	5838	3 month	3 month
+16-44 years	9606	Homo sapiens (human)	5839	16-44 year	16-44 year
+4 months-15 years	9606	Homo sapiens (human)	5840	4 month-15 year	4 month-15 year
+21-86 years	9606	Homo sapiens (human)	5841	21-86 year	21-86 year
+33-66 years old	9606	Homo sapiens (human)	5842	33-66 year old	33-66 year
+27 to 45 years	9606	Homo sapiens (human)	5843	27 to 45 year	27 to 45 year
+21-47 years	9606	Homo sapiens (human)	5844	21-47 year	21-47 year
+6-8 weeks	9986	Oryctolagus cuniculus (rabbit)	5845	6-8 week	6-8 week
+36-43 days	10000667	Rattus norvegicus Sprague-Dawley	5846	36-43 days	36-43 days
+30-89 years old	9606	Homo sapiens (human)	5847	30-89 year old	30-89 year
+18-47 years old	9606	Homo sapiens (human)	5848	18-47 year old	18-47 year
+6-9 months	10001405	Mus musculus NZB X NZW	5849	6-9 month	6-9 month
+11 weeks	10000206	Oryctolagus cuniculus New Zealand White	5850	11 week	11 week
+5 weeks	10000667	Rattus norvegicus Sprague-Dawley	5851	5 week	5 week
+11 months	10001279	Mus musculus APP Tg-SwDI	5852	11 month	11 month
+4-18 years	9606	Homo sapiens (human)	5853	4-18 year	4-18 year
+8-12 weeks	10000028	Mus musculus C3H	5854	8-12 week	8-12 week
+2-54 years-old	9606	Homo sapiens (human)	5855	2-54 year-old	2-54 year
+5-11 years	9606	Homo sapiens (human)	5856	5-11 year	5-11 year
+32-60	9606	Homo sapiens (human)	5857	32-60	32-60
+9-10 weeks	10000054	Mus musculus DBA/1	5858	9-10 week	9-10 week
+8-12 weeks	10000220	Mus musculus C57BL/6 X DBA/2	5859	8-12 week	8-12 week
+5-49 years	9606	Homo sapiens (human)	5860	5-49 year	5-49 year
+3-4 months	10001019	Mus musculus B10.D2	5861	3-4 month	3-4 month
+8 weeks	10116	Rattus norvegicus (brown rat)	5862	8 week	8 week
+3-4 months	10000228	Mus musculus CBA	5863	3-4 month	3-4 month
+NULL	10001296	Mus musculus A.SW/SN	5864	null	null
+8-14 weeks	10000228	Mus musculus CBA	5865	8-14 week	8-14 week
+46-70 years	9606	Homo sapiens (human)	5866	46-70 year	46-70 year
+49-56 years	9606	Homo sapiens (human)	5867	49-56 year	49-56 year
+28 to 57 years	9606	Homo sapiens (human)	5868	28 to 57 year	28 to 57 year
+3-4 months	10001241	Mus musculus APP	5869	3-4 month	3-4 month
+4-6 weeks	10116	Rattus norvegicus (brown rat)	5870	4-6 week	4-6 week
+2 months old	10000206	Oryctolagus cuniculus New Zealand White	5871	2 month old	2 month
+13-72 years	9606	Homo sapiens (human)	5872	13-72 year	13-72 year
+8 to 12 weeks old	10000000	Mus musculus BALB/c	5873	8 to 12 week old	8 to 12 week
+8 weeks old	10000054	Mus musculus DBA/1	5874	8 week old	8 week
+12-16 weeks	10000054	Mus musculus DBA/1	5875	12-16 week	12-16 week
+6.5 to 11 years	9606	Homo sapiens (human)	5876	6.5 to 11 year	6.5 to 11 year
+6-8 weeks	10001395	Mus musculus BUB/Bn	5877	6-8 week	6-8 week
+4 to 6 weeks	10001041	Rattus norvegicus Wistar	5878	4 to 6 week	4 to 6 week
+54-74 years	9606	Homo sapiens (human)	5879	54-74 year	54-74 year
+mean age 45 years	9606	Homo sapiens (human)	5880	mean age 45 year	mean age 45 year
+3.5 months	10001279	Mus musculus APP Tg-SwDI	5881	3.5 month	3.5 month
+11-15 months	10001279	Mus musculus APP Tg-SwDI	5882	11-15 month	11-15 month
+10 months	10090	Mus musculus (mouse)	5883	10 month	10 month
+0.3-56 years	9606	Homo sapiens (human)	5884	0.3-56 year	0.3-56 year
+0.5-36 years	9606	Homo sapiens (human)	5885	0.5-36 year	0.5-36 year
+46-66 years	9606	Homo sapiens (human)	5886	46-66 year	46-66 year
+NULL	10001279	Mus musculus APP Tg-SwDI	5887	null	null
+0.3-45 years	9606	Homo sapiens (human)	5888	0.3-45 year	0.3-45 year
+18-87 years	9606	Homo sapiens (human)	5889	18-87 year	18-87 year
+mean age 59.8 years	9606	Homo sapiens (human)	5890	mean age 59.8 year	mean age 59.8 year
+2-12 years	9606	Homo sapiens (human)	5891	2-12 year	2-12 year
+14-64 years	9606	Homo sapiens (human)	5892	14-64 year	14-64 year
+21-74 years	9606	Homo sapiens (human)	5893	21-74 year	21-74 year
+32-46 years	9606	Homo sapiens (human)	5894	32-46 year	32-46 year
+6 to 8 weeks	10000255	Mus musculus AKR	5895	6 to 8 week	6 to 8 week
+5 to 6 weeks	10001406	Mus musculus MLR/lpr	5896	5 to 6 week	5 to 6 week
+Adult	9031	Gallus gallus (chicken)	5897	adult	adult
+6-8 weeks	10000600	Mus musculus HLA-DR Transgenic	5898	6-8 week	6-8 week
+7 to 12 weeks	10000662	Rattus norvegicus Lewis	5899	7 to 12 week	7 to 12 week
+21-77 years old	9606	Homo sapiens (human)	5900	21-77 year old	21-77 year
+8-12 weeks	10000023	Mus musculus BDF1	5901	8-12 week	8-12 week
+2 months	10000625	Mus musculus MRL	5902	2 month	2 month
+18-37 years	9606	Homo sapiens (human)	5903	18-37 year	18-37 year
+15-83 years	9606	Homo sapiens (human)	5904	15-83 year	15-83 year
+10-98 years	9606	Homo sapiens (human)	5905	10-98 year	10-98 year
+15 to 71 years	9606	Homo sapiens (human)	5906	15 to 71 year	15 to 71 year
+19-56 years	9606	Homo sapiens (human)	5907	19-56 year	19-56 year
+18 months	9940	Ovis aries (domestic sheep)	5908	18 month	18 month
+6 to 8 weeks	10001537	Mus musculus PL	5909	6 to 8 week	6 to 8 week
+14-42 years	9606	Homo sapiens (human)	5910	14-42 year	14-42 year
+NULL	10001507	Rattus norvegicus BioBreeding	5911	null	null
+2 months	10001268	Mus musculus 3xTg-AD	5912	2 month	2 month
+16 to 72 years	9606	Homo sapiens (human)	5913	16 to 72 year	16 to 72 year
+13-59 years	9606	Homo sapiens (human)	5914	13-59 year	13-59 year
+36-38 weeks	10001405	Mus musculus NZB X NZW	5915	36-38 week	36-38 week
+36-38 weeks	10000000	Mus musculus BALB/c	5916	36-38 week	36-38 week
+7-month-old	10001406	Mus musculus MLR/lpr	5917	7-month-old	7 month
+6-8 weeks	10001406	Mus musculus MLR/lpr	5918	6-8 week	6-8 week
+5 months	10001406	Mus musculus MLR/lpr	5919	5 month	5 month
+21, 27 and 36 weeks	10001405	Mus musculus NZB X NZW	5920	21, 27 and 36 week	21, 27 and 36 week
+10 to 12 weeks	10000625	Mus musculus MRL	5921	10 to 12 week	10 to 12 week
+52-84 years	9606	Homo sapiens (human)	5922	52-84 year	52-84 year
+22-72 years	9606	Homo sapiens (human)	5923	22-72 year	22-72 year
+45 days	10001041	Rattus norvegicus Wistar	5924	45 days	45 days
+6-10 weeks	10001406	Mus musculus MLR/lpr	5925	6-10 week	6-10 week
+6 to 8 weeks	10000625	Mus musculus MRL	5926	6 to 8 week	6 to 8 week
+17 months	10000625	Mus musculus MRL	5927	17 month	17 month
+12-20 weeks	10001406	Mus musculus MLR/lpr	5928	12-20 week	12-20 week
+12 - 20 weeks	10001406	Mus musculus MLR/lpr	5929	12 - 20 week	12 - 20 week
+14-22 weeks	10001406	Mus musculus MLR/lpr	5930	14-22 week	14-22 week
+50 to 68	9606	Homo sapiens (human)	5931	50 to 68	50 to 68
+Within 1 week after birth	9606	Homo sapiens (human)	5932	within 1 week after birth	within 1 week after birth
+17-58 years	9606	Homo sapiens (human)	5933	17-58 year	17-58 year
+49-71 years	9606	Homo sapiens (human)	5934	49-71 year	49-71 year
+47-62 years	9606	Homo sapiens (human)	5935	47-62 year	47-62 year
+14-67 years	9606	Homo sapiens (human)	5936	14-67 year	14-67 year
+50-74 years	9606	Homo sapiens (human)	5937	50-74 year	50-74 year
+0.3-5.7 years	9606	Homo sapiens (human)	5938	0.3-5.7 year	0.3-5.7 year
+10-12 weeks	10000625	Mus musculus MRL	5939	10-12 week	10-12 week
+16-17 years	9606	Homo sapiens (human)	5940	16-17 year	16-17 year
+10-12 weeks	10001406	Mus musculus MLR/lpr	5941	10-12 week	10-12 week
+6 weeks	10001133	Rattus norvegicus DA	5942	6 week	6 week
+15-73 years	9606	Homo sapiens (human)	5943	15-73 year	15-73 year
+26-47 years	9606	Homo sapiens (human)	5944	26-47 year	26-47 year
+32 to 66 years	9606	Homo sapiens (human)	5945	32 to 66 year	32 to 66 year
+48-51	9606	Homo sapiens (human)	5946	48-51	48-51
+40.8-69.4 years	9606	Homo sapiens (human)	5947	40.8-69.4 year	40.8-69.4 year
+21 days	10001427	Mus musculus viable motheaten	5948	21 days	21 days
+Young adult	10000000	Mus musculus BALB/c	5949	young adult	young adult
+23-66 years old	9606	Homo sapiens (human)	5950	23-66 year old	23-66 year
+6-62 years-old	9606	Homo sapiens (human)	5951	6-62 year-old	6-62 year
+13-68	9606	Homo sapiens (human)	5952	13-68	13-68
+12-20 weeks	9986	Oryctolagus cuniculus (rabbit)	5953	12-20 week	12-20 week
+12-18 months	10000194	Bos taurus Holstein-Friesian	5954	12-18 month	12-18 month
+23-38 years	9606	Homo sapiens (human)	5955	23-38 year	23-38 year
+4-6 months	9534	Chlorocebus aethiops (African green monkey)	5956	4-6 month	4-6 month
+7 weeks	10000618	Mus musculus ICR	5957	7 week	7 week
+21-57 years	9606	Homo sapiens (human)	5958	21-57 year	21-57 year
+7 months old	10000206	Oryctolagus cuniculus New Zealand White	5959	7 month old	7 month
+68 to 77 years	9606	Homo sapiens (human)	5960	68 to 77 year	68 to 77 year
+16 to 65 years	9606	Homo sapiens (human)	5961	16 to 65 year	16 to 65 year
+6-7 months	10001405	Mus musculus NZB X NZW	5962	6-7 month	6-7 month
+22-80 years	9606	Homo sapiens (human)	5963	22-80 year	22-80 year
+23.6-53.8	9606	Homo sapiens (human)	5964	23.6-53.8	23.6-53.8
+21-49 years	9606	Homo sapiens (human)	5965	21-49 year	21-49 year
+>10 weeks	10000662	Rattus norvegicus Lewis	5966	>10 week	>10 week
+5 months	10000662	Rattus norvegicus Lewis	5967	5 month	5 month
+28-70 years	9606	Homo sapiens (human)	5968	28-70 year	28-70 year
+40.6 +/- 11.4 years	9606	Homo sapiens (human)	5969	40.6 ± 11.4 year	40.6 ± 11.4 year
+Adult	10000660	Rattus norvegicus Fischer	5970	adult	adult
+Adult	10000658	Rattus norvegicus Brown Norway	5971	adult	adult
+12-18 weeks	10000067	Mus musculus C57BL/6	5972	12-18 week	12-18 week
+under 7 years	9606	Homo sapiens (human)	5973	under 7 year	under 7 year
+NULL	9548	Macaca radiata (bonnet macaque)	5974	null	null
+66 to 70 years	9606	Homo sapiens (human)	5975	66 to 70 year	66 to 70 year
+14 to 45	9606	Homo sapiens (human)	5976	14 to 45	14 to 45
+7 to 9 weeks	10000000	Mus musculus BALB/c	5977	7 to 9 week	7 to 9 week
+24 to 35 years	9606	Homo sapiens (human)	5978	24 to 35 year	24 to 35 year
+6 months	10001247	Oryctolagus cuniculus Dutch Half Lop	5979	6 month	6 month
+calves	10000193	Bos taurus Holstein	5980	calves	calves
+Steer	10000193	Bos taurus Holstein	5981	steer	steer
+33 to 53 years	9606	Homo sapiens (human)	5982	33 to 53 year	33 to 53 year
+4-6 months	10000206	Oryctolagus cuniculus New Zealand White	5983	4-6 month	4-6 month
+26 to 37 years	9606	Homo sapiens (human)	5984	26 to 37 year	26 to 37 year
+28–36 years	9606	Homo sapiens (human)	5985	2836 year	2836 year
+24 weeks	10000662	Rattus norvegicus Lewis	5986	24 week	24 week
+3 months	10000204	Oryctolagus cuniculus Japanese white	5987	3 month	3 month
+6 weeks	10000631	Mus musculus NMRI	5988	6 week	6 week
+20 weeks	10000662	Rattus norvegicus Lewis	5989	20 week	20 week
+adult	9337	Trichosurus vulpecula (common brush-tailed possum)	5990	adult	adult
+5 years	9606	Homo sapiens (human)	5991	5 year	5 year
+8 to 10 weeks	10000062	Mus musculus FVB/J	5992	8 to 10 week	8 to 10 week
+7-13 years	9606	Homo sapiens (human)	5993	7-13 year	7-13 year
+53-75 years	9606	Homo sapiens (human)	5994	53-75 year	53-75 year
+59-100 years	9606	Homo sapiens (human)	5995	59-100 year	59-100 year
+49-57 years	9606	Homo sapiens (human)	5996	49-57 year	49-57 year
+adult	9986	Oryctolagus cuniculus (rabbit)	5997	adult	adult
+5-13 years	9606	Homo sapiens (human)	5998	5-13 year	5-13 year
+17-57 years	9606	Homo sapiens (human)	5999	17-57 year	17-57 year
+16-24 years	9534	Chlorocebus aethiops (African green monkey)	6000	16-24 year	16-24 year
+6-12 months	10001241	Mus musculus APP	6001	6-12 month	6-12 month
+30 to 77 years	9606	Homo sapiens (human)	6002	30 to 77 year	30 to 77 year
+13 years	9548	Macaca radiata (bonnet macaque)	6003	13 year	13 year
+5-6 months	9986	Oryctolagus cuniculus (rabbit)	6004	5-6 month	5-6 month
+26-84 years	9606	Homo sapiens (human)	6005	26-84 year	26-84 year
+5 to 6 weeks	10000019	Mus musculus BALB/cByJ	6006	5 to 6 week	5 to 6 week
+17 to 82 years	9606	Homo sapiens (human)	6007	17 to 82 year	17 to 82 year
+59-84 years old	9606	Homo sapiens (human)	6008	59-84 year old	59-84 year
+37-69 years	9606	Homo sapiens (human)	6009	37-69 year	37-69 year
+7 months	10000206	Oryctolagus cuniculus New Zealand White	6010	7 month	7 month
+26-61 years	9606	Homo sapiens (human)	6011	26-61 year	26-61 year
+6 to 8 weeks	10000055	Mus musculus DBA/2	6012	6 to 8 week	6 to 8 week
+75.9 +/- 7.5 years	9606	Homo sapiens (human)	6013	75.9 ± 7.5 year	75.9 ± 7.5 year
+5-17 years	9606	Homo sapiens (human)	6014	5-17 year	5-17 year
+Elderly	9606	Homo sapiens (human)	6015	elderly	elderly
+3.1-18 years	9606	Homo sapiens (human)	6016	3.1-18 year	3.1-18 year
+19-55 years	9606	Homo sapiens (human)	6017	19-55 year	19-55 year
+14-79 years	9606	Homo sapiens (human)	6018	14-79 year	14-79 year
+17 months	10000627	Mus musculus MRL/MpJ	6019	17 month	17 month
+5 to 7 years	9548	Macaca radiata (bonnet macaque)	6020	5 to 7 year	5 to 7 year
+1-38 years	9606	Homo sapiens (human)	6021	1-38 year	1-38 year
+5 to 6 weeks	10001998	Mus musculus CD1	6022	5 to 6 week	5 to 6 week
+10 weeks	9823	Sus scrofa (pig)	6023	10 week	10 week
+38-68 years	9606	Homo sapiens (human)	6024	38-68 year	38-68 year
+27-47 years	9606	Homo sapiens (human)	6025	27-47 year	27-47 year
+31and 73 years	9606	Homo sapiens (human)	6026	31and 73 year	31and 73 year
+32 to 97 years	9606	Homo sapiens (human)	6027	32 to 97 year	32 to 97 year
+6 to 8 weeks	10000638	Mus musculus Nude	6028	6 to 8 week	6 to 8 week
+33 to 81 years	9606	Homo sapiens (human)	6029	33 to 81 year	33 to 81 year
+29 to 75 years	9606	Homo sapiens (human)	6030	29 to 75 year	29 to 75 year
+49-66 years	9606	Homo sapiens (human)	6031	49-66 year	49-66 year
+adult	10001211	Mus musculus (C57BL/6 X A/J)	6032	adult	adult
+11 to 82	9606	Homo sapiens (human)	6033	11 to 82	11 to 82
+7-30 years	9606	Homo sapiens (human)	6034	7-30 year	7-30 year
+17 to 84 years	9606	Homo sapiens (human)	6035	17 to 84 year	17 to 84 year
+17 to 84	9606	Homo sapiens (human)	6036	17 to 84	17 to 84
+38-72 years	9606	Homo sapiens (human)	6037	38-72 year	38-72 year
+6 to 10 weeks	10000236	Mus musculus CBA/J	6038	6 to 10 week	6 to 10 week
+6 to 10 weeks	10000206	Oryctolagus cuniculus New Zealand White	6039	6 to 10 week	6 to 10 week
+10-14 weeks	10001332	Rattus norvegicus LEW.1AV1	6040	10-14 week	10-14 week
+20 to 75	9606	Homo sapiens (human)	6041	20 to 75	20 to 75
+54-71 years	9606	Homo sapiens (human)	6042	54-71 year	54-71 year
+30-82 years old	9606	Homo sapiens (human)	6043	30-82 year old	30-82 year
+15 to 78 years	9606	Homo sapiens (human)	6044	15 to 78 year	15 to 78 year
+NULL	9337	Trichosurus vulpecula (common brush-tailed possum)	6045	null	null
+Less than 20 years	9606	Homo sapiens (human)	6046	less than 20 year	less than 20 year
+mature	9554	Papio (baboon)	6047	mature	mature
+NULL	10001354	Mus musculus SJL X BALB/c	6048	null	null
+20-95 years old	9606	Homo sapiens (human)	6049	20-95 year old	20-95 year
+18–73	9606	Homo sapiens (human)	6050	1873	1873
+17-74 years	9606	Homo sapiens (human)	6051	17-74 year	17-74 year
+middle aged	9606	Homo sapiens (human)	6052	middle aged	middle aged
+38-73	9606	Homo sapiens (human)	6053	38-73	38-73
+2-14 years	9606	Homo sapiens (human)	6054	2-14 year	2-14 year
+NULL	9493	Cebuella pygmaea (pygmy marmoset)	6055	null	null
+2 and 6 years	9615	Canis lupus familiaris (dogs)	6056	2 and 6 year	2 and 6 year
+40 to 66 years	9606	Homo sapiens (human)	6057	40 to 66 year	40 to 66 year
+43 to 83 years	9606	Homo sapiens (human)	6058	43 to 83 year	43 to 83 year
+23-47 years	9606	Homo sapiens (human)	6059	23-47 year	23-47 year
+8 to 10 weeks	10001471	Mus musculus NOD.Idd3/5	6060	8 to 10 week	8 to 10 week
+21-90 years old	9606	Homo sapiens (human)	6061	21-90 year old	21-90 year
+63 years	10000119	Homo sapiens Caucasian	6062	63 year	63 year
+NULL	10001473	Mus musculus 1H3.1 TCR Tg	6063	null	null
+21 months-45 years	9606	Homo sapiens (human)	6064	21 month-45 year	21 month-45 year
+19 to 79 years	9606	Homo sapiens (human)	6065	19 to 79 year	19 to 79 year
+16-66 years	9606	Homo sapiens (human)	6066	16-66 year	16-66 year
+22 to 55 years	9606	Homo sapiens (human)	6067	22 to 55 year	22 to 55 year
+Median age 33 years	9606	Homo sapiens (human)	6068	median age 33 year	median age 33 year
+NULL	10000639	Mus musculus NZB	6069	null	null
+49-76 years	9606	Homo sapiens (human)	6070	49-76 year	49-76 year
+32-79 years	9606	Homo sapiens (human)	6071	32-79 year	32-79 year
+54 to 70 years	9606	Homo sapiens (human)	6072	54 to 70 year	54 to 70 year
+25-75 years	9606	Homo sapiens (human)	6073	25-75 year	25-75 year
+40-84 years	9606	Homo sapiens (human)	6074	40-84 year	40-84 year
+19-75 years	9606	Homo sapiens (human)	6075	19-75 year	19-75 year
+34-61 years old	9606	Homo sapiens (human)	6076	34-61 year old	34-61 year
+37 to 78 years	9606	Homo sapiens (human)	6077	37 to 78 year	37 to 78 year
+30-63 years	9606	Homo sapiens (human)	6078	30-63 year	30-63 year
+8-9 weeks	10001427	Mus musculus viable motheaten	6079	8-9 week	8-9 week
+29-71 years	9606	Homo sapiens (human)	6080	29-71 year	29-71 year
+average age = 12.32 years	9606	Homo sapiens (human)	6081	average age = 12.32 year	average age = 12.32 year
+7 month	9940	Ovis aries (domestic sheep)	6082	7 month	7 month
+35-70 years	9606	Homo sapiens (human)	6083	35-70 year	35-70 year
+5 to 6 weeks	10000655	Mus musculus Swiss Webster	6084	5 to 6 week	5 to 6 week
+18-35	9606	Homo sapiens (human)	6085	18-35	18-35
+6-14 years	9606	Homo sapiens (human)	6086	6-14 year	6-14 year
+adult	10001099	Mus musculus CF-1	6087	adult	adult
+18 months	9913	Bos taurus (bovine)	6088	18 month	18 month
+mean age = 30.4 years	9606	Homo sapiens (human)	6089	mean age = 30.4 year	mean age = 30.4 year
+2-19 years	9606	Homo sapiens (human)	6090	2-19 year	2-19 year
+8-31 weeks	9823	Sus scrofa (pig)	6091	8-31 week	8-31 week
+3-4 months	10000000	Mus musculus BALB/c	6092	3-4 month	3-4 month
+19-83 years	9606	Homo sapiens (human)	6093	19-83 year	19-83 year
+11-12 weeks	10000000	Mus musculus BALB/c	6094	11-12 week	11-12 week
+0.8-18.7 years	9606	Homo sapiens (human)	6095	0.8-18.7 year	0.8-18.7 year
+52.7 +/- 10 years	9606	Homo sapiens (human)	6096	52.7 ± 10 year	52.7 ± 10 year
+32-72 years	9606	Homo sapiens (human)	6097	32-72 year	32-72 year
+48 +/- 12 years	9606	Homo sapiens (human)	6098	48 ± 12 year	48 ± 12 year
+24-54 years	9606	Homo sapiens (human)	6099	24-54 year	24-54 year
+2-11 years	9606	Homo sapiens (human)	6100	2-11 year	2-11 year
+2.5-22 years	9606	Homo sapiens (human)	6101	2.5-22 year	2.5-22 year
+6 to 8 weeks	10000642	Mus musculus Outbred	6102	6 to 8 week	6 to 8 week
+22 to 31 years	9606	Homo sapiens (human)	6103	22 to 31 year	22 to 31 year
+23-71 years	9606	Homo sapiens (human)	6104	23-71 year	23-71 year
+66.6 +/- 7.4 years	9606	Homo sapiens (human)	6105	66.6 ± 7.4 year	66.6 ± 7.4 year
+18-63 years	9606	Homo sapiens (human)	6106	18-63 year	18-63 year
+6-8 weeks	10001041	Rattus norvegicus Wistar	6107	6-8 week	6-8 week
+14-68 years	9606	Homo sapiens (human)	6108	14-68 year	14-68 year
+15-86 years	9606	Homo sapiens (human)	6109	15-86 year	15-86 year
+> 12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6110	> 12 week	> 12 week
+8 to 12 weeks	10001283	Mus musculus BALB/c X B10.Q	6111	8 to 12 week	8 to 12 week
+9 to 12 weeks	10001470	Mus musculus Factor VIII null	6112	9 to 12 week	9 to 12 week
+> 1.5 years	9483	Callithrix jacchus (common marmoset)	6113	> 1.5 year	> 1.5 year
+> 4 years	9544	Macaca mulatta (rhesus macaque)	6114	> 4 year	> 4 year
+21 to 86 years	9606	Homo sapiens (human)	6115	21 to 86 year	21 to 86 year
+3 to 14 years	9606	Homo sapiens (human)	6116	3 to 14 year	3 to 14 year
+20-59 years	9606	Homo sapiens (human)	6117	20-59 year	20-59 year
+31.63 +/- 1.37 years	9606	Homo sapiens (human)	6118	31.63 ± 1.37 year	31.63 ± 1.37 year
+36.1 years (mean)	9606	Homo sapiens (human)	6119	36.1 year (mean)	36.1 year (mean)
+55 ± 27 years	9606	Homo sapiens (human)	6120	55  27 year	55  27 year
+24.92 +/- 0.84	9606	Homo sapiens (human)	6121	24.92 ± 0.84	24.92 ± 0.84
+NULL	10001717	Mus musculus A.TH	6122	null	null
+8- to 10-week-old	10000000	Mus musculus BALB/c	6123	8- to 10-week-old	8- to 10 week
+3 years	9606	Homo sapiens (human)	6124	3 year	3 year
+<6 months	10000000	Mus musculus BALB/c	6125	<6 month	<6 month
+NULL	10001719	Mesocricetus auratus LVG	6126	null	null
+5 weeks.	10090	Mus musculus (mouse)	6127	5 week.	5 week.
+mean age = 46 years	9606	Homo sapiens (human)	6128	mean age = 46 year	mean age = 46 year
+43.62 +/- 1.07 years	9606	Homo sapiens (human)	6129	43.62 ± 1.07 year	43.62 ± 1.07 year
+young	10000000	Mus musculus BALB/c	6130	young	young
+100 day fetus	10001726	Sus scrofa Miniature Minnesota	6131	100 day fetus	100 day fetus
+4-6 weeks	10000915	Mus musculus Kunming	6132	4-6 week	4-6 week
+23 to 27 weeks	10001728	Mus musculus PBL-SCID-bo	6133	23 to 27 week	23 to 27 week
+23 to 27 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	6134	23 to 27 week	23 to 27 week
+35 to 65 years	9606	Homo sapiens (human)	6135	35 to 65 year	35 to 65 year
+9 weeks	9823	Sus scrofa (pig)	6136	9 week	9 week
+12-14 weeks old	10000000	Mus musculus BALB/c	6137	12-14 week old	12-14 week
+4 weeks	10000919	Gallus gallus White Leghorn	6138	4 week	4 week
+NULL	10000201	Oryctolagus cuniculus Fauve de Bourgogne	6139	null	null
+24-75 years	9606	Homo sapiens (human)	6140	24-75 year	24-75 year
+7-9 weeks	10000618	Mus musculus ICR	6141	7-9 week	7-9 week
+26 weeks	10000625	Mus musculus MRL	6142	26 week	26 week
+NULL	10001743	Mus musculus BW	6143	null	null
+< 30 years	9606	Homo sapiens (human)	6144	< 30 year	< 30 year
+2 to 65 years	9606	Homo sapiens (human)	6145	2 to 65 year	2 to 65 year
+30-52 years	9606	Homo sapiens (human)	6146	30-52 year	30-52 year
+NULL	10001744	Mus musculus B10.STC77	6147	null	null
+Adult	10001749	Rattus norvegicus KGH	6148	adult	adult
+18–55 years	9606	Homo sapiens (human)	6149	1855 year	1855 year
+NULL	198115	Alouatta macconnelli	6150	null	null
+16-77 years	9606	Homo sapiens (human)	6151	16-77 year	16-77 year
+48 ± 8 years	9606	Homo sapiens (human)	6152	48  8 year	48  8 year
+51.4 +/- 18 years	9606	Homo sapiens (human)	6153	51.4 ± 18 year	51.4 ± 18 year
+29 +/- 9 days	9913	Bos taurus (bovine)	6154	29 ± 9 days	29 ± 9 days
+3 to 4 months	9823	Sus scrofa (pig)	6155	3 to 4 month	3 to 4 month
+2-49 years	9606	Homo sapiens (human)	6156	2-49 year	2-49 year
+20 to 34 years	9606	Homo sapiens (human)	6157	20 to 34 year	20 to 34 year
+6-10 weeks	10000010	Mus musculus BALB/c LACK TCR Tg	6158	6-10 week	6-10 week
+6-7 weeks	10000915	Mus musculus Kunming	6159	6-7 week	6-7 week
+Mean age of 54. 04	9606	Homo sapiens (human)	6160	mean age of 54. 04	mean age of 54. 04
+6 weeks	10001717	Mus musculus A.TH	6161	6 week	6 week
+22 to 34 years	9606	Homo sapiens (human)	6162	22 to 34 year	22 to 34 year
+7.5 months	9606	Homo sapiens (human)	6163	7.5 month	7.5 month
+10-15 years	9544	Macaca mulatta (rhesus macaque)	6164	10-15 year	10-15 year
+6-7 weeks	10000019	Mus musculus BALB/cByJ	6165	6-7 week	6-7 week
+> 2 months	9823	Sus scrofa (pig)	6166	> 2 month	> 2 month
+72.5±5.2 years	9606	Homo sapiens (human)	6167	72.55.2 year	72.55.2 year
+72.3±6.7 years	9606	Homo sapiens (human)	6168	72.36.7 year	72.36.7 year
+mean age = 38.6 years	9606	Homo sapiens (human)	6169	mean age = 38.6 year	mean age = 38.6 year
+5-59 years old	9606	Homo sapiens (human)	6170	5-59 year old	5-59 year
+6–8weeks old	10000000	Mus musculus BALB/c	6171	68weeks old	68weeks old
+10 weeks	10000667	Rattus norvegicus Sprague-Dawley	6172	10 week	10 week
+32-68 years old	9606	Homo sapiens (human)	6173	32-68 year old	32-68 year
+>55 years	9606	Homo sapiens (human)	6174	>55 year	>55 year
+5-6 weeks old	10000654	Mus musculus Swiss albino	6175	5-6 week old	5-6 week
+NULL	100937	Papio papio (baboon)	6176	null	null
+4 weeks	10000017	Mus musculus BALB/c X DBA/2	6177	4 week	4 week
+36.47 +/- 12.46 years	9606	Homo sapiens (human)	6178	36.47 ± 12.46 year	36.47 ± 12.46 year
+40.15 +/- 8.8 years	9606	Homo sapiens (human)	6179	40.15 ± 8.8 year	40.15 ± 8.8 year
+Infants and adults	9606	Homo sapiens (human)	6180	infants and adults	infants and adults
+2 weeks	9103	Meleagris gallopavo (common turkey)	6181	2 week	2 week
+5 weeks	9103	Meleagris gallopavo (common turkey)	6182	5 week	5 week
+4 months	9925	Capra hircus (domestic goat)	6183	4 month	4 month
+10-62 years	9606	Homo sapiens (human)	6184	10-62 year	10-62 year
+4 to 6 weeks	10000655	Mus musculus Swiss Webster	6185	4 to 6 week	4 to 6 week
+53 +/- 11 years	9606	Homo sapiens (human)	6186	53 ± 11 year	53 ± 11 year
+21-85 years	9606	Homo sapiens (human)	6187	21-85 year	21-85 year
+mean age=53.7 years	9606	Homo sapiens (human)	6188	mean age=53.7 year	mean age=53.7 year
+16-22 years	9534	Chlorocebus aethiops (African green monkey)	6189	16-22 year	16-22 year
+5-10 weeks	10000038	Mus musculus C3H/He	6190	5-10 week	5-10 week
+2 weeks	10000668	Cavia porcellus Duncan-Hartley	6191	2 week	2 week
+17-50 years	9606	Homo sapiens (human)	6192	17-50 year	17-50 year
+NULL	10001790	Mus musculus alpha1KI	6193	null	null
+6 weeks	10000641	Mus musculus OF1	6194	6 week	6 week
+NULL	10002851	Mus musculus HLA-B*13:02 Tg	6195	null	null
+4-8 years	9606	Homo sapiens (human)	6196	4-8 year	4-8 year
+16 weeks	9986	Oryctolagus cuniculus (rabbit)	6197	16 week	16 week
+8 - 10 weeks	10000000	Mus musculus BALB/c	6198	8 - 10 week	8 - 10 week
+11-78 years	9606	Homo sapiens (human)	6199	11-78 year	11-78 year
+57-59	9606	Homo sapiens (human)	6200	57-59	57-59
+23-66	9606	Homo sapiens (human)	6201	23-66	23-66
+26-48	9606	Homo sapiens (human)	6202	26-48	26-48
+19-66	9606	Homo sapiens (human)	6203	19-66	19-66
+40-42	9606	Homo sapiens (human)	6204	40-42	40-42
+44-47	9606	Homo sapiens (human)	6205	44-47	44-47
+63-64	9606	Homo sapiens (human)	6206	63-64	63-64
+31-32	9606	Homo sapiens (human)	6207	31-32	31-32
+3-25 years	9606	Homo sapiens (human)	6208	3-25 year	3-25 year
+8 weeks	10000627	Mus musculus MRL/MpJ	6209	8 week	8 week
+6 months	10000206	Oryctolagus cuniculus New Zealand White	6210	6 month	6 month
+17-73 years	9606	Homo sapiens (human)	6211	17-73 year	17-73 year
+6-40 years	9606	Homo sapiens (human)	6212	6-40 year	6-40 year
+4 weeks	10000206	Oryctolagus cuniculus New Zealand White	6213	4 week	4 week
+18-28 years old	9606	Homo sapiens (human)	6214	18-28 year old	18-28 year
+18-41 years old	9606	Homo sapiens (human)	6215	18-41 year old	18-41 year
+4 to 6 weeks	10000253	Mus musculus A/J	6216	4 to 6 week	4 to 6 week
+60-80 years	9606	Homo sapiens (human)	6217	60-80 year	60-80 year
+4 to 6 weeks	10001998	Mus musculus CD1	6218	4 to 6 week	4 to 6 week
+6 to 7 weeks	10000973	Mus musculus 129	6219	6 to 7 week	6 to 7 week
+15 months	10000667	Rattus norvegicus Sprague-Dawley	6220	15 month	15 month
+66 weeks	10000000	Mus musculus BALB/c	6221	66 week	66 week
+10–14-week old	10000000	Mus musculus BALB/c	6222	1014-week old	1014 week
+25 years mean age	9606	Homo sapiens (human)	6223	25 year mean age	25 year mean age
+mean age = 65.6 years	9606	Homo sapiens (human)	6224	mean age = 65.6 year	mean age = 65.6 year
+3 weeks	10000275	Mus musculus B10.RIII	6225	3 week	3 week
+3 weeks	10000269	Mus musculus B10.G	6226	3 week	3 week
+3 weeks	10000276	Mus musculus B10.S	6227	3 week	3 week
+5 weeks	8839	Anas platyrhynchos (duck)	6228	5 week	5 week
+22-42 years	9606	Homo sapiens (human)	6229	22-42 year	22-42 year
+< 3 years	9606	Homo sapiens (human)	6230	< 3 year	< 3 year
+5 years	9541	Macaca fascicularis (crab eating macaque)	6231	5 year	5 year
+11-77 years	9606	Homo sapiens (human)	6232	11-77 year	11-77 year
+35-75 years old	9606	Homo sapiens (human)	6233	35-75 year old	35-75 year
+Mean age: 32.56 years	9606	Homo sapiens (human)	6234	mean age: 32.56 year	mean age: 32.56 year
+Mean age: 34 years	9606	Homo sapiens (human)	6235	mean age: 34 year	mean age: 34 year
+4 to 6 week old	10000263	Mus musculus B10.BR	6236	4 to 6 week old	4 to 6 week
+28-74 years	9606	Homo sapiens (human)	6237	28-74 year	28-74 year
+1.1–69 years	9606	Homo sapiens (human)	6238	1.169 year	1.169 year
+0.9-78 years	9606	Homo sapiens (human)	6239	0.9-78 year	0.9-78 year
+4 weeks old	9031	Gallus gallus (chicken)	6240	4 week old	4 week
+4 weeks old	8782	Ave (bird)	6241	4 week old	4 week
+Young adult	10000206	Oryctolagus cuniculus New Zealand White	6242	young adult	young adult
+3 months	8847	Anser sp. (goose)	6243	3 month	3 month
+4 weeks old	8847	Anser sp. (goose)	6244	4 week old	4 week
+4 weeks old	8839	Anas platyrhynchos (duck)	6245	4 week old	4 week
+30-58 years	9606	Homo sapiens (human)	6246	30-58 year	30-58 year
+23-64 years	9606	Homo sapiens (human)	6247	23-64 year	23-64 year
+8 weeks	10000248	Mus musculus 129 GIX+	6248	8 week	8 week
+12-14 weeks	10000199	Oryctolagus cuniculus Californian	6249	12-14 week	12-14 week
+7-8 weeks old	10000663	Rattus norvegicus LOU	6250	7-8 week old	7-8 week
+12-74 years	9606	Homo sapiens (human)	6251	12-74 year	12-74 year
+15 months	10001268	Mus musculus 3xTg-AD	6252	15 month	15 month
+36-63 years	9606	Homo sapiens (human)	6253	36-63 year	36-63 year
+49-72 years	9606	Homo sapiens (human)	6254	49-72 year	49-72 year
+NULL	10001976	Bos taurus Santa Gertrudis	6255	null	null
+8-46 years	9606	Homo sapiens (human)	6256	8-46 year	8-46 year
+12-15 months	10001268	Mus musculus 3xTg-AD	6257	12-15 month	12-15 month
+20-84 years	9606	Homo sapiens (human)	6258	20-84 year	20-84 year
+39.0 +/- 13.8 years	9606	Homo sapiens (human)	6259	39.0 ± 13.8 year	39.0 ± 13.8 year
+60 days	10000038	Mus musculus C3H/He	6260	60 days	60 days
+27 to 60 years	9606	Homo sapiens (human)	6261	27 to 60 year	27 to 60 year
+NULL	7962	Cyprinus carpio (carp)	6262	null	null
+27 to 77 years	9606	Homo sapiens (human)	6263	27 to 77 year	27 to 77 year
+33 to 84 years	9606	Homo sapiens (human)	6264	33 to 84 year	33 to 84 year
+13-34 years	9606	Homo sapiens (human)	6265	13-34 year	13-34 year
+6 to 38 years	9606	Homo sapiens (human)	6266	6 to 38 year	6 to 38 year
+35 to 56 years	9606	Homo sapiens (human)	6267	35 to 56 year	35 to 56 year
+2 weeks	10001436	Gallus gallus P2a	6268	2 week	2 week
+44.1 +/- 13.2 years	9606	Homo sapiens (human)	6269	44.1 ± 13.2 year	44.1 ± 13.2 year
+41.5 +/- 9.8 years	9606	Homo sapiens (human)	6270	41.5 ± 9.8 year	41.5 ± 9.8 year
+31.7+/-4.5	9606	Homo sapiens (human)	6271	31.7±4.5	31.7±4.5
+7.5 to 16.5 years	9606	Homo sapiens (human)	6272	7.5 to 16.5 year	7.5 to 16.5 year
+37.0 +/- 12.6 years	9606	Homo sapiens (human)	6273	37.0 ± 12.6 year	37.0 ± 12.6 year
+31.6+/-5.4	9606	Homo sapiens (human)	6274	31.6±5.4	31.6±5.4
+22-85 years	9606	Homo sapiens (human)	6275	22-85 year	22-85 year
+3 months	10001240	Mus musculus APPsw	6276	3 month	3 month
+4-6 weeks old	10000645	Mus musculus PrP null	6277	4-6 week old	4-6 week
+6 weeks old	10000645	Mus musculus PrP null	6278	6 week old	6 week
+37-57 years	9606	Homo sapiens (human)	6279	37-57 year	37-57 year
+5 to 38 years	9606	Homo sapiens (human)	6280	5 to 38 year	5 to 38 year
+2 to 15 years	9606	Homo sapiens (human)	6281	2 to 15 year	2 to 15 year
+8 +/- 3 years	9606	Homo sapiens (human)	6282	8 ± 3 year	8 ± 3 year
+5 week old	10000645	Mus musculus PrP null	6283	5 week old	5 week
+60 to 77 years	9606	Homo sapiens (human)	6284	60 to 77 year	60 to 77 year
+27 to 37 years	9606	Homo sapiens (human)	6285	27 to 37 year	27 to 37 year
+28 to 39 years	9606	Homo sapiens (human)	6286	28 to 39 year	28 to 39 year
+8 to 10 weeks	10000668	Cavia porcellus Duncan-Hartley	6287	8 to 10 week	8 to 10 week
+38+/- 11 years	9606	Homo sapiens (human)	6288	38± 11 year	38± 11 year
+3 years	9541	Macaca fascicularis (crab eating macaque)	6289	3 year	3 year
+2 to 73 years	9606	Homo sapiens (human)	6290	2 to 73 year	2 to 73 year
+median age 21 years	9606	Homo sapiens (human)	6291	median age 21 year	median age 21 year
+43-70 years	9606	Homo sapiens (human)	6292	43-70 year	43-70 year
+36 to 47 years	9606	Homo sapiens (human)	6293	36 to 47 year	36 to 47 year
+34-48 years	9606	Homo sapiens (human)	6294	34-48 year	34-48 year
+70 +/- 9 years	9606	Homo sapiens (human)	6295	70 ± 9 year	70 ± 9 year
+8 weeks	10000653	Mus musculus Swiss	6296	8 week	8 week
+64 to 76 years	9606	Homo sapiens (human)	6297	64 to 76 year	64 to 76 year
+6 - 8 weeks	10000253	Mus musculus A/J	6298	6 - 8 week	6 - 8 week
+3-48 years old	9606	Homo sapiens (human)	6299	3-48 year old	3-48 year
+1 year 8 months to 68 years	9606	Homo sapiens (human)	6300	1 year 8 month to 68 year	1 year 8 month to 68 year
+31 to 49 years	9606	Homo sapiens (human)	6301	31 to 49 year	31 to 49 year
+15 to 67 years	9606	Homo sapiens (human)	6302	15 to 67 year	15 to 67 year
+21 to 84 years	9606	Homo sapiens (human)	6303	21 to 84 year	21 to 84 year
+16 to 84 years	9606	Homo sapiens (human)	6304	16 to 84 year	16 to 84 year
+mean age = 40.3 years	9606	Homo sapiens (human)	6305	mean age = 40.3 year	mean age = 40.3 year
+10 to 801 days	10001584	Sus scrofa alpha1,3GALT null	6306	10 to 801 days	10 to 801 days
+Four-week-old	10000919	Gallus gallus White Leghorn	6307	4-week-old	4 week
+8-week-old	10000000	Mus musculus BALB/c	6308	8-week-old	8 week
+NULL	7797	Squalus acanthias (spiny dogfish)	6309	null	null
+8 to 9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6310	8 to 9 week	8 to 9 week
+NULL	9872	Odocoileus hemionus (mule deer)	6311	null	null
+3-70 years old	9606	Homo sapiens (human)	6312	3-70 year old	3-70 year
+3 to 56 years	9606	Homo sapiens (human)	6313	3 to 56 year	3 to 56 year
+2 to 47 years	9606	Homo sapiens (human)	6314	2 to 47 year	2 to 47 year
+3 years	9534	Chlorocebus aethiops (African green monkey)	6315	3 year	3 year
+Adult	10000920	Gallus gallus Leghorn	6316	adult	adult
+8-9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6317	8-9 week	8-9 week
+48 months	9913	Bos taurus (bovine)	6318	48 month	48 month
+mean age = 63 years	9606	Homo sapiens (human)	6319	mean age = 63 year	mean age = 63 year
+mean age = 57 years	9606	Homo sapiens (human)	6320	mean age = 57 year	mean age = 57 year
+9 to 53 years	9606	Homo sapiens (human)	6321	9 to 53 year	9 to 53 year
+5-13 weeks	10000000	Mus musculus BALB/c	6322	5-13 week	5-13 week
+4 weeks	10090	Mus musculus (mouse)	6323	4 week	4 week
+mean 53.8 years	9606	Homo sapiens (human)	6324	mean 53.8 year	mean 53.8 year
+24 weeks	10000000	Mus musculus BALB/c	6325	24 week	24 week
+6 - 8 weeks	10001487	Mus musculus Apolipoprotein E null	6326	6 - 8 week	6 - 8 week
+25 to 45 years	9606	Homo sapiens (human)	6327	25 to 45 year	25 to 45 year
+0.7 to 20.9 years (median = 11.0)	9606	Homo sapiens (human)	6328	0.7 to 20.9 year (median = 11.0)	0.7 to 20.9 year (median = 11.0)
+2 to 67 years	9606	Homo sapiens (human)	6329	2 to 67 year	2 to 67 year
+2 to 53 years	9606	Homo sapiens (human)	6330	2 to 53 year	2 to 53 year
+4-6 weeks	10000218	Mus musculus C57BL/6 X C3H	6331	4-6 week	4-6 week
+36.2 +/- 8.9 years	9606	Homo sapiens (human)	6332	36.2 ± 8.9 year	36.2 ± 8.9 year
+7 to 8 weeks	10000019	Mus musculus BALB/cByJ	6333	7 to 8 week	7 to 8 week
+6 to 12 months	9669	Mustela putorius furo (black ferret)	6334	6 to 12 month	6 to 12 month
+20-24 weeks	10001406	Mus musculus MLR/lpr	6335	20-24 week	20-24 week
+3 years	10090	Mus musculus (mouse)	6336	3 year	3 year
+1-2 years	9940	Ovis aries (domestic sheep)	6337	1-2 year	1-2 year
+4-6 weeks	10001221	Mus musculus C57BL/6 x SJL	6338	4-6 week	4-6 week
+13 weeks	10000000	Mus musculus BALB/c	6339	13 week	13 week
+0.5 - 3 years	9606	Homo sapiens (human)	6340	0.5 - 3 year	0.5 - 3 year
+2-65 years	9606	Homo sapiens (human)	6341	2-65 year	2-65 year
+3 weeks	10000639	Mus musculus NZB	6342	3 week	3 week
+26 weeks	10001406	Mus musculus MLR/lpr	6343	26 week	26 week
+59 to 80 years	9606	Homo sapiens (human)	6344	59 to 80 year	59 to 80 year
+9 to 12 weeks	10090	Mus musculus (mouse)	6345	9 to 12 week	9 to 12 week
+10-64 years	9606	Homo sapiens (human)	6346	10-64 year	10-64 year
+6 weeks	8835	Anas (ducks)	6347	6 week	6 week
+24 to 59 years	9606	Homo sapiens (human)	6348	24 to 59 year	24 to 59 year
+10 weeks	10000194	Bos taurus Holstein-Friesian	6349	10 week	10 week
+27 to 55 years	9606	Homo sapiens (human)	6350	27 to 55 year	27 to 55 year
+19 to 64 years	9606	Homo sapiens (human)	6351	19 to 64 year	19 to 64 year
+9 to 10 weeks	10000067	Mus musculus C57BL/6	6352	9 to 10 week	9 to 10 week
+3-4 weeks	9823	Sus scrofa (pig)	6353	3-4 week	3-4 week
+10 weeks	10000653	Mus musculus Swiss	6354	10 week	10 week
+NULL	8847	Anser sp. (goose)	6355	null	null
+NULL	8835	Anas (ducks)	6356	null	null
+58.4 +/- 14.3 years	9606	Homo sapiens (human)	6357	58.4 ± 14.3 year	58.4 ± 14.3 year
+NULL	40674	Mammal	6358	null	null
+<42-79 years	9606	Homo sapiens (human)	6359	<42-79 year	<42-79 year
+24-61 years	9606	Homo sapiens (human)	6360	24-61 year	24-61 year
+2 to 4 weeks	10000067	Mus musculus C57BL/6	6361	2 to 4 week	2 to 4 week
+1 month - 13 years	9606	Homo sapiens (human)	6362	1 month - 13 year	1 month - 13 year
+18-74 years	9606	Homo sapiens (human)	6363	18-74 year	18-74 year
+26-96 years	9606	Homo sapiens (human)	6364	26-96 year	26-96 year
+9-12 weeks	10001926	Mus musculus FVIII null	6365	9-12 week	9-12 week
+2-3 months	10001406	Mus musculus MLR/lpr	6366	2-3 month	2-3 month
+6 months	10000185	Canis familiaris beagle	6367	6 month	6 month
+15 months	10001286	Mus musculus APPswe/PSEN1	6368	15 month	15 month
+38-55  years	9606	Homo sapiens (human)	6369	38-55  year	38-55  year
+8 to 10 years	9541	Macaca fascicularis (crab eating macaque)	6370	8 to 10 year	8 to 10 year
+54-64 years	10000119	Homo sapiens Caucasian	6371	54-64 year	54-64 year
+60 years	10000119	Homo sapiens Caucasian	6372	60 year	60 year
+1 year	9986	Oryctolagus cuniculus (rabbit)	6373	1 year	1 year
+6 or 12 months	10001286	Mus musculus APPswe/PSEN1	6374	6 or 12 month	6 or 12 month
+7 weeks	10000915	Mus musculus Kunming	6375	7 week	7 week
+55-79 years	9606	Homo sapiens (human)	6376	55-79 year	55-79 year
+7 to 78 years	9606	Homo sapiens (human)	6377	7 to 78 year	7 to 78 year
+5 to 80 years	9606	Homo sapiens (human)	6378	5 to 80 year	5 to 80 year
+4 months	10000000	Mus musculus BALB/c	6379	4 month	4 month
+3 to 5 years	9541	Macaca fascicularis (crab eating macaque)	6380	3 to 5 year	3 to 5 year
+51-74 years	9606	Homo sapiens (human)	6381	51-74 year	51-74 year
+27 weeks	10001406	Mus musculus MLR/lpr	6382	27 week	27 week
+42.18+/-13.23	9606	Homo sapiens (human)	6383	42.18±13.23	42.18±13.23
+44.94+/-15.65	9606	Homo sapiens (human)	6384	44.94±15.65	44.94±15.65
+20 weeks	10001406	Mus musculus MLR/lpr	6385	20 week	20 week
+> 2 months	10000067	Mus musculus C57BL/6	6386	> 2 month	> 2 month
+4 years	9544	Macaca mulatta (rhesus macaque)	6387	4 year	4 year
+1 to 5 years	9606	Homo sapiens (human)	6388	1 to 5 year	1 to 5 year
+8 weeks	10000204	Oryctolagus cuniculus Japanese white	6389	8 week	8 week
+5 to 7 weeks	10000038	Mus musculus C3H/He	6390	5 to 7 week	5 to 7 week
+10 to 73 years	9606	Homo sapiens (human)	6391	10 to 73 year	10 to 73 year
+34-71 years	9606	Homo sapiens (human)	6392	34-71 year	34-71 year
+5-12 months	10001286	Mus musculus APPswe/PSEN1	6393	5-12 month	5-12 month
+34-68 years	9606	Homo sapiens (human)	6394	34-68 year	34-68 year
+NULL	10001598	Mus musculus human duffy Fyb protein Tg	6395	null	null
+8 to 12 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6396	8 to 12 week	8 to 12 week
+NULL	10001599	Mus musculus duffy Fy null	6397	null	null
+6 to 8 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6398	6 to 8 week	6 to 8 week
+8.4 to 12.4 years	10000185	Canis familiaris beagle	6399	8.4 to 12.4 year	8.4 to 12.4 year
+44-74 years	9606	Homo sapiens (human)	6400	44-74 year	44-74 year
+28-82	9606	Homo sapiens (human)	6401	28-82	28-82
+34-82 years	9606	Homo sapiens (human)	6402	34-82 year	34-82 year
+3.4-86 years	9606	Homo sapiens (human)	6403	3.4-86 year	3.4-86 year
+5 to 14 years	9606	Homo sapiens (human)	6404	5 to 14 year	5 to 14 year
+18 months	10000627	Mus musculus MRL/MpJ	6405	18 month	18 month
+> 12 years old	9606	Homo sapiens (human)	6406	> 12 year old	> 12 year
+2 to 16 years	9606	Homo sapiens (human)	6407	2 to 16 year	2 to 16 year
+1 day to 103 years	9606	Homo sapiens (human)	6408	1 day to 103 year	1 day to 103 year
+6-8 weeks	10000631	Mus musculus NMRI	6409	6-8 week	6-8 week
+4 months	9986	Oryctolagus cuniculus (rabbit)	6410	4 month	4 month
+38-54 weeks	10000627	Mus musculus MRL/MpJ	6411	38-54 week	38-54 week
+4-43 years	9606	Homo sapiens (human)	6412	4-43 year	4-43 year
+2 years	9481	Callithrix (marmoset)	6413	2 year	2 year
+23.2 +/- 5.7 years	9606	Homo sapiens (human)	6414	23.2 ± 5.7 year	23.2 ± 5.7 year
+1 year	10002168	Oryctolagus cuniculus Belgian White	6415	1 year	1 year
+8 to 10 months	10000220	Mus musculus C57BL/6 X DBA/2	6416	8 to 10 month	8 to 10 month
+13-22 years	9606	Homo sapiens (human)	6417	13-22 year	13-22 year
+60.9 +/- 11 years	9606	Homo sapiens (human)	6418	60.9 ± 11 year	60.9 ± 11 year
+59.4 +/- 5.4 years	9606	Homo sapiens (human)	6419	59.4 ± 5.4 year	59.4 ± 5.4 year
+0-96 years	9606	Homo sapiens (human)	6420	0-96 year	0-96 year
+38-79 years	9606	Homo sapiens (human)	6421	38-79 year	38-79 year
+6-7 weks	10000662	Rattus norvegicus Lewis	6422	6-7 week	6-7 week
+22 weeks	10000919	Gallus gallus White Leghorn	6423	22 week	22 week
+10-77 years	9606	Homo sapiens (human)	6424	10-77 year	10-77 year
+4.5-12.1 years	9541	Macaca fascicularis (crab eating macaque)	6425	4.5-12.1 year	4.5-12.1 year
+12-30	9606	Homo sapiens (human)	6426	12-30	12-30
+43 t0 53 months	9483	Callithrix jacchus (common marmoset)	6427	43 t0 53 month	43 t0 53 month
+98 to 140 days	9031	Gallus gallus (chicken)	6428	98 to 140 days	98 to 140 days
+28 to 54 years	9606	Homo sapiens (human)	6429	28 to 54 year	28 to 54 year
+8-10 weeks	10000062	Mus musculus FVB/J	6430	8-10 week	8-10 week
+8 weeks	10001446	Rattus norvegicus Wistar Kyoto	6431	8 week	8 week
+35-84 years	9606	Homo sapiens (human)	6432	35-84 year	35-84 year
+35-85 years	9606	Homo sapiens (human)	6433	35-85 year	35-85 year
+2 to 6 years	9606	Homo sapiens (human)	6434	2 to 6 year	2 to 6 year
+18-33 years	9606	Homo sapiens (human)	6435	18-33 year	18-33 year
+19 to 85 years	9606	Homo sapiens (human)	6436	19 to 85 year	19 to 85 year
+2 months	42414	Sigmodon (cotton rat)	6437	2 month	2 month
+1 to 5 years or > 15 years	9606	Homo sapiens (human)	6438	1 to 5 year or > 15 year	1 to 5 year or > 15 year
+adult	10001041	Rattus norvegicus Wistar	6439	adult	adult
+NULL	10001247	Oryctolagus cuniculus Dutch Half Lop	6440	null	null
+mean age = 4.4 years	9544	Macaca mulatta (rhesus macaque)	6441	mean age = 4.4 year	mean age = 4.4 year
+NULL	10000641	Mus musculus OF1	6442	null	null
+mean age 3-4 years	9606	Homo sapiens (human)	6443	mean age 3-4 year	mean age 3-4 year
+4 to 80 years	9606	Homo sapiens (human)	6444	4 to 80 year	4 to 80 year
+4 weeks	10000618	Mus musculus ICR	6445	4 week	4 week
+median age 63 years	9606	Homo sapiens (human)	6446	median age 63 year	median age 63 year
+adult	10001001	Rattus norvegicus WKAH	6447	adult	adult
+31-66 years	9606	Homo sapiens (human)	6448	31-66 year	31-66 year
+22-63 years	9606	Homo sapiens (human)	6449	22-63 year	22-63 year
+27-105 years	9606	Homo sapiens (human)	6450	27-105 year	27-105 year
+9.42 +/- 3.84 years	9606	Homo sapiens (human)	6451	9.42 ± 3.84 year	9.42 ± 3.84 year
+6.94 +/- 3.58 years	9606	Homo sapiens (human)	6452	6.94 ± 3.58 year	6.94 ± 3.58 year
+9 weeks	10000024	Mus musculus Biozzi	6453	9 week	9 week
+15 to 92 years	9606	Homo sapiens (human)	6454	15 to 92 year	15 to 92 year
+11 +/- 7 years	9606	Homo sapiens (human)	6455	11 ± 7 year	11 ± 7 year
+12.9 +/- 7.7 years	9606	Homo sapiens (human)	6456	12.9 ± 7.7 year	12.9 ± 7.7 year
+12.8 +/- 8 years	9606	Homo sapiens (human)	6457	12.8 ± 8 year	12.8 ± 8 year
+13.6 +/- 6.8 years	9606	Homo sapiens (human)	6458	13.6 ± 6.8 year	13.6 ± 6.8 year
+22.7 +/- 14 years	9606	Homo sapiens (human)	6459	22.7 ± 14 year	22.7 ± 14 year
+14.1 +/- 12 years	9606	Homo sapiens (human)	6460	14.1 ± 12 year	14.1 ± 12 year
+9.6 +/- 3.1 years	9606	Homo sapiens (human)	6461	9.6 ± 3.1 year	9.6 ± 3.1 year
+14.3 +/- 5.7 years	9606	Homo sapiens (human)	6462	14.3 ± 5.7 year	14.3 ± 5.7 year
+23.8 +/- 2.3 years	9606	Homo sapiens (human)	6463	23.8 ± 2.3 year	23.8 ± 2.3 year
+4-9 years	9606	Homo sapiens (human)	6464	4-9 year	4-9 year
+34-75 years	9606	Homo sapiens (human)	6465	34-75 year	34-75 year
+12 to 54 years	9606	Homo sapiens (human)	6466	12 to 54 year	12 to 54 year
+1 to 66 years	9606	Homo sapiens (human)	6467	1 to 66 year	1 to 66 year
+4 to 54 years	9606	Homo sapiens (human)	6468	4 to 54 year	4 to 54 year
+4 to 28 years	9606	Homo sapiens (human)	6469	4 to 28 year	4 to 28 year
+50.3 years median age	9606	Homo sapiens (human)	6470	50.3 year median age	50.3 year median age
+56.5 years median age	9606	Homo sapiens (human)	6471	56.5 year median age	56.5 year median age
+6-12 weeks	9669	Mustela putorius furo (black ferret)	6472	6-12 week	6-12 week
+17-95 years	9606	Homo sapiens (human)	6473	17-95 year	17-95 year
+13-81 years	9606	Homo sapiens (human)	6474	13-81 year	13-81 year
+9 weeks	10090	Mus musculus (mouse)	6475	9 week	9 week
+55.9 +/- 19.2 years	9606	Homo sapiens (human)	6476	55.9 ± 19.2 year	55.9 ± 19.2 year
+8-10 weeks	10001575	Mus musculus C57BL/6 alpha1,3GT null	6477	8-10 week	8-10 week
+piglet	9823	Sus scrofa (pig)	6478	piglet	piglet
+1-60 years	9606	Homo sapiens (human)	6479	1-60 year	1-60 year
+3 months	1240228	Cairina moschata domestica (Muscovy Duck (domestic type))	6480	3 month	3 month
+37.9 +/- 6.5 years	9606	Homo sapiens (human)	6481	37.9 ± 6.5 year	37.9 ± 6.5 year
+37.6 +/- 11.0 years	9606	Homo sapiens (human)	6482	37.6 ± 11.0 year	37.6 ± 11.0 year
+3-41 years	9606	Homo sapiens (human)	6483	3-41 year	3-41 year
+6 to 8 weeks	10002050	Mus musculus HLA-DQB1*03:02 Tg	6484	6 to 8 week	6 to 8 week
+6 to 8 weeks	10000616	Mus musculus HLA-DRB1*04:01 Tg	6485	6 to 8 week	6 to 8 week
+6 to 8 weeks	10001377	Mus musculus HLA-DQB1*06:01 Tg	6486	6 to 8 week	6 to 8 week
+6-8 weeks	9031	Gallus gallus (chicken)	6487	6-8 week	6-8 week
+12-73 years	9606	Homo sapiens (human)	6488	12-73 year	12-73 year
+23-59 years	9606	Homo sapiens (human)	6489	23-59 year	23-59 year
+3 to 4 months	10000206	Oryctolagus cuniculus New Zealand White	6490	3 to 4 month	3 to 4 month
+2 to 3 weeks	10000000	Mus musculus BALB/c	6491	2 to 3 week	2 to 3 week
+1-10 years old	9606	Homo sapiens (human)	6492	1-10 year old	1-10 year
+23.9 to 53.9 years	9606	Homo sapiens (human)	6493	23.9 to 53.9 year	23.9 to 53.9 year
+40.7 to 73.3 years	9606	Homo sapiens (human)	6494	40.7 to 73.3 year	40.7 to 73.3 year
+3 to 4 months	10000000	Mus musculus BALB/c	6495	3 to 4 month	3 to 4 month
+20-85	9606	Homo sapiens (human)	6496	20-85	20-85
+6 weeks and 18 months	10000000	Mus musculus BALB/c	6497	6 week and 18 month	6 week and 18 month
+6 -12 weeks	10000000	Mus musculus BALB/c	6498	6 -12 week	6 -12 week
+7- 32 years	9606	Homo sapiens (human)	6499	7- 32 year	7- 32 year
+8 to 10 weeks	10000054	Mus musculus DBA/1	6500	8 to 10 week	8 to 10 week
+53.7 +/- 11.2	9606	Homo sapiens (human)	6501	53.7 ± 11.2	53.7 ± 11.2
+58.8 +/- 8.7	9606	Homo sapiens (human)	6502	58.8 ± 8.7	58.8 ± 8.7
+15-50 years	9606	Homo sapiens (human)	6503	15-50 year	15-50 year
+1-24 years	9606	Homo sapiens (human)	6504	1-24 year	1-24 year
+2.2-47.9 years	9606	Homo sapiens (human)	6505	2.2-47.9 year	2.2-47.9 year
+48-93 years	9606	Homo sapiens (human)	6506	48-93 year	48-93 year
+adult	10090	Mus musculus (mouse)	6507	adult	adult
+7 weeks	9031	Gallus gallus (chicken)	6508	7 week	7 week
+4 to 9 years	9606	Homo sapiens (human)	6509	4 to 9 year	4 to 9 year
+mean age = 9.3 years	9606	Homo sapiens (human)	6510	mean age = 9.3 year	mean age = 9.3 year
+17 to 56 years	9606	Homo sapiens (human)	6511	17 to 56 year	17 to 56 year
+NULL	10002063	Ovis aries Merino	6512	null	null
+10 years	9544	Macaca mulatta (rhesus macaque)	6513	10 year	10 year
+55.7 +/- 5.7	9606	Homo sapiens (human)	6514	55.7 ± 5.7	55.7 ± 5.7
+49.5 +/- 7.5	9606	Homo sapiens (human)	6515	49.5 ± 7.5	49.5 ± 7.5
+NULL	1240228	Cairina moschata domestica (Muscovy Duck (domestic type))	6516	null	null
+mean age = 38 years	9606	Homo sapiens (human)	6517	mean age = 38 year	mean age = 38 year
+45 days	9823	Sus scrofa (pig)	6518	45 days	45 days
+19-66 years	9606	Homo sapiens (human)	6519	19-66 year	19-66 year
+1 to 268 days	9606	Homo sapiens (human)	6520	1 to 268 days	1 to 268 days
+3 days	10000067	Mus musculus C57BL/6	6521	3 days	3 days
+NULL	42414	Sigmodon (cotton rat)	6522	null	null
+8 weeks	10000019	Mus musculus BALB/cByJ	6523	8 week	8 week
+3 years	30538	Vicugna pacos (alpaca)	6524	3 year	3 year
+1.1-20 years	9606	Homo sapiens (human)	6525	1.1-20 year	1.1-20 year
+7-20 weeks	10001487	Mus musculus Apolipoprotein E null	6526	7-20 week	7-20 week
+18 to 47 years	9606	Homo sapiens (human)	6527	18 to 47 year	18 to 47 year
+22 to 58 years	9606	Homo sapiens (human)	6528	22 to 58 year	22 to 58 year
+17 to 42 years	9606	Homo sapiens (human)	6529	17 to 42 year	17 to 42 year
+22 to 62 years	9606	Homo sapiens (human)	6530	22 to 62 year	22 to 62 year
+2-8 years	9606	Homo sapiens (human)	6531	2-8 year	2-8 year
+4-7 years	9606	Homo sapiens (human)	6532	4-7 year	4-7 year
+12 weeks	10000013	Mus musculus BALB/c X A/J	6533	12 week	12 week
+5 week	10000067	Mus musculus C57BL/6	6534	5 week	5 week
+4-10 years	9606	Homo sapiens (human)	6535	4-10 year	4-10 year
+44-52 weeks	9031	Gallus gallus (chicken)	6536	44-52 week	44-52 week
+5 to 8 week	10000013	Mus musculus BALB/c X A/J	6537	5 to 8 week	5 to 8 week
+8 week	10000013	Mus musculus BALB/c X A/J	6538	8 week	8 week
+123 days	9031	Gallus gallus (chicken)	6539	123 days	123 days
+1 week	9031	Gallus gallus (chicken)	6540	1 week	1 week
+21-94 years	9606	Homo sapiens (human)	6541	21-94 year	21-94 year
+12-14 weeks	10000038	Mus musculus C3H/He	6542	12-14 week	12-14 week
+8-15 weeks	10000639	Mus musculus NZB	6543	8-15 week	8-15 week
+7-12 months	10000206	Oryctolagus cuniculus New Zealand White	6544	7-12 month	7-12 month
+10 to 89 years	9606	Homo sapiens (human)	6545	10 to 89 year	10 to 89 year
+41 to 73 years	9606	Homo sapiens (human)	6546	41 to 73 year	41 to 73 year
+56 to 72 years	9606	Homo sapiens (human)	6547	56 to 72 year	56 to 72 year
+61 to 70 years	9606	Homo sapiens (human)	6548	61 to 70 year	61 to 70 year
+4-16 years	9606	Homo sapiens (human)	6549	4-16 year	4-16 year
+43 to 71 years	9606	Homo sapiens (human)	6550	43 to 71 year	43 to 71 year
+8 years	9606	Homo sapiens (human)	6551	8 year	8 year
+4-54 years	9606	Homo sapiens (human)	6552	4-54 year	4-54 year
+27 to 85 years	9606	Homo sapiens (human)	6553	27 to 85 year	27 to 85 year
+mean 61.2 years	9606	Homo sapiens (human)	6554	mean 61.2 year	mean 61.2 year
+7-8 weeks	10000019	Mus musculus BALB/cByJ	6555	7-8 week	7-8 week
+7 weeks	10000667	Rattus norvegicus Sprague-Dawley	6556	7 week	7 week
+12-13 weeks	10000206	Oryctolagus cuniculus New Zealand White	6557	12-13 week	12-13 week
+median 9 years	9606	Homo sapiens (human)	6558	median 9 year	median 9 year
+12-15 years	9606	Homo sapiens (human)	6559	12-15 year	12-15 year
+5-32 years	9606	Homo sapiens (human)	6560	5-32 year	5-32 year
+3 to 4 months	9986	Oryctolagus cuniculus (rabbit)	6561	3 to 4 month	3 to 4 month
+3-4 months	10000206	Oryctolagus cuniculus New Zealand White	6562	3-4 month	3-4 month
+5 weeks	10000019	Mus musculus BALB/cByJ	6563	5 week	5 week
+8-10 weeks	10000657	Mus musculus Xenomouse	6564	8-10 week	8-10 week
+NULL	419612	Camelus ferus (Wild Bactrian camel)	6565	null	null
+29-50 years	9606	Homo sapiens (human)	6566	29-50 year	29-50 year
+2 months	10000669	Cavia porcellus Hartley	6567	2 month	2 month
+1-23 years	9606	Homo sapiens (human)	6568	1-23 year	1-23 year
+2-40 years	9606	Homo sapiens (human)	6569	2-40 year	2-40 year
+18 to 90 years	9606	Homo sapiens (human)	6570	18 to 90 year	18 to 90 year
+8-30 years	9606	Homo sapiens (human)	6571	8-30 year	8-30 year
+42 days	9823	Sus scrofa (pig)	6572	42 days	42 days
+4 years	9796	Equus caballus (domestic horse)	6573	4 year	4 year
+85 days	9031	Gallus gallus (chicken)	6574	85 days	85 days
+2 days	9031	Gallus gallus (chicken)	6575	2 days	2 days
+49 to 62 years	9606	Homo sapiens (human)	6576	49 to 62 year	49 to 62 year
+39 to 54 years	9606	Homo sapiens (human)	6577	39 to 54 year	39 to 54 year
+59 to 65 years	9606	Homo sapiens (human)	6578	59 to 65 year	59 to 65 year
+NULL	452646	Neogale vison (mink)	6579	null	null
+NULL	381198	Anser cygnoides domesticus	6580	null	null
+8 to 74 years	9606	Homo sapiens (human)	6581	8 to 74 year	8 to 74 year
+6 weeks	9874	Odocoileus virginianus (white-tailed deer)	6582	6 week	6 week
+43 +/- 12 years	9606	Homo sapiens (human)	6583	43 ± 12 year	43 ± 12 year
+8-12 weeks	10001601	Mus musculus C57BL/6 X 129	6584	8-12 week	8-12 week
+1 to 7 years	9606	Homo sapiens (human)	6585	1 to 7 year	1 to 7 year
+0.8 to 81 years	9606	Homo sapiens (human)	6586	0.8 to 81 year	0.8 to 81 year
+2 to 36 months	9606	Homo sapiens (human)	6587	2 to 36 month	2 to 36 month
+36 +/- 10 years	9606	Homo sapiens (human)	6588	36 ± 10 year	36 ± 10 year
+4 to 25 years	9606	Homo sapiens (human)	6589	4 to 25 year	4 to 25 year
+54.8 to 72.4 years	9606	Homo sapiens (human)	6590	54.8 to 72.4 year	54.8 to 72.4 year
+9 to 36 months	9606	Homo sapiens (human)	6591	9 to 36 month	9 to 36 month
+22.4 to 58.8 years	9606	Homo sapiens (human)	6592	22.4 to 58.8 year	22.4 to 58.8 year
+4-8 years	9541	Macaca fascicularis (crab eating macaque)	6593	4-8 year	4-8 year
+12 to 192 weeks	9615	Canis lupus familiaris (dogs)	6594	12 to 192 week	12 to 192 week
+median age: 7.5 years	9606	Homo sapiens (human)	6595	median age: 7.5 year	median age: 7.5 year
+11 to 66 months	9615	Canis lupus familiaris (dogs)	6596	11 to 66 month	11 to 66 month
+40-67 years	9606	Homo sapiens (human)	6597	40-67 year	40-67 year
+9-12 weeks	10090	Mus musculus (mouse)	6598	9-12 week	9-12 week
+26-72 years	9606	Homo sapiens (human)	6599	26-72 year	26-72 year
+7 weeks	10000973	Mus musculus 129	6600	7 week	7 week
+15 weeks	10000206	Oryctolagus cuniculus New Zealand White	6601	15 week	15 week
+NULL	10117	Rattus rattus (house rat)	6602	null	null
+3 to 4 months	10000653	Mus musculus Swiss	6603	3 to 4 month	3 to 4 month
+51-70 years	9606	Homo sapiens (human)	6604	51-70 year	51-70 year
+9-51 years	9606	Homo sapiens (human)	6605	9-51 year	9-51 year
+NULL	9666	Mustela lutreola (mink)	6606	null	null
+21-25 years	9606	Homo sapiens (human)	6607	21-25 year	21-25 year
+8-10 weeks	10000206	Oryctolagus cuniculus New Zealand White	6608	8-10 week	8-10 week
+38 to 81 years	9606	Homo sapiens (human)	6609	38 to 81 year	38 to 81 year
+3 months	10141	Cavia porcellus (guinea pig)	6610	3 month	3 month
+60-83 years	9606	Homo sapiens (human)	6611	60-83 year	60-83 year
+adult	10141	Cavia porcellus (guinea pig)	6612	adult	adult
+10-70 years	9606	Homo sapiens (human)	6613	10-70 year	10-70 year
+56-64 years	9606	Homo sapiens (human)	6614	56-64 year	56-64 year
+over 18 years	10000119	Homo sapiens Caucasian	6615	over 18 year	over 18 year
+10 to 100 years	9606	Homo sapiens (human)	6616	10 to 100 year	10 to 100 year
+4 weeks	10000667	Rattus norvegicus Sprague-Dawley	6617	4 week	4 week
+6 to 8 months	10000206	Oryctolagus cuniculus New Zealand White	6618	6 to 8 month	6 to 8 month
+17 to 24 years	9606	Homo sapiens (human)	6619	17 to 24 year	17 to 24 year
+19.9 to 60.5 years	9606	Homo sapiens (human)	6620	19.9 to 60.5 year	19.9 to 60.5 year
+< 5 years	9606	Homo sapiens (human)	6621	< 5 year	< 5 year
+9-61 years	9606	Homo sapiens (human)	6622	9-61 year	9-61 year
+5 months	10000206	Oryctolagus cuniculus New Zealand White	6623	5 month	5 month
+NULL	314147	Glire (rodent or rabbit)	6624	null	null
+3 months	10000664	Rattus norvegicus LOU/C	6625	3 month	3 month
+6-8 weeks	10001597	Mus musculus alpha-galactosyl transferase null	6626	6-8 week	6-8 week
+12-16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6627	12-16 week	12-16 week
+51-81 years	9606	Homo sapiens (human)	6628	51-81 year	51-81 year
+12-35 years	9606	Homo sapiens (human)	6629	12-35 year	12-35 year
+5 week	10000000	Mus musculus BALB/c	6630	5 week	5 week
+19 to 47 years	9606	Homo sapiens (human)	6631	19 to 47 year	19 to 47 year
+31 to 73 years	9606	Homo sapiens (human)	6632	31 to 73 year	31 to 73 year
+13 to 31 years	9606	Homo sapiens (human)	6633	13 to 31 year	13 to 31 year
+46.7 yeas (mean)	9606	Homo sapiens (human)	6634	46.7 yeas (mean)	46.7 yeas (mean)
+25.8 to 53.2 years	9606	Homo sapiens (human)	6635	25.8 to 53.2 year	25.8 to 53.2 year
+39.6 to 63 years	9606	Homo sapiens (human)	6636	39.6 to 63 year	39.6 to 63 year
+23-29 years	9606	Homo sapiens (human)	6637	23-29 year	23-29 year
+mean age = 33.6 years	9606	Homo sapiens (human)	6638	mean age = 33.6 year	mean age = 33.6 year
+18-66 years	9606	Homo sapiens (human)	6639	18-66 year	18-66 year
+6 days	10000618	Mus musculus ICR	6640	6 days	6 days
+8 to 9 weeks	10000630	Mus musculus NHI Swiss	6641	8 to 9 week	8 to 9 week
+43 to 88 years	9606	Homo sapiens (human)	6642	43 to 88 year	43 to 88 year
+45-62 years	9606	Homo sapiens (human)	6643	45-62 year	45-62 year
+5 to 6 months	9940	Ovis aries (domestic sheep)	6644	5 to 6 month	5 to 6 month
+15.8 to 51.8 years	9606	Homo sapiens (human)	6645	15.8 to 51.8 year	15.8 to 51.8 year
+28 to 49.6 years	9606	Homo sapiens (human)	6646	28 to 49.6 year	28 to 49.6 year
+5 to 11 months	10000194	Bos taurus Holstein-Friesian	6647	5 to 11 month	5 to 11 month
+NULL	10002278	Mus musculus Antibody Transgenic	6648	null	null
+1-12 years	9606	Homo sapiens (human)	6649	1-12 year	1-12 year
+17 to 70 years	9606	Homo sapiens (human)	6650	17 to 70 year	17 to 70 year
+21 to 83 years	9606	Homo sapiens (human)	6651	21 to 83 year	21 to 83 year
+NULL	10002257	Mus musculus Kymouse	6652	null	null
+> 6 weeks	10001998	Mus musculus CD1	6653	> 6 week	> 6 week
+43.9 to 71.5 years	9606	Homo sapiens (human)	6654	43.9 to 71.5 year	43.9 to 71.5 year
+2.8 months	9606	Homo sapiens (human)	6655	2.8 month	2.8 month
+3-6 years	9606	Homo sapiens (human)	6656	3-6 year	3-6 year
+10.6 months	9606	Homo sapiens (human)	6657	10.6 month	10.6 month
+10-12 weeks	9986	Oryctolagus cuniculus (rabbit)	6658	10-12 week	10-12 week
+10-45 years	9606	Homo sapiens (human)	6659	10-45 year	10-45 year
+13-48 years	9606	Homo sapiens (human)	6660	13-48 year	13-48 year
+6 months	9544	Macaca mulatta (rhesus macaque)	6661	6 month	6 month
+40 days	10000000	Mus musculus BALB/c	6662	40 days	40 days
+5 to 8 years	9606	Homo sapiens (human)	6663	5 to 8 year	5 to 8 year
+18 to 78 years	9606	Homo sapiens (human)	6664	18 to 78 year	18 to 78 year
+1 day to 6 months	9823	Sus scrofa (pig)	6665	1 day to 6 month	1 day to 6 month
+23 to 59 years	9606	Homo sapiens (human)	6666	23 to 59 year	23 to 59 year
+2-7 years	9796	Equus caballus (domestic horse)	6667	2-7 year	2-7 year
+30 to 55 years	9606	Homo sapiens (human)	6668	30 to 55 year	30 to 55 year
+32 to 52 years	9606	Homo sapiens (human)	6669	32 to 52 year	32 to 52 year
+38 to 44 years	9606	Homo sapiens (human)	6670	38 to 44 year	38 to 44 year
+young	10002275	Sus scrofa Duroc X Yorkshire X Hampshire	6671	young	young
+19-74 years	9606	Homo sapiens (human)	6672	19-74 year	19-74 year
+NULL	10002262	Rattus norvegicus OmniRat5Lew x Rat4	6673	null	null
+2 months	10000054	Mus musculus DBA/1	6674	2 month	2 month
+mean 54.37 years	9606	Homo sapiens (human)	6675	mean 54.37 year	mean 54.37 year
+mean 39 years	9606	Homo sapiens (human)	6676	mean 39 year	mean 39 year
+46-63 years	9606	Homo sapiens (human)	6677	46-63 year	46-63 year
+43-65 years	9606	Homo sapiens (human)	6678	43-65 year	43-65 year
+mean 51.32 years	9606	Homo sapiens (human)	6679	mean 51.32 year	mean 51.32 year
+24 weeks	9669	Mustela putorius furo (black ferret)	6680	24 week	24 week
+7 to 19 weeks	10000067	Mus musculus C57BL/6	6681	7 to 19 week	7 to 19 week
+9 days	8839	Anas platyrhynchos (duck)	6682	9 days	9 days
+6 weeks	10000271	Mus musculus B10.M	6683	6 week	6 week
+2-3 months	10000061	Mus musculus FVB	6684	2-3 month	2-3 month
+average 30.2 years	9606	Homo sapiens (human)	6685	average 30.2 year	average 30.2 year
+6 to 66 years	9606	Homo sapiens (human)	6686	6 to 66 year	6 to 66 year
+8 weeks	10001029	Mus musculus SCID (NOD.CB17-Prkdc<sup>scid</sup>)	6687	8 week	8 week
+44 to 52 weeks	9031	Gallus gallus (chicken)	6688	44 to 52 week	44 to 52 week
+12 week	10000000	Mus musculus BALB/c	6689	12 week	12 week
+3 to 5 months	9541	Macaca fascicularis (crab eating macaque)	6690	3 to 5 month	3 to 5 month
+mean 48 years	9606	Homo sapiens (human)	6691	mean 48 year	mean 48 year
+24-35 years	9606	Homo sapiens (human)	6692	24-35 year	24-35 year
+3 to 8 weeks	10001998	Mus musculus CD1	6693	3 to 8 week	3 to 8 week
+9 to 12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6694	9 to 12 week	9 to 12 week
+2-7 years	9913	Bos taurus (bovine)	6695	2-7 year	2-7 year
+8 to 10 weeks	10000038	Mus musculus C3H/He	6696	8 to 10 week	8 to 10 week
+4-6 months	9940	Ovis aries (domestic sheep)	6697	4-6 month	4-6 month
+40 to 78 years	9606	Homo sapiens (human)	6698	40 to 78 year	40 to 78 year
+11 to 51 years	9606	Homo sapiens (human)	6699	11 to 51 year	11 to 51 year
+2 months - 12 years	9606	Homo sapiens (human)	6700	2 month - 12 year	2 month - 12 year
+juvenile	84645	Labeo rohita (Jayanti rohu)	6701	juvenile	juvenile
+9 to 16 years	9606	Homo sapiens (human)	6702	9 to 16 year	9 to 16 year
+3 to 8 years	9606	Homo sapiens (human)	6703	3 to 8 year	3 to 8 year
+2 years	30538	Vicugna pacos (alpaca)	6704	2 year	2 year
+22 to 78 years	9606	Homo sapiens (human)	6705	22 to 78 year	22 to 78 year
+6 to 8 weeks	10001623	Mus musculus AG129	6706	6 to 8 week	6 to 8 week
+16 to 80 years	9606	Homo sapiens (human)	6707	16 to 80 year	16 to 80 year
+52 years old on average	9606	Homo sapiens (human)	6708	52 year old on average	52 year on average
+3 weeks	10000664	Rattus norvegicus LOU/C	6709	3 week	3 week
+8 weeks	9986	Oryctolagus cuniculus (rabbit)	6710	8 week	8 week
+31 to 61 years	9606	Homo sapiens (human)	6711	31 to 61 year	31 to 61 year
+10-19 years	9606	Homo sapiens (human)	6712	10-19 year	10-19 year
+10-29 years	9606	Homo sapiens (human)	6713	10-29 year	10-29 year
+1 months	10000632	Mus musculus NOD	6714	1 month	1 month
+7 to 65 years	9606	Homo sapiens (human)	6715	7 to 65 year	7 to 65 year
+22 to 73 years	9606	Homo sapiens (human)	6716	22 to 73 year	22 to 73 year
+16 to 68 years	9606	Homo sapiens (human)	6717	16 to 68 year	16 to 68 year
+8 to 10 weels	10000000	Mus musculus BALB/c	6718	8 to 10 week	8 to 10 week
+36.8 years (mean)	9606	Homo sapiens (human)	6719	36.8 year (mean)	36.8 year (mean)
+2 to 100 years	9606	Homo sapiens (human)	6720	2 to 100 year	2 to 100 year
+21-36 years	9606	Homo sapiens (human)	6721	21-36 year	21-36 year
+42-71 years	9606	Homo sapiens (human)	6722	42-71 year	42-71 year
+60-87 years	9606	Homo sapiens (human)	6723	60-87 year	60-87 year
+72-75 years	9606	Homo sapiens (human)	6724	72-75 year	72-75 year
+38 to 76 years	9606	Homo sapiens (human)	6725	38 to 76 year	38 to 76 year
+average 34.5 years	9606	Homo sapiens (human)	6726	average 34.5 year	average 34.5 year
+8 weeks	10001602	Mus musculus RBF	6727	8 week	8 week
+19.5 to 60.2 years	9606	Homo sapiens (human)	6728	19.5 to 60.2 year	19.5 to 60.2 year
+19.7 to 63.3 years	9606	Homo sapiens (human)	6729	19.7 to 63.3 year	19.7 to 63.3 year
+4 weeks old	10001406	Mus musculus MLR/lpr	6730	4 week old	4 week
+1-51 years	9606	Homo sapiens (human)	6731	1-51 year	1-51 year
+3-4 years	9554	Papio (baboon)	6732	3-4 year	3-4 year
+2-4 years	9544	Macaca mulatta (rhesus macaque)	6733	2-4 year	2-4 year
+2-5 years	9541	Macaca fascicularis (crab eating macaque)	6734	2-5 year	2-5 year
+1-25 years	9515	Sapajus apella (black-capped capuchin)	6735	1-25 year	1-25 year
+4 months	10032	Cricetulus migratorius (gray dwarf hamster)	6736	4 month	4 month
+4 months	10090	Mus musculus (mouse)	6737	4 month	4 month
+58-70 years	9606	Homo sapiens (human)	6738	58-70 year	58-70 year
+8 months to 54 years	9606	Homo sapiens (human)	6739	8 month to 54 year	8 month to 54 year
+55.9 to 76.9 years	9606	Homo sapiens (human)	6740	55.9 to 76.9 year	55.9 to 76.9 year
+11 months - 55 years	9606	Homo sapiens (human)	6741	11 month - 55 year	11 month - 55 year
+5-9 weeks	10000000	Mus musculus BALB/c	6742	5-9 week	5-9 week
+56-73 years	9606	Homo sapiens (human)	6743	56-73 year	56-73 year
+NULL	10002034	Fish	6744	null	null
+37 to 79 years	9606	Homo sapiens (human)	6745	37 to 79 year	37 to 79 year
+45 to 74 years	9606	Homo sapiens (human)	6746	45 to 74 year	45 to 74 year
+35 to 75 years	9606	Homo sapiens (human)	6747	35 to 75 year	35 to 75 year
+19 to 62 years	9606	Homo sapiens (human)	6748	19 to 62 year	19 to 62 year
+26 to 55 years	9606	Homo sapiens (human)	6749	26 to 55 year	26 to 55 year
+13 to 68 years	9606	Homo sapiens (human)	6750	13 to 68 year	13 to 68 year
+18 to 88 years	9606	Homo sapiens (human)	6751	18 to 88 year	18 to 88 year
+21 to 85 years	9606	Homo sapiens (human)	6752	21 to 85 year	21 to 85 year
+17 to 96 years	9606	Homo sapiens (human)	6753	17 to 96 year	17 to 96 year
+18-90 years	9606	Homo sapiens (human)	6754	18-90 year	18-90 year
+2 years	9844	Lama glama (llama)	6755	2 year	2 year
+11-68 years	9606	Homo sapiens (human)	6756	11-68 year	11-68 year
+12 to 88 years	9606	Homo sapiens (human)	6757	12 to 88 year	12 to 88 year
+NULL	10002138	Mus musculus B10	6758	null	null
+53.2 years	9606	Homo sapiens (human)	6759	53.2 year	53.2 year
+51.0 years	9606	Homo sapiens (human)	6760	51.0 year	51.0 year
+34.3 years	9606	Homo sapiens (human)	6761	34.3 year	34.3 year
+36.1 years	9606	Homo sapiens (human)	6762	36.1 year	36.1 year
+23 to 45 years	9606	Homo sapiens (human)	6763	23 to 45 year	23 to 45 year
+30 to 45 years	9606	Homo sapiens (human)	6764	30 to 45 year	30 to 45 year
+42 +/- 8.1 years	9606	Homo sapiens (human)	6765	42 ± 8.1 year	42 ± 8.1 year
+6-37 years	9606	Homo sapiens (human)	6766	6-37 year	6-37 year
+18–48 years	9606	Homo sapiens (human)	6767	1848 year	1848 year
+55.2 to 65.2 years	9606	Homo sapiens (human)	6768	55.2 to 65.2 year	55.2 to 65.2 year
+46-91 years	9606	Homo sapiens (human)	6769	46-91 year	46-91 year
+49 to 73 years	9606	Homo sapiens (human)	6770	49 to 73 year	49 to 73 year
+30 to 51 years	9606	Homo sapiens (human)	6771	30 to 51 year	30 to 51 year
+at least 2 months	10000206	Oryctolagus cuniculus New Zealand White	6772	at least 2 month	at least 2 month
+16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6773	16 week	16 week
+18-38 years, with an average of 22 years	9606	Homo sapiens (human)	6774	18-38 year, with an average of 22 year	18-38 year, with an average of 22 year
+6-8 weeks	10002278	Mus musculus Antibody Transgenic	6775	6-8 week	6-8 week
+26-51 years	9606	Homo sapiens (human)	6776	26-51 year	26-51 year
+29 to 71 years	9606	Homo sapiens (human)	6777	29 to 71 year	29 to 71 year
+1 to 18 years	9606	Homo sapiens (human)	6778	1 to 18 year	1 to 18 year
+10-12 weeks	10000206	Oryctolagus cuniculus New Zealand White	6779	10-12 week	10-12 week
+14-71 years	9606	Homo sapiens (human)	6780	14-71 year	14-71 year
+10 days	9031	Gallus gallus (chicken)	6781	10 days	10 days
+47 +/- 4.5 years	9606	Homo sapiens (human)	6782	47 ± 4.5 year	47 ± 4.5 year
+14 weeks	10000067	Mus musculus C57BL/6	6783	14 week	14 week
+7 to 41 years	9606	Homo sapiens (human)	6784	7 to 41 year	7 to 41 year
+1-39 years	9606	Homo sapiens (human)	6785	1-39 year	1-39 year
+15 months	9606	Homo sapiens (human)	6786	15 month	15 month
+14-50 years	9606	Homo sapiens (human)	6787	14-50 year	14-50 year
+20 to 66 years	9606	Homo sapiens (human)	6788	20 to 66 year	20 to 66 year
+18 to 54 years	9606	Homo sapiens (human)	6789	18 to 54 year	18 to 54 year
+49 to 63 years	9606	Homo sapiens (human)	6790	49 to 63 year	49 to 63 year
+33 to 71 years	9606	Homo sapiens (human)	6791	33 to 71 year	33 to 71 year
+29 to 73 years	9606	Homo sapiens (human)	6792	29 to 73 year	29 to 73 year
+3 to 4 weeks	10000915	Mus musculus Kunming	6793	3 to 4 week	3 to 4 week
+neonate	9544	Macaca mulatta (rhesus macaque)	6794	neonate	neonate
+18 months	10001406	Mus musculus MLR/lpr	6795	18 month	18 month
+adult	10000200	Oryctolagus cuniculus Chinchilla	6796	adult	adult
+36.8 to 64 years	9606	Homo sapiens (human)	6797	36.8 to 64 year	36.8 to 64 year
+38.2 to 68 years	9606	Homo sapiens (human)	6798	38.2 to 68 year	38.2 to 68 year
+21.1 to 39.9 years	9606	Homo sapiens (human)	6799	21.1 to 39.9 year	21.1 to 39.9 year
+44.6 to 69.4 years	9606	Homo sapiens (human)	6800	44.6 to 69.4 year	44.6 to 69.4 year
+47-71 years	9606	Homo sapiens (human)	6801	47-71 year	47-71 year
+4 days	10090	Mus musculus (mouse)	6802	4 days	4 days
+41 to 77 years	9606	Homo sapiens (human)	6803	41 to 77 year	41 to 77 year
+54 to 74.6 years	9606	Homo sapiens (human)	6804	54 to 74.6 year	54 to 74.6 year
+51.6 to 77.2 years	9606	Homo sapiens (human)	6805	51.6 to 77.2 year	51.6 to 77.2 year
+28-56 years	9606	Homo sapiens (human)	6806	28-56 year	28-56 year
+27-56 years	9606	Homo sapiens (human)	6807	27-56 year	27-56 year
+10 week old	10000000	Mus musculus BALB/c	6808	10 week old	10 week
+9-10 weeks	10000629	Mus musculus ND4 Swiss Webster	6809	9-10 week	9-10 week
+10 weeks	10002257	Mus musculus Kymouse	6810	10 week	10 week
+32 to 69 years	9606	Homo sapiens (human)	6811	32 to 69 year	32 to 69 year
+9 weeks	10000206	Oryctolagus cuniculus New Zealand White	6812	9 week	9 week
+12-58 years	9606	Homo sapiens (human)	6813	12-58 year	12-58 year
+16-38 years	9606	Homo sapiens (human)	6814	16-38 year	16-38 year
+1 year	9796	Equus caballus (domestic horse)	6815	1 year	1 year
+young	8835	Anas (ducks)	6816	young	young
+NULL	9837	Camelus bactrianus (camel)	6817	null	null
+40-48 years	9606	Homo sapiens (human)	6818	40-48 year	40-48 year
+21 to 30 years	9606	Homo sapiens (human)	6819	21 to 30 year	21 to 30 year
+6 - 58 years	9606	Homo sapiens (human)	6820	6 - 58 year	6 - 58 year
+15-40 years	9606	Homo sapiens (human)	6821	15-40 year	15-40 year
+12 to 16 weeks	10000064	Mus musculus C57BL/10.Q	6822	12 to 16 week	12 to 16 week
+6-8 months	10002034	Fish	6823	6-8 month	6-8 month
+3 months	9606	Homo sapiens (human)	6824	3 month	3 month
+14 - 66 years	9606	Homo sapiens (human)	6825	14 - 66 year	14 - 66 year
+25.4 to 52.4 years	9606	Homo sapiens (human)	6826	25.4 to 52.4 year	25.4 to 52.4 year
+51 and 66 years	9606	Homo sapiens (human)	6827	51 and 66 year	51 and 66 year
+9-90 years	9606	Homo sapiens (human)	6828	9-90 year	9-90 year
+adult	30538	Vicugna pacos (alpaca)	6829	adult	adult
+21 weeks	9823	Sus scrofa (pig)	6830	21 week	21 week
+20 to 30 years	9606	Homo sapiens (human)	6831	20 to 30 year	20 to 30 year
+46-49 years	9606	Homo sapiens (human)	6832	46-49 year	46-49 year
+7 years	9844	Lama glama (llama)	6833	7 year	7 year
+32-54 years	9606	Homo sapiens (human)	6834	32-54 year	32-54 year
+8-15 weeks	10002378	Mus musculus SPRET/Ei	6835	8-15 week	8-15 week
+8-15 weeks	10000973	Mus musculus 129	6836	8-15 week	8-15 week
+30 to 40 years	9606	Homo sapiens (human)	6837	30 to 40 year	30 to 40 year
+1 month	10141	Cavia porcellus (guinea pig)	6838	1 month	1 month
+3.4 to 24.4 years	9606	Homo sapiens (human)	6839	3.4 to 24.4 year	3.4 to 24.4 year
+6 weeks	10000658	Rattus norvegicus Brown Norway	6840	6 week	6 week
+mean 6.6 years	9606	Homo sapiens (human)	6841	mean 6.6 year	mean 6.6 year
+NULL	10002355	Bos taurus human immunoglobulin, bIGHMnull, bIGHML1 null, bIGL null	6842	null	null
+6 years	30538	Vicugna pacos (alpaca)	6843	6 year	6 year
+20 to 89 years	9606	Homo sapiens (human)	6844	20 to 89 year	20 to 89 year
+20-49 years	9606	Homo sapiens (human)	6845	20-49 year	20-49 year
+average age = 50 years	9606	Homo sapiens (human)	6846	average age = 50 year	average age = 50 year
+5-9 weeks	10000619	Mus musculus ICR X Swiss	6847	5-9 week	5-9 week
+born before 1968	9606	Homo sapiens (human)	6848	born before 1968	born before 1968
+7 days	9823	Sus scrofa (pig)	6849	7 days	7 days
+18 to 85 years	9606	Homo sapiens (human)	6850	18 to 85 year	18 to 85 year
+3-61 years	9606	Homo sapiens (human)	6851	3-61 year	3-61 year
+10-24 weeks	10000000	Mus musculus BALB/c	6852	10-24 week	10-24 week
+0.2 to 18 years	9685	Felis catus (cat)	6853	0.2 to 18 year	0.2 to 18 year
+0.3 to 12 years	9685	Felis catus (cat)	6854	0.3 to 12 year	0.3 to 12 year
+8-14 weeks	10000601	Mus musculus HLA-DR1 Tg	6855	8-14 week	8-14 week
+6 weeks old	10001438	Mus musculus BALB/cAnN	6856	6 week old	6 week
+NULL	9788	Equid (horse)	6857	null	null
+4-6 week	10000000	Mus musculus BALB/c	6858	4-6 week	4-6 week
+29-87 years	9606	Homo sapiens (human)	6859	29-87 year	29-87 year
+6 to 15 weeks	10000067	Mus musculus C57BL/6	6860	6 to 15 week	6 to 15 week
+mean age = 71.3 years	9606	Homo sapiens (human)	6861	mean age = 71.3 year	mean age = 71.3 year
+mean age = 68.3 years	9606	Homo sapiens (human)	6862	mean age = 68.3 year	mean age = 68.3 year
+mean age = 66.3 years	9606	Homo sapiens (human)	6863	mean age = 66.3 year	mean age = 66.3 year
+mean age = 60.1 years	9606	Homo sapiens (human)	6864	mean age = 60.1 year	mean age = 60.1 year
+9.9-17 years	9541	Macaca fascicularis (crab eating macaque)	6865	9.9-17 year	9.9-17 year
+4 to 6 weeks old	10000000	Mus musculus BALB/c	6866	4 to 6 week old	4 to 6 week
+28 weeks	10000067	Mus musculus C57BL/6	6867	28 week	28 week
+3 months	9031	Gallus gallus (chicken)	6868	3 month	3 month
+50-86 years	9606	Homo sapiens (human)	6869	50-86 year	50-86 year
+4-49 years	9606	Homo sapiens (human)	6870	4-49 year	4-49 year
+50-71 years	9606	Homo sapiens (human)	6871	50-71 year	50-71 year
+26-54 years	9606	Homo sapiens (human)	6872	26-54 year	26-54 year
+>56 years	9606	Homo sapiens (human)	6873	>56 year	>56 year
+10 weeks	10001998	Mus musculus CD1	6874	10 week	10 week
+7-9 weeks	10001998	Mus musculus CD1	6875	7-9 week	7-9 week
+28-91 years	9606	Homo sapiens (human)	6876	28-91 year	28-91 year
+mean = 48 years	9606	Homo sapiens (human)	6877	mean = 48 year	mean = 48 year
+68.5 +/- 16.4 years	9606	Homo sapiens (human)	6878	68.5 ± 16.4 year	68.5 ± 16.4 year
+53-85 years	9606	Homo sapiens (human)	6879	53-85 year	53-85 year
+10 to 72 years	9606	Homo sapiens (human)	6880	10 to 72 year	10 to 72 year
+6 months	9823	Sus scrofa (pig)	6881	6 month	6 month
+Mean age = 47.1 years	9606	Homo sapiens (human)	6882	mean age = 47.1 year	mean age = 47.1 year
+34-79 years	9606	Homo sapiens (human)	6883	34-79 year	34-79 year
+38-60 years	9606	Homo sapiens (human)	6884	38-60 year	38-60 year
+22-87 years	9606	Homo sapiens (human)	6885	22-87 year	22-87 year
+28-75 years	9606	Homo sapiens (human)	6886	28-75 year	28-75 year
+62-91 years	9606	Homo sapiens (human)	6887	62-91 year	62-91 year
+2-23 years	9606	Homo sapiens (human)	6888	2-23 year	2-23 year
+10 to 66 years	9606	Homo sapiens (human)	6889	10 to 66 year	10 to 66 year
+NULL	70699	unidentified monkey	6890	null	null
+3-4 years	9534	Chlorocebus aethiops (African green monkey)	6891	3-4 year	3-4 year
+6 months	10000067	Mus musculus C57BL/6	6892	6 month	6 month
+6 weeks	10000629	Mus musculus ND4 Swiss Webster	6893	6 week	6 week
+27-77 years	9606	Homo sapiens (human)	6894	27-77 year	27-77 year
+28 to 53 years	9606	Homo sapiens (human)	6895	28 to 53 year	28 to 53 year
+7-9weeks	10000067	Mus musculus C57BL/6	6896	7-9weeks	7-9weeks
+5 weeks	10000206	Oryctolagus cuniculus New Zealand White	6897	5 week	5 week
+1-9 years	9606	Homo sapiens (human)	6898	1-9 year	1-9 year
+2-7 years	9606	Homo sapiens (human)	6899	2-7 year	2-7 year
+72-86 years	9606	Homo sapiens (human)	6900	72-86 year	72-86 year
+71-87 years	9606	Homo sapiens (human)	6901	71-87 year	71-87 year
+8-18 years	9606	Homo sapiens (human)	6902	8-18 year	8-18 year
+1-6 years	9606	Homo sapiens (human)	6903	1-6 year	1-6 year
+9 months	10000193	Bos taurus Holstein	6904	9 month	9 month
+Over 50 years	9606	Homo sapiens (human)	6905	over 50 year	over 50 year
+17 to 39 years	9606	Homo sapiens (human)	6906	17 to 39 year	17 to 39 year
+1.5 months to 40 years	9606	Homo sapiens (human)	6907	1.5 month to 40 year	1.5 month to 40 year
+12 to 60 months	9606	Homo sapiens (human)	6908	12 to 60 month	12 to 60 month
+17 to 30 years	9606	Homo sapiens (human)	6909	17 to 30 year	17 to 30 year
+17 months - 4 years	9606	Homo sapiens (human)	6910	17 month - 4 year	17 month - 4 year
+22 to 81 years	9606	Homo sapiens (human)	6911	22 to 81 year	22 to 81 year
+0-9 years	9606	Homo sapiens (human)	6912	0-9 year	0-9 year
+6-15 years	9541	Macaca fascicularis (crab eating macaque)	6913	6-15 year	6-15 year
+10-weeks	10000000	Mus musculus BALB/c	6914	10-week	10 week
+6 weeks	10001406	Mus musculus MLR/lpr	6915	6 week	6 week
+NULL	10001601	Mus musculus C57BL/6 X 129	6916	null	null
+4 to 8 weeks	10000067	Mus musculus C57BL/6	6917	4 to 8 week	4 to 8 week
+31 to 48 years	9606	Homo sapiens (human)	6918	31 to 48 year	31 to 48 year
+5-6 weeks	10001438	Mus musculus BALB/cAnN	6919	5-6 week	5-6 week
+40-63 years	9606	Homo sapiens (human)	6920	40-63 year	40-63 year
+22 to 69 years	9606	Homo sapiens (human)	6921	22 to 69 year	22 to 69 year
+6-46 years	9606	Homo sapiens (human)	6922	6-46 year	6-46 year
+14-54 years	9606	Homo sapiens (human)	6923	14-54 year	14-54 year
+39-77 years	9606	Homo sapiens (human)	6924	39-77 year	39-77 year
+16 to 18 years	9606	Homo sapiens (human)	6925	16 to 18 year	16 to 18 year
+3 years	9837	Camelus bactrianus (camel)	6926	3 year	3 year
+30-68 years	9606	Homo sapiens (human)	6927	30-68 year	30-68 year
+50 to 71 years	9606	Homo sapiens (human)	6928	50 to 71 year	50 to 71 year
+3 months to 15 years	9606	Homo sapiens (human)	6929	3 month to 15 year	3 month to 15 year
+5 to 9 months	9606	Homo sapiens (human)	6930	5 to 9 month	5 to 9 month
+7 months to 10 years	9606	Homo sapiens (human)	6931	7 month to 10 year	7 month to 10 year
+8 weeks	10000002	Mus musculus BALB/c beta2m null	6932	8 week	8 week
+23-84 years	9606	Homo sapiens (human)	6933	23-84 year	23-84 year
+NULL	10002275	Sus scrofa Duroc X Yorkshire X Hampshire	6934	null	null
+16 to 41 years	9606	Homo sapiens (human)	6935	16 to 41 year	16 to 41 year
+Young adult	9606	Homo sapiens (human)	6936	young adult	young adult
+34-96 years	9606	Homo sapiens (human)	6937	34-96 year	34-96 year
+NULL	36176	Chiloscyllium plagiosum (whitespotted bambooshark)	6938	null	null
+29-96 years	9606	Homo sapiens (human)	6939	29-96 year	29-96 year
+15-48 years	9606	Homo sapiens (human)	6940	15-48 year	15-48 year
+18 to 55 years	9544	Macaca mulatta (rhesus macaque)	6941	18 to 55 year	18 to 55 year
+7-39 years	9606	Homo sapiens (human)	6942	7-39 year	7-39 year
+21 to 72 years	9606	Homo sapiens (human)	6943	21 to 72 year	21 to 72 year
+4-11 months	9606	Homo sapiens (human)	6944	4-11 month	4-11 month
+NULL	30522	Bos indicus x Bos taurus (hybrid cow)	6945	null	null
+NULL	9915	Bos indicus (Indicine cattle)	6946	null	null
+<5 years	9606	Homo sapiens (human)	6947	<5 year	<5 year
+40 to 41 years	9606	Homo sapiens (human)	6948	40 to 41 year	40 to 41 year
+13-84 years	9606	Homo sapiens (human)	6949	13-84 year	13-84 year
+76.9-80.3 years	9606	Homo sapiens (human)	6950	76.9-80.3 year	76.9-80.3 year
+49- 55.6 years	9606	Homo sapiens (human)	6951	49- 55.6 year	49- 55.6 year
+25 weeks	10000920	Gallus gallus Leghorn	6952	25 week	25 week
+mean 38 years	9606	Homo sapiens (human)	6953	mean 38 year	mean 38 year
+9-44 years	9606	Homo sapiens (human)	6954	9-44 year	9-44 year
+mean 11 years	9606	Homo sapiens (human)	6955	mean 11 year	mean 11 year
+mean 13. 8 years	9606	Homo sapiens (human)	6956	mean 13. 8 year	mean 13. 8 year
+30-66 years	9606	Homo sapiens (human)	6957	30-66 year	30-66 year
+31-59 years	9606	Homo sapiens (human)	6958	31-59 year	31-59 year
+21-61 years	9606	Homo sapiens (human)	6959	21-61 year	21-61 year
+28-60 years	9606	Homo sapiens (human)	6960	28-60 year	28-60 year
+17 to 71 years	9606	Homo sapiens (human)	6961	17 to 71 year	17 to 71 year
+24 to 65 yesrs	9606	Homo sapiens (human)	6962	24 to 65 year	24 to 65 year
+mean 30 years	9606	Homo sapiens (human)	6963	mean 30 year	mean 30 year
+26-85 years	9606	Homo sapiens (human)	6964	26-85 year	26-85 year
+31-45 years	9606	Homo sapiens (human)	6965	31-45 year	31-45 year
+7 - 8 weeks	10000067	Mus musculus C57BL/6	6966	7 - 8 week	7 - 8 week
+NULL	10002503	Sus scrofa Duroc X Large White X Landrace	6967	null	null
+6 to 16 years	9606	Homo sapiens (human)	6968	6 to 16 year	6 to 16 year
+12 months	9940	Ovis aries (domestic sheep)	6969	12 month	12 month
+35 to 52 years	9606	Homo sapiens (human)	6970	35 to 52 year	35 to 52 year
+29-63 years	9606	Homo sapiens (human)	6971	29-63 year	29-63 year
+25 to 70 years	9606	Homo sapiens (human)	6972	25 to 70 year	25 to 70 year
+35-72 years	9606	Homo sapiens (human)	6973	35-72 year	35-72 year
+4-6 months	9913	Bos taurus (bovine)	6974	4-6 month	4-6 month
+29 to 81 years	9606	Homo sapiens (human)	6975	29 to 81 year	29 to 81 year
+59 to 72 years	9606	Homo sapiens (human)	6976	59 to 72 year	59 to 72 year
+8 months	10000206	Oryctolagus cuniculus New Zealand White	6977	8 month	8 month
+10-16 weeks	10000206	Oryctolagus cuniculus New Zealand White	6978	10-16 week	10-16 week
+18-83 years	9606	Homo sapiens (human)	6979	18-83 year	18-83 year
+8-12 weeks	10114	Rattus (rat)	6980	8-12 week	8-12 week
+NULL	8128	Oreochromis niloticus (Nile tilapia)	6981	null	null
+35-87 years	9606	Homo sapiens (human)	6982	35-87 year	35-87 year
+5 to 6 weeks	10000667	Rattus norvegicus Sprague-Dawley	6983	5 to 6 week	5 to 6 week
+22-34.5 years	9606	Homo sapiens (human)	6984	22-34.5 year	22-34.5 year
+23-37.5 years	9606	Homo sapiens (human)	6985	23-37.5 year	23-37.5 year
+4-78 years	9606	Homo sapiens (human)	6986	4-78 year	4-78 year
+15 to 76 years	9606	Homo sapiens (human)	6987	15 to 76 year	15 to 76 year
+31-65 years	9606	Homo sapiens (human)	6988	31-65 year	31-65 year
+2-3 months	10000206	Oryctolagus cuniculus New Zealand White	6989	2-3 month	2-3 month
+average age = 43.6 years	9606	Homo sapiens (human)	6990	average age = 43.6 year	average age = 43.6 year
+average age = 44.8 years	9606	Homo sapiens (human)	6991	average age = 44.8 year	average age = 44.8 year
+8 to 10 weeks	10001306	Mus musculus KRN TCR Tg	6992	8 to 10 week	8 to 10 week
+NULL	42716	Didelphis albiventris (white-eared opossum)	6993	null	null
+6 weeks	10002278	Mus musculus Antibody Transgenic	6994	6 week	6 week
+NULL	10041	Peromyscus leucopus (white-footed mouse)	6995	null	null
+17-68 years	9606	Homo sapiens (human)	6996	17-68 year	17-68 year
+19 to 45 years	9606	Homo sapiens (human)	6997	19 to 45 year	19 to 45 year
+36- 57 years	9606	Homo sapiens (human)	6998	36- 57 year	36- 57 year
+32 to 73 years	9606	Homo sapiens (human)	6999	32 to 73 year	32 to 73 year
+13 week	9823	Sus scrofa (pig)	7000	13 week	13 week
+55-86 years	9606	Homo sapiens (human)	7001	55-86 year	55-86 year
+1 month - 4 years	9606	Homo sapiens (human)	7002	1 month - 4 year	1 month - 4 year
+20-89 years	9606	Homo sapiens (human)	7003	20-89 year	20-89 year
+<21 years	9606	Homo sapiens (human)	7004	<21 year	<21 year
+median 54 years	9606	Homo sapiens (human)	7005	median 54 year	median 54 year
+median 55 years	9606	Homo sapiens (human)	7006	median 55 year	median 55 year
+6-17 years	9606	Homo sapiens (human)	7007	6-17 year	6-17 year
+NULL	10002411	Gallus gallus SynVH	7008	null	null
+7-8 weeks	10001487	Mus musculus Apolipoprotein E null	7009	7-8 week	7-8 week
+0-77 years	9606	Homo sapiens (human)	7010	0-77 year	0-77 year
+9-17 years	9606	Homo sapiens (human)	7011	9-17 year	9-17 year
+6-18 years	9606	Homo sapiens (human)	7012	6-18 year	6-18 year
+NULL	10088	Mus <genus> (mice)	7013	null	null
+31 to 32 years	9606	Homo sapiens (human)	7014	31 to 32 year	31 to 32 year
+3 months to 25 years	9606	Homo sapiens (human)	7015	3 month to 25 year	3 month to 25 year
+>/= 15 years	9606	Homo sapiens (human)	7016	>/= 15 year	>/= 15 year
+49-80.3 years	9606	Homo sapiens (human)	7017	49-80.3 year	49-80.3 year
+6-10 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	7018	6-10 week	6-10 week
+1.5 years	9837	Camelus bactrianus (camel)	7019	1.5 year	1.5 year
+8-16 years	9606	Homo sapiens (human)	7020	8-16 year	8-16 year
+9 months	9925	Capra hircus (domestic goat)	7021	9 month	9 month
+median 48 years	9606	Homo sapiens (human)	7022	median 48 year	median 48 year
+median 50 years	9606	Homo sapiens (human)	7023	median 50 year	median 50 year
+6-weeks	10000000	Mus musculus BALB/c	7024	6-week	6 week
+35.3 to 54.3 years	9606	Homo sapiens (human)	7025	35.3 to 54.3 year	35.3 to 54.3 year
+48.5 to 61.2 years	9606	Homo sapiens (human)	7026	48.5 to 61.2 year	48.5 to 61.2 year
+NULL	9845	Ruminant	7027	null	null
+25-76 years	9606	Homo sapiens (human)	7028	25-76 year	25-76 year
+4-6 weeks	10036	Mesocricetus auratus (Syrian golden hamster)	7029	4-6 week	4-6 week
+55-70 years	9606	Homo sapiens (human)	7030	55-70 year	55-70 year
+4 to 6 weeks	10000206	Oryctolagus cuniculus New Zealand White	7031	4 to 6 week	4 to 6 week
+21 to 76 years	9606	Homo sapiens (human)	7032	21 to 76 year	21 to 76 year
+4-6 weeks	10000206	Oryctolagus cuniculus New Zealand White	7033	4-6 week	4-6 week
+6-8 weeks	10000624	Mus musculus MF1	7034	6-8 week	6-8 week
+16-83 years	9606	Homo sapiens (human)	7035	16-83 year	16-83 year
+33 to 83 years	9606	Homo sapiens (human)	7036	33 to 83 year	33 to 83 year
+24 to 28 years	9606	Homo sapiens (human)	7037	24 to 28 year	24 to 28 year
+0- 59 years	9606	Homo sapiens (human)	7038	0- 59 year	0- 59 year
+40-70 years	9606	Homo sapiens (human)	7039	40-70 year	40-70 year
+4-86 years	9606	Homo sapiens (human)	7040	4-86 year	4-86 year
+3-5 years	9544	Macaca mulatta (rhesus macaque)	7041	3-5 year	3-5 year
+36 to 70 years	9606	Homo sapiens (human)	7042	36 to 70 year	36 to 70 year
+15-42 years	9606	Homo sapiens (human)	7043	15-42 year	15-42 year
+5-37 years	9606	Homo sapiens (human)	7044	5-37 year	5-37 year
+44-83 years	9606	Homo sapiens (human)	7045	44-83 year	44-83 year
+22-74 years	9606	Homo sapiens (human)	7046	22-74 year	22-74 year
+mean 63.87 years	9606	Homo sapiens (human)	7047	mean 63.87 year	mean 63.87 year
+1-3 years	9685	Felis catus (cat)	7048	1-3 year	1-3 year
+3-9 years	9544	Macaca mulatta (rhesus macaque)	7049	3-9 year	3-9 year
+8-9 years	9606	Homo sapiens (human)	7050	8-9 year	8-9 year
+38 to 64 years	9606	Homo sapiens (human)	7051	38 to 64 year	38 to 64 year
+5 weeks	10001998	Mus musculus CD1	7052	5 week	5 week
+2-45 years	9606	Homo sapiens (human)	7053	2-45 year	2-45 year
+5-6 weeks	10000667	Rattus norvegicus Sprague-Dawley	7054	5-6 week	5-6 week
+10-13 years	9606	Homo sapiens (human)	7055	10-13 year	10-13 year
+mean 55.4 years	9606	Homo sapiens (human)	7056	mean 55.4 year	mean 55.4 year
+3-9 years	9606	Homo sapiens (human)	7057	3-9 year	3-9 year
+5 years	9544	Macaca mulatta (rhesus macaque)	7058	5 year	5 year
+mean 53.4 years	9606	Homo sapiens (human)	7059	mean 53.4 year	mean 53.4 year
+9-49 years	9606	Homo sapiens (human)	7060	9-49 year	9-49 year
+mean 59 years	9606	Homo sapiens (human)	7061	mean 59 year	mean 59 year
+8 weeks	10000218	Mus musculus C57BL/6 X C3H	7062	8 week	8 week
+6-8 weeks	10116	Rattus norvegicus (brown rat)	7063	6-8 week	6-8 week
+19-87 years	9606	Homo sapiens (human)	7064	19-87 year	19-87 year
+6-8 months	9825	Sus scrofa domesticus (domestic pig)	7065	6-8 month	6-8 month
+11 weeks	10000667	Rattus norvegicus Sprague-Dawley	7066	11 week	11 week
+11-83 years	9606	Homo sapiens (human)	7067	11-83 year	11-83 year
+1-7 years	9913	Bos taurus (bovine)	7068	1-7 year	1-7 year
+6 to 32 years	9606	Homo sapiens (human)	7069	6 to 32 year	6 to 32 year
+1 year old	9940	Ovis aries (domestic sheep)	7070	1 year old	1 year
+1 year old	9986	Oryctolagus cuniculus (rabbit)	7071	1 year old	1 year
+7 to 55 years	9606	Homo sapiens (human)	7072	7 to 55 year	7 to 55 year
+7 to 36 years	9606	Homo sapiens (human)	7073	7 to 36 year	7 to 36 year
+NULL	10002784	sus scrofa TLRI Black Pig No.1	7074	null	null
+4-5 weeks	10000019	Mus musculus BALB/cByJ	7075	4-5 week	4-5 week
+9-12 weeks	10001470	Mus musculus Factor VIII null	7076	9-12 week	9-12 week
+12-88 years	9606	Homo sapiens (human)	7077	12-88 year	12-88 year
+5- 55 years	9606	Homo sapiens (human)	7078	5- 55 year	5- 55 year
+40 to 72 years	9606	Homo sapiens (human)	7079	40 to 72 year	40 to 72 year
+NULL	10001737	Mus musculus B6.P	7080	null	null
+12-43 years	9606	Homo sapiens (human)	7081	12-43 year	12-43 year
+NULL	10001678	Mus musculus B10 X 129	7082	null	null
+37-70 years	9606	Homo sapiens (human)	7083	37-70 year	37-70 year
+4 days - 9 months	9606	Homo sapiens (human)	7084	4 days - 9 month	4 days - 9 month
+2 weeks	10000662	Rattus norvegicus Lewis	7085	2 week	2 week
+26-41 years	9606	Homo sapiens (human)	7086	26-41 year	26-41 year
+8-20 weeks	10002058	B6.ERAAP null	7087	8-20 week	8-20 week
+middle-aged	9606	Homo sapiens (human)	7088	middle-aged	middle-aged
+25-73 years	9606	Homo sapiens (human)	7089	25-73 year	25-73 year
+NULL	10029	Cricetulus griseus (Chinese hamsters)	7090	null	null
+12 to 51 years	9606	Homo sapiens (human)	7091	12 to 51 year	12 to 51 year
+37 to 70 years	9606	Homo sapiens (human)	7092	37 to 70 year	37 to 70 year
+7 months	9606	Homo sapiens (human)	7093	7 month	7 month
+6 months to 5 years	9606	Homo sapiens (human)	7094	6 month to 5 year	6 month to 5 year
+60-64 years	9606	Homo sapiens (human)	7095	60-64 year	60-64 year
+NULL	10000034	Mus musculus C3H/An	7096	null	null
+NULL	9305	Sarcophilus harrisii (Tasmanian devil)	7097	null	null
+5 months to 5 years	9606	Homo sapiens (human)	7098	5 month to 5 year	5 month to 5 year
+6 months to 15 years	9606	Homo sapiens (human)	7099	6 month to 15 year	6 month to 15 year
+NULL	10002058	B6.ERAAP null	7100	null	null
+neonatal	9606	Homo sapiens (human)	7101	neonatal	neonatal
+young and old	10116	Rattus norvegicus (brown rat)	7102	young and old	young and old
+old	10116	Rattus norvegicus (brown rat)	7103	old	old
+7-8 weeks	10090	Mus musculus (mouse)	7104	7-8 week	7-8 week
+NULL	10000108	Mus musculus C57BL/6 X B10.D2	7105	null	null
+NULL	9402	Pteropus alecto (black flying fox)	7106	null	null
+5-8 weeks	10000062	Mus musculus FVB/J	7107	5-8 week	5-8 week
+7-11 weeks	10000067	Mus musculus C57BL/6	7108	7-11 week	7-11 week
+10 years	9615	Canis lupus familiaris (dogs)	7109	10 year	10 year
+1 year	9606	Homo sapiens (human)	7110	1 year	1 year
+55-85 years	9606	Homo sapiens (human)	7111	55-85 year	55-85 year
+55-74	9606	Homo sapiens (human)	7112	55-74	55-74
+25 to 87 years	9606	Homo sapiens (human)	7113	25 to 87 year	25 to 87 year
+NULL	10000213	Mus musculus (C57BL/6 X BALB/c) H2bm8	7114	null	null
+80 years old	9606	Homo sapiens (human)	7115	80 year old	80 year
+8 to 10 weeks	10001122	Mus musculus µMT	7116	8 to 10 week	8 to 10 week
+59	9606	Homo sapiens (human)	7117	59	59
+51 years old	9606	Homo sapiens (human)	7118	51 year old	51 year
+64 years old	9606	Homo sapiens (human)	7119	64 year old	64 year
+60 years old	9606	Homo sapiens (human)	7120	60 year old	60 year
+Fetus	9606	Homo sapiens (human)	7121	fetus	fetus
+75	9606	Homo sapiens (human)	7122	75	75
+76	9606	Homo sapiens (human)	7123	76	76
+78	9606	Homo sapiens (human)	7124	78	78
+80	9606	Homo sapiens (human)	7125	80	80
+81	9606	Homo sapiens (human)	7126	81	81
+82	9606	Homo sapiens (human)	7127	82	82
+84	9606	Homo sapiens (human)	7128	84	84
+85	9606	Homo sapiens (human)	7129	85	85
+86	9606	Homo sapiens (human)	7130	86	86
+87	9606	Homo sapiens (human)	7131	87	87
+88	9606	Homo sapiens (human)	7132	88	88
+89	9606	Homo sapiens (human)	7133	89	89
+90	9606	Homo sapiens (human)	7134	90	90
+91	9606	Homo sapiens (human)	7135	91	91
+92	9606	Homo sapiens (human)	7136	92	92
+93	9606	Homo sapiens (human)	7137	93	93
+94	9606	Homo sapiens (human)	7138	94	94
+95	9606	Homo sapiens (human)	7139	95	95
+96	9606	Homo sapiens (human)	7140	96	96
+97	9606	Homo sapiens (human)	7141	97	97
+98	9606	Homo sapiens (human)	7142	98	98
+99	9606	Homo sapiens (human)	7143	99	99
+100	9606	Homo sapiens (human)	7144	100	100
+101	9606	Homo sapiens (human)	7145	101	101
+37-91 years old	9606	Homo sapiens (human)	7146	37-91 year old	37-91 year
+35-87 years old	9606	Homo sapiens (human)	7147	35-87 year old	35-87 year
+31-88 years old	9606	Homo sapiens (human)	7148	31-88 year old	31-88 year
+22-49 years	9606	Homo sapiens (human)	7149	22-49 year	22-49 year
+8-20 weeks	10000632	Mus musculus NOD	7150	8-20 week	8-20 week

--- a/newscripts/formatter.py
+++ b/newscripts/formatter.py
@@ -1,0 +1,45 @@
+import re
+
+
+def age_style(string):
+    """
+    Removes extraneous hyphens in age data, e.g.,
+    1-year-old --> 1 year old
+    1 year-old --> 1 year old
+    1-year old --> 1 year old
+    4-6 year-old --> 4-6 year old
+
+    Removes "old", e.g.,
+    1 year old --> 1 year
+    1-2 day old --> 1-2 day
+
+    -- string: The string to be processed.
+    -- return: The processed version of the string.
+    """
+    string = re.sub(
+        r"(\d+\.?\d*)(-)(year|month|week|day|hour)",
+        r"\g<1> \g<3>",
+        string
+    )
+    string = re.sub(
+        r"(year|month|week|day|hour)([\s-])(old)",
+        r"\g<1>",
+        string
+    )
+    return string
+
+
+def format_age(age_dict, target_column):
+    """
+    Applies age data normalization steps to data in a column of age_dict.
+
+    -- age_dict: A dict of age data created using converter.py.
+    -- target_column: The column to be processed.
+    -- return: A dict with a new column for age-formatted data.
+    """
+    new_column = f"{target_column}_style=age"
+    for index, rowdict in age_dict.items():
+        data = rowdict[target_column]
+        age_formatted_data = age_style(data)
+        rowdict[new_column] = age_formatted_data
+    return age_dict

--- a/newscripts/normalize.py
+++ b/newscripts/normalize.py
@@ -23,7 +23,7 @@ def prepare_spellcheck(spellcheckTSV):
         for row in reader:
             correctTerm = str(row["correct_term"])
             variants = str(row["variants_to_replace"])
-            variants = variants.split(", ")
+            variants = variants.split("|")
             SCdict[correctTerm] = variants
     return SCdict
 

--- a/newscripts/normalize.py
+++ b/newscripts/normalize.py
@@ -1,10 +1,9 @@
-# This script takes an input file and normalizes whitespace/dashes in it.
-
 import csv
 import sys
 import re
 import unicodedata as ud
 from converter import TSV2dict, dict2TSV
+from formatter import format_age
 
 
 def prepare_spellcheck(spellcheckTSV):
@@ -78,7 +77,7 @@ def standardize_string(string):
     return string
 
 
-def normalize(inputTSV, outputTSV, spellcheckTSV, target_column):
+def normalize(inputTSV, outputTSV, spellcheckTSV, target_column, style):
     """
     Applies normalization steps to all data items in target column or columns
     in an input TSV, creates a new column for the normalized data, and writes
@@ -90,6 +89,9 @@ def normalize(inputTSV, outputTSV, spellcheckTSV, target_column):
        data spellchecking.
     -- target_column: A string or list. If string, the name of the column to
        be normalized. If list, the names of the columns to be normalized.
+    -- style: A style (e.g. age) to be applied via formatter. Currently
+       anything other than "age" in this argument place will result in no
+       style being applied.
     """
     # Make spellcheck dict.
     SCdict = prepare_spellcheck(spellcheckTSV)
@@ -111,6 +113,8 @@ def normalize(inputTSV, outputTSV, spellcheckTSV, target_column):
             sc_data = run_spellcheck(standardized_data, SCdict)
             newcolumn = f"normalized_{target_column}"
             rowdict[newcolumn] = sc_data
+    if style == "age":
+        maindict = format_age(maindict, newcolumn)
     dict2TSV(maindict, outputTSV)
 
 
@@ -119,4 +123,5 @@ if __name__ == "__main__":
     outputTSV = sys.argv[2]
     spellcheckTSV = sys.argv[3]
     target_column = sys.argv[4]
-    normalize(inputTSV, outputTSV, spellcheckTSV, target_column)
+    style = sys.argv[5]
+    normalize(inputTSV, outputTSV, spellcheckTSV, target_column, style)

--- a/newscripts/text_swaps.tsv
+++ b/newscripts/text_swaps.tsv
@@ -21,7 +21,7 @@ correct_term	variants_to_replace
 19	nineteen
 adults	adutls
 adult	adutl
-year	"years, yr, yrs, yo, yeras, yeays, yesrs"
-month	"months, mo, mos, monts"
-week	"weeks, wk, wks, weels, weks, wo, wekk, wekks"
-hour	"hours, hr, hrs"
+year	years|yr|yrs|yo|yera|yeras|yeays|yesrs
+month	months|mo|mos|monts
+week	weeks|wk|wks|weels|weks|wo|wekk|wekks
+hour	hours|hr|hrs

--- a/newscripts/text_swaps.tsv
+++ b/newscripts/text_swaps.tsv
@@ -21,11 +21,7 @@ correct_term	variants_to_replace
 19	nineteen
 adults	adutls
 adult	adutl
-year	"yr, yo"
-years	"yrs, yeras, yeays, yesrs"
-month	"mo"
-months	"mos, monts"
-week	"wk, wo, wekk"
-weeks	"wks, weels, weks, wekks"
-hour	"hr"
-hours	"hrs"
+year	"years, yr, yrs, yo, yeras, yeays, yesrs"
+month	"months, mo, mos, monts"
+week	"weeks, wk, wks, weels, weks, wo, wekk, wekks"
+hour	"hours, hr, hrs"


### PR DESCRIPTION
Adds a styling step to do format-specific stuff like removing hyphens between (unit) and "old" in age data like "3-year-old". Also changes the splitter from a comma to a | in text_swaps.tsv to avoid CSV/TSV reading issues.