### PR TITLE
Moves most functions out of normalize.py

### DIFF
--- a/scripts/data_loc_splitter.py
+++ b/scripts/data_loc_splitter.py
@@ -1,0 +1,65 @@
+import pandas as pd
+import re
+
+
+def academic_location_regex():
+    # Base terms for figures and tables, including common abbreviations and supplementary materials
+    fig_table_terms = r"\b(table|fig(?:ure)?|(supplementary|supplemental) (?:table|fig(?:ure)|data|file?)|supporting (?:table|fig(?:ure)|information?)|additional file(s)?|appendix|suppl)\b"
+    # Sections of the paper
+    sections = r"\b(title|abstract|introduction|materials and methods|animals and methods|materials|methods|results|discussion|conclusion|acknowledgements|references|appendices)\b"
+    # Page terms to match different ways of referencing pages
+    page_terms = r"((text )?page|pg\.?|p\.?) \d+"
+    # Combine them with options for numbering (e.g., figure 1, table S1)
+    pattern = rf"{fig_table_terms} (?:s)?\d+[a-z]?|{sections}|{page_terms}"
+
+    return pattern
+
+
+def biological_db_regex():
+    # Handle PDB identifiers, generic identifiers (letter followed by numbers), and accession numbers
+    pdb_pattern = r"\bpdb [0-9][a-zA-Z0-9]{2}[a-zA-Z]|[0-9][a-zA-Z0-9][a-zA-Z][a-zA-Z0-9]|[0-9][a-zA-Z][a-zA-Z0-9]{2}\b"
+    generic_identifier_pattern = r"\b[a-zA-Z] \d+\b"
+    accession_pattern = r"\baccession(:)? [\w: ]+\b"
+    return rf"({pdb_pattern})|({generic_identifier_pattern})|({accession_pattern})"
+
+
+def website_url_regex():
+    # Simple pattern for matching specific URLs and more generic HTTP URLs
+    specific_domain = r"^https://hla-ligand-atlas\.org/[^\s]*$"
+    general_http = r"^(https?://[^\s/$.?#].[^\s]*$)"
+    return rf"({specific_domain})|({general_http})"
+
+
+def is_normalized(string):
+    academic_pattern = academic_location_regex()
+    bio_db_pattern = biological_db_regex()
+    website_pattern = website_url_regex()
+        
+    if re.search(academic_pattern, string, re.IGNORECASE):
+        return 'Y'
+    elif re.search(bio_db_pattern, string, re.IGNORECASE):
+        return 'Y'
+    elif re.search(website_pattern, string, re.IGNORECASE):
+        return 'Y'
+    else:
+        return 'N'
+
+
+def normalize_dataframe(df, column_name):
+    # Explode the DataFrame to create a new row for each string in the list found in phrase_normalized_col
+    df['normalized_location'] = df[column_name].copy()
+    df = df.explode('normalized_location').reset_index(drop=True)
+    df['normalized'] = df['normalized_location'].apply(is_normalized)
+    return df
+
+def dict_to_dataframe(maindict, column_name):
+    # Convert dictionary to DataFrame
+    df = pd.DataFrame.from_dict(maindict, orient='index')
+    # Normalize data
+    df = normalize_dataframe(df, column_name)
+    return df
+
+def dataframe_to_dict(df):
+    # Convert DataFrame back to dictionary format suitable for dict2TSV
+    result_dict = df.to_dict(orient='index')
+    return result_dict

--- a/scripts/normalize.py
+++ b/scripts/normalize.py
@@ -3,10 +3,10 @@ import sys
 import os
 import re
 import editdistance
-import unicodedata as ud
 import pandas as pd
 from converter import TSV2dict, dict2TSV
 import text_formatter as tf
+import data_loc_splitter as splt
 
 # TODO: Check if this is still needed and remove if not
 def is_known_invalid_location(data):
@@ -27,69 +27,6 @@ def is_known_invalid_location(data):
     elif re.match(r'[a-zA-Z]\s\d+', data):
         return True
     return False
-
-
-def academic_location_regex():
-    # Base terms for figures and tables, including common abbreviations and supplementary materials
-    fig_table_terms = r"\b(table|fig(?:ure)?|(supplementary|supplemental) (?:table|fig(?:ure)|data|file?)|supporting (?:table|fig(?:ure)|information?)|additional file(s)?|appendix|suppl)\b"
-    # Sections of the paper
-    sections = r"\b(title|abstract|introduction|materials and methods|animals and methods|materials|methods|results|discussion|conclusion|acknowledgements|references|appendices)\b"
-    # Page terms to match different ways of referencing pages
-    page_terms = r"((text )?page|pg\.?|p\.?) \d+"
-    # Combine them with options for numbering (e.g., figure 1, table S1)
-    pattern = rf"{fig_table_terms} (?:s)?\d+[a-z]?|{sections}|{page_terms}"
-
-    return pattern
-
-
-def biological_db_regex():
-    # Handle PDB identifiers, generic identifiers (letter followed by numbers), and accession numbers
-    pdb_pattern = r"\bpdb [0-9][a-zA-Z0-9]{2}[a-zA-Z]|[0-9][a-zA-Z0-9][a-zA-Z][a-zA-Z0-9]|[0-9][a-zA-Z][a-zA-Z0-9]{2}\b"
-    generic_identifier_pattern = r"\b[a-zA-Z] \d+\b"
-    accession_pattern = r"\baccession(:)? [\w: ]+\b"
-    return rf"({pdb_pattern})|({generic_identifier_pattern})|({accession_pattern})"
-
-
-def website_url_regex():
-    # Simple pattern for matching specific URLs and more generic HTTP URLs
-    specific_domain = r"^https://hla-ligand-atlas\.org/[^\s]*$"
-    general_http = r"^(https?://[^\s/$.?#].[^\s]*$)"
-    return rf"({specific_domain})|({general_http})"
-
-
-def is_normalized(string):
-    academic_pattern = academic_location_regex()
-    bio_db_pattern = biological_db_regex()
-    website_pattern = website_url_regex()
-        
-    if re.search(academic_pattern, string, re.IGNORECASE):
-        return 'Y'
-    elif re.search(bio_db_pattern, string, re.IGNORECASE):
-        return 'Y'
-    elif re.search(website_pattern, string, re.IGNORECASE):
-        return 'Y'
-    else:
-        return 'N'
-
-
-def normalize_dataframe(df, column_name):
-    # Explode the DataFrame to create a new row for each string in the list found in phrase_normalized_col
-    df['normalized_location'] = df[column_name].copy()
-    df = df.explode('normalized_location').reset_index(drop=True)
-    df['normalized'] = df['normalized_location'].apply(is_normalized)
-    return df
-
-def dict_to_dataframe(maindict, column_name):
-    # Convert dictionary to DataFrame
-    df = pd.DataFrame.from_dict(maindict, orient='index')
-    # Normalize data
-    df = normalize_dataframe(df, column_name)
-    return df
-
-def dataframe_to_dict(df):
-    # Convert DataFrame back to dictionary format suitable for dict2TSV
-    result_dict = df.to_dict(orient='index')
-    return result_dict
 
 
 def stripped_data_loc(data_loc_dict):
@@ -273,8 +210,8 @@ def normalize(inputTSV, outputTSV, char_norm_data_TSV, spellcheckTSV, word_curat
     # TODO: Decide on this or go with inserted N/A values.
     if style == "data_loc":
         # Convert dict to DataFrame, normalize, and convert back
-        df = dict_to_dataframe(maindict, phrase_column)
-        final_dict = dataframe_to_dict(df)
+        df = splt.dict_to_dataframe(maindict, phrase_column)
+        final_dict = splt.dataframe_to_dict(df)
         stripped = stripped_data_loc(final_dict)
         dict2TSV(stripped, os.path.join("data_loc", "output_files", "stripped_data_loc.tsv"))
     if style == "age":

--- a/scripts/text_formatter.py
+++ b/scripts/text_formatter.py
@@ -1,5 +1,3 @@
-import csv
-import os
 import re
 import unicodedata as ud
 

--- a/scripts/text_formatter.py
+++ b/scripts/text_formatter.py
@@ -1,4 +1,125 @@
+import csv
+import os
 import re
+import unicodedata as ud
+
+
+###############################################################################
+#                                                                             #
+#                               CHAR NORMALIZER                               #
+#                                                                             #
+###############################################################################
+
+
+def track_changes(original_string, new_string, change_dict, tracker_item):
+    if original_string != new_string:
+        change_dict[tracker_item] = "Y"
+    else:
+        change_dict[tracker_item] = "N"
+
+
+def char_normalizer(string):
+    """
+    Adapted from JasonPBennett/Data-Field-Standardization/.../data_loc_v2.py
+
+    Standardizes a string by removing unnecessary whitespaces,
+    converting to ASCII, and converting to lowercase.
+
+    :param string: The string to be standardized.
+    :return: Standardized string.
+    """
+
+    change_dict = {}
+    change_dict["before_char_normalization"] = string
+    # Convert en- and em-dashes to hyphens.
+    string1 = string.replace(r"–", "-")
+    track_changes(string, string1, change_dict, "en-dash")
+    string2 = string1.replace(r"—", "-")
+    track_changes(string1, string2, change_dict, "em-dash")
+    # Standardize plus-minus characters.
+    string3 = string2.replace(r"±", r"+/-")
+    track_changes(string2, string3, change_dict, "plus-minus")
+    # Remove unnecessary whitespaces.
+    string4 = string3.strip()
+    track_changes(string3, string4, change_dict, "strip_whitespace")
+    string5 = re.sub(r"(\s\s+)", r" ", string4)
+    track_changes(string4, string5, change_dict, "remove_multi_whitespace")
+    # Convert to ascii.
+    string6 = ud.normalize('NFKD', string5).encode('ascii', 'replace').decode('ascii')
+    track_changes(string5, string6, change_dict, "convert_to_ascii")
+    # Convert to lowercase.
+    string7 = string6.lower()
+    track_changes(string6, string7, change_dict, "lowercase")
+    change_dict["after_char_normalization"] = string7
+    return string7, change_dict
+
+
+###############################################################################
+#                                                                             #
+#                               WORD NORMALIZER                               #
+#                                                                             #
+###############################################################################
+
+
+def word_normalizer(string, SCdict, WCdict,  sc_data_dict):
+    """
+    Performs word normalization  using SCdict (created via prepare_spellcheck &
+    used to store preferred and alternative versions of certain words).
+
+    -- string: The text to be spellchecked.
+    -- SCdict: The spellcheck dict.
+    -- WCdict: The manual word-curation dict.
+    -- sc_data_dict: Dict that stores usage frequencies of each term in the
+       spellcheck dict.
+    -- return: A corrected version of the string.
+    """
+
+    # Checks for each alternative term in each preferred-alternative term
+    # pair in SCdict, then replaces alternatives with preferred terms.
+    # Recognizes terms divided by whitespace, hyphens, periods, or commas,
+    # but not alphanumeric characters, i.e., would catch "one" in the
+    # string "three-to-one odds", but not "one" in "bone."
+
+    delimiters = [",", ".", "-", " ", "(", ")", ":", ";", "+", "=", ">", "<"]
+    string_stripped = string
+    for delimiter in delimiters:
+        string_stripped = " ".join(string_stripped.split(delimiter))
+        wordlist = string_stripped.split(" ")
+    known_words = []
+    for input_word, word_dict in SCdict.items():
+        known_words.append(word_dict["correct_term"])
+    for word in wordlist:
+        if word in SCdict.keys():
+            input_word = word
+            correct_term = SCdict[input_word]["correct_term"]
+            string = re.sub(
+                fr"(^|\s+|[-.,]+)({input_word})($|\s+|[-.,]+)",
+                fr"\g<1>{correct_term}\g<3>",
+                string
+            )
+            count = sc_data_dict[input_word]["occurrences"]
+            count += 1
+            sc_data_dict[input_word]["occurrences"] = count
+        elif word in known_words:
+            continue
+        elif word in WCdict.keys():
+            continue
+        elif re.fullmatch(r"[0-9=+\-/<>:]+", word):
+            continue
+        else:
+            WCdict[word] = {
+                "input_word": word,
+                "correct_term": "",
+                "input_context": string,
+            }
+    return string
+
+
+###############################################################################
+#                                                                             #
+#                              PHRASE NORMALIZER                              #
+#                                                                             #
+###############################################################################
 
 
 def approved_and_phrases(query_string_list):
@@ -96,6 +217,7 @@ def age_phrase_normalizer(string):
     )
     return string
 
+
 def data_loc_phrase_normalizer(string):
     """
     Normalize localization phrases in a given text by identifying combined prefixes and types
@@ -190,6 +312,14 @@ def data_loc_phrase_normalizer(string):
     results = approved_and_phrases(results)
 
     return results
+
+
+def phrase_normalizer(string, style):
+    if style == "age":
+        string = age_phrase_normalizer(string)
+    if style == "data_loc":
+        string = data_loc_phrase_normalizer(string)
+    return string
 
 """
 input_strings = [


### PR DESCRIPTION
Moves most normalization functions into text_formatter.py to make normalize.py as clean/readable as possible. Also creates a dedicated script for data-loc row splitting. I've run it on age and data-loc to confirm outputs remain the same.